### PR TITLE
Use rest-utils shutdown hook to shutdown cleanly when possible. Fixes #7...

### DIFF
--- a/src/main/java/io/confluent/kafkarest/Main.java
+++ b/src/main/java/io/confluent/kafkarest/Main.java
@@ -27,10 +27,9 @@ public class Main {
         try {
             KafkaRestConfig config = new KafkaRestConfig((args.length > 0 ? args[0] : null));
             KafkaRestApplication app = new KafkaRestApplication(config);
-            Server server = app.createServer();
-            server.start();
+            app.start();
             System.out.println("Server started, listening for requests...");
-            server.join();
+            app.join();
         } catch (RestConfigException e) {
             System.out.println("Server configuration failed: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/io/confluent/kafkarest/MetadataObserver.java
+++ b/src/main/java/io/confluent/kafkarest/MetadataObserver.java
@@ -128,4 +128,8 @@ public class MetadataObserver {
         }
         return partitions;
     }
+
+    public void shutdown() {
+        zkClient.close();
+    }
 }

--- a/src/main/java/io/confluent/kafkarest/ProducerPool.java
+++ b/src/main/java/io/confluent/kafkarest/ProducerPool.java
@@ -46,6 +46,10 @@ public class ProducerPool {
         }
     }
 
+    public void shutdown() {
+        producer.close();
+    }
+
     public interface ProduceRequestCallback {
         public void onCompletion(Map<Integer, Long> partitionOffsets);
         public void onException(Exception e);


### PR DESCRIPTION
Blocked by https://github.com/confluentinc/rest-utils/pull/2
