### PR TITLE
Change default port to 8082 so it's not the same as the rest-utils defaults. Fixes #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ server with
 
 where `server.properties` contains configuration settings as specified by the `KafkaRestConfiguration` class. Although the
 properties file is not required, the default configuration is not intended for production. Production deployments *should*
-specify a properties file. By default the server starts bound to port 8080, does not specify a unique instance ID (required
+specify a properties file. By default the server starts bound to port 8082, does not specify a unique instance ID (required
 to safely run multiple proxies concurrently), and expects Zookeeper to be available at `localhost:2181` and a Kafka broker
 at `localhost:9092`.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -12,14 +12,7 @@ Configuration Options
   Unique ID for this REST server instance. This is used in generating unique IDs for consumers that do not specify their ID. The ID is empty by default, which makes a single server setup easier to get up and running, but is not safe for multi-server deployments where automatic consumer IDs are used.
 
   * Type: string
-  * Default: 
-  * Importance: high
-
-``port``
-  Port to listen on for new connections.
-
-  * Type: int
-  * Default: 8080
+  * Default:
   * Importance: high
 
 ``response.mediatype.default``
@@ -122,6 +115,13 @@ Configuration Options
   * Default: 30000
   * Importance: low
 
+``port``
+  Port to listen on for new connections.
+
+  * Type: int
+  * Default: 8082
+  * Importance: low
+
 ``producer.threads``
   Number of threads to run produce requests on.
 
@@ -142,3 +142,4 @@ Configuration Options
   * Type: int
   * Default: 1000
   * Importance: low
+

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -32,14 +32,14 @@ Assuming you have the Kafka and Kafka REST Proxy code checked out:
 
    # Make a few requests to test the API:
    # Get a list of topics
-   $ curl "http://localhost:8080/topics"
+   $ curl "http://localhost:8082/topics"
      [{"name":"test","num_partitions":3},{"name":"test2","num_partitions":1}]
    # Get info about one partition
-   $ curl "http://localhost:8080/topics/test"
+   $ curl "http://localhost:8082/topics/test"
      {"name":"test","num_partitions":3}
    # Produce a message with value "Kafka" to the topic test
    $ curl -X POST -H "Content-Type: application/vnd.kafka.v1+json" \
-         --data '{"records":[{"value":"S2Fma2E="}]}' "http://localhost:8080/topics/test"
+         --data '{"records":[{"value":"S2Fma2E="}]}' "http://localhost:8082/topics/test"
      {"offsets":[{"partition": 3, "offset": 1}]}
 
 Installation
@@ -62,7 +62,7 @@ where ``server.properties`` contains configuration settings as specified by the
 ``KafkaRestConfiguration`` class. Although the properties file is not required,
 the default configuration is not intended for production. Production deployments
 *should* specify a properties file. By default the server starts bound to port
-8080, does not specify a unique instance ID (required to safely run multiple
+8082, does not specify a unique instance ID (required to safely run multiple
 proxies concurrently), and expects Zookeeper to be available at ``localhost:2181``
 and a Kafka broker at ``localhost:9092``.
 

--- a/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -109,12 +109,16 @@ public class KafkaRestConfig extends RestConfig {
       + "is automatically destroyed.";
   public static final String CONSUMER_INSTANCE_TIMEOUT_MS_DEFAULT = "300000";
 
+  private static final int KAFKAREST_PORT_DEFAULT = 8082;
+
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka-rest";
 
   private static final ConfigDef config;
 
   static {
     config = baseConfigDef()
+        .defineOverride(PORT_CONFIG, ConfigDef.Type.INT, KAFKAREST_PORT_DEFAULT,
+                        ConfigDef.Importance.LOW, PORT_CONFIG_DOC)
         .defineOverride(RESPONSE_MEDIATYPE_PREFERRED_CONFIG, Type.LIST,
                         Versions.PREFERRED_RESPONSE_TYPES, Importance.HIGH,
                         RESPONSE_MEDIATYPE_PREFERRED_CONFIG_DOC)


### PR DESCRIPTION
@nehanarkhede Whenever you have a chance, should be an easy review for you since it mirrors the schema-registry patch.
