### PR TITLE
Update to Kafka 0.8.2.0 and use generic classes for Producers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <restutils.version>0.1-SNAPSHOT</restutils.version>
         <jersey.version>2.6</jersey.version>
-        <kafka.version>0.8.2-beta</kafka.version>
+        <kafka.version>0.8.2.0</kafka.version>
         <kafka.scala.version>2.10</kafka.scala.version>
         <!-- See note about workaround below. This should match the version used in the version of rest-utils you're using. -->
         <restutils.junit.version>4.11</restutils.junit.version>

--- a/src/main/java/io/confluent/kafkarest/ProducerRecordProxyCollection.java
+++ b/src/main/java/io/confluent/kafkarest/ProducerRecordProxyCollection.java
@@ -26,7 +26,7 @@ import io.confluent.kafkarest.entities.ProduceRecord;
  * Implementation of Iterable<ProducerRecord> that just wraps an underlying collection of
  * ProduceRecord entities.
  */
-public class ProducerRecordProxyCollection implements Iterable<ProducerRecord> {
+public class ProducerRecordProxyCollection<K,V> implements Iterable<ProducerRecord<byte[],byte[]>> {
 
   private final String topic;
   private final Integer partition;
@@ -50,11 +50,11 @@ public class ProducerRecordProxyCollection implements Iterable<ProducerRecord> {
   }
 
   @Override
-  public Iterator<ProducerRecord> iterator() {
+  public Iterator<ProducerRecord<byte[],byte[]>> iterator() {
     return new ProxyIterator(underlying.iterator());
   }
 
-  private class ProxyIterator implements Iterator<ProducerRecord> {
+  private class ProxyIterator implements Iterator<ProducerRecord<byte[],byte[]>> {
 
     Iterator<? extends ProduceRecord> underlying;
 
@@ -68,7 +68,7 @@ public class ProducerRecordProxyCollection implements Iterable<ProducerRecord> {
     }
 
     @Override
-    public ProducerRecord next() {
+    public ProducerRecord<byte[],byte[]> next() {
       if (partition == null) {
         return underlying.next().getKafkaRecord(topic);
       } else {

--- a/src/main/java/io/confluent/kafkarest/entities/ProduceRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/ProduceRecord.java
@@ -120,11 +120,11 @@ public class ProduceRecord {
     return result;
   }
 
-  public ProducerRecord getKafkaRecord(String topic) {
-    return new ProducerRecord(topic, key, value);
+  public ProducerRecord<byte[],byte[]> getKafkaRecord(String topic) {
+    return new ProducerRecord<byte[],byte[]>(topic, key, value);
   }
 
-  public ProducerRecord getKafkaRecord(String topic, int partition) {
-    return new ProducerRecord(topic, partition, key, value);
+  public ProducerRecord<byte[],byte[]> getKafkaRecord(String topic, int partition) {
+    return new ProducerRecord<byte[],byte[]>(topic, partition, key, value);
   }
 }

--- a/src/main/java/io/confluent/kafkarest/entities/TopicProduceRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/TopicProduceRecord.java
@@ -110,12 +110,12 @@ public class TopicProduceRecord extends ProduceRecord {
   }
 
   @Override
-  public ProducerRecord getKafkaRecord(String topic) {
-    return new ProducerRecord(topic, partition, this.getKey(), this.getValue());
+  public ProducerRecord<byte[],byte[]> getKafkaRecord(String topic) {
+    return new ProducerRecord<byte[],byte[]>(topic, partition, this.getKey(), this.getValue());
   }
 
   @Override
-  public ProducerRecord getKafkaRecord(String topic, int partition) {
+  public ProducerRecord<byte[],byte[]> getKafkaRecord(String topic, int partition) {
     throw new UnsupportedOperationException(
         "TopicProduceRecord cannot generate Kafka records for specific partitions.");
   }

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerTest.java
@@ -41,18 +41,18 @@ public class ConsumerTest extends AbstractConsumerTest {
   private static final Topic topic = new Topic(topicName, new Properties(), partitions);
   private static final String groupName = "testconsumergroup";
 
-  private final List<ProducerRecord> recordsOnlyValues = Arrays.asList(
-      new ProducerRecord(topicName, "value".getBytes()),
-      new ProducerRecord(topicName, "value2".getBytes()),
-      new ProducerRecord(topicName, "value3".getBytes()),
-      new ProducerRecord(topicName, "value4".getBytes())
+  private final List<ProducerRecord<byte[],byte[]>> recordsOnlyValues = Arrays.asList(
+      new ProducerRecord<byte[],byte[]>(topicName, "value".getBytes()),
+      new ProducerRecord<byte[],byte[]>(topicName, "value2".getBytes()),
+      new ProducerRecord<byte[],byte[]>(topicName, "value3".getBytes()),
+      new ProducerRecord<byte[],byte[]>(topicName, "value4".getBytes())
   );
 
-  private final List<ProducerRecord> recordsWithKeys = Arrays.asList(
-      new ProducerRecord(topicName, "key".getBytes(), "value".getBytes()),
-      new ProducerRecord(topicName, "key".getBytes(), "value2".getBytes()),
-      new ProducerRecord(topicName, "key".getBytes(), "value3".getBytes()),
-      new ProducerRecord(topicName, "key".getBytes(), "value4".getBytes())
+  private final List<ProducerRecord<byte[],byte[]>> recordsWithKeys = Arrays.asList(
+      new ProducerRecord<byte[],byte[]>(topicName, "key".getBytes(), "value".getBytes()),
+      new ProducerRecord<byte[],byte[]>(topicName, "key".getBytes(), "value2".getBytes()),
+      new ProducerRecord<byte[],byte[]>(topicName, "key".getBytes(), "value3".getBytes()),
+      new ProducerRecord<byte[],byte[]>(topicName, "key".getBytes(), "value4".getBytes())
   );
 
 


### PR DESCRIPTION
Straightforward patch, would be most helpful to make sure I didn't miss any instances that should have the generic types. Merging is blocked by confluentinc/schema-registry#58.
