### PR TITLE
Add host.name setting to override the default canonical host name. Fixes #31.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -87,6 +87,13 @@ Configuration Options
   * Default: 1
   * Importance: low
 
+``host.name``
+  The host name used to generate absolute URLs in responses. If empty, the default canonical hostname is used
+
+  * Type: string
+  * Default:
+  * Importance: low
+
 ``metric.reporters``
   A list of classes to use as metrics reporters. Implementing the <code>MetricReporter</code> interface allows plugging in classes that will be notified of new metric creation. The JmxReporter is always included to register JMX statistics.
 
@@ -142,4 +149,3 @@ Configuration Options
   * Type: int
   * Default: 1000
   * Importance: low
-

--- a/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -37,6 +37,12 @@ public class KafkaRestConfig extends RestConfig {
       + "are used.";
   public static final String ID_DEFAULT = "";
 
+  public static final String HOST_NAME_CONFIG = "host.name";
+  private static final String HOST_NAME_DOC =
+      "The host name used to generate absolute URLs in responses. If empty, the default canonical"
+      + " hostname is used";
+  public static final String HOST_NAME_DEFAULT = "";
+
   public static final String ZOOKEEPER_CONNECT_CONFIG = "zookeeper.connect";
   private static final String
       ZOOKEEPER_CONNECT_DOC =
@@ -128,6 +134,7 @@ public class KafkaRestConfig extends RestConfig {
         .defineOverride(METRICS_JMX_PREFIX_CONFIG, Type.STRING,
                         METRICS_JMX_PREFIX_DEFAULT_OVERRIDE, Importance.LOW, METRICS_JMX_PREFIX_DOC)
         .define(ID_CONFIG, Type.STRING, ID_DEFAULT, Importance.HIGH, ID_CONFIG_DOC)
+        .define(HOST_NAME_CONFIG, Type.STRING, HOST_NAME_DEFAULT, Importance.LOW, HOST_NAME_DOC)
         .define(ZOOKEEPER_CONNECT_CONFIG, Type.STRING, ZOOKEEPER_CONNECT_DEFAULT,
                 Importance.HIGH, ZOOKEEPER_CONNECT_DOC)
         .define(SCHEMA_REGISTRY_CONNECT_CONFIG, Type.STRING, SCHEMA_REGISTRY_CONNECT_DEFAULT,

--- a/src/main/java/io/confluent/kafkarest/UriUtils.java
+++ b/src/main/java/io/confluent/kafkarest/UriUtils.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest;
+
+import java.net.URI;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+public class UriUtils {
+
+  public static UriBuilder absoluteUriBuilder(KafkaRestConfig config, UriInfo uriInfo) {
+    String hostname = config.getString(KafkaRestConfig.HOST_NAME_CONFIG);
+    UriBuilder builder = uriInfo.getAbsolutePathBuilder();
+    if (hostname.length() > 0) {
+      builder.host(hostname);
+      // Resetting the hostname removes the scheme and port for some reason, so they may need to
+      // be reset.
+      URI origAbsoluteUri = uriInfo.getAbsolutePath();
+      builder.scheme(origAbsoluteUri.getScheme());
+      // Only reset the port if it was set in the original URI
+      if (origAbsoluteUri.getPort() != -1) {
+        builder.port(config.getInt(KafkaRestConfig.PORT_CONFIG));
+      }
+    }
+    return builder;
+  }
+}

--- a/src/main/java/io/confluent/kafkarest/resources/ConsumersResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/ConsumersResource.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.UriInfo;
 
 import io.confluent.kafkarest.ConsumerManager;
 import io.confluent.kafkarest.Context;
+import io.confluent.kafkarest.UriUtils;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
 import io.confluent.kafkarest.entities.ConsumerRecord;
@@ -64,9 +65,8 @@ public class ConsumersResource {
       config = new ConsumerInstanceConfig();
     }
     String instanceId = ctx.getConsumerManager().createConsumer(group, config);
-    String
-        instanceBaseUri =
-        uriInfo.getAbsolutePathBuilder().path("instances").path(instanceId).build().toString();
+    String instanceBaseUri = UriUtils.absoluteUriBuilder(ctx.getConfig(), uriInfo)
+        .path("instances").path(instanceId).build().toString();
     return new CreateConsumerInstanceResponse(instanceId, instanceBaseUri);
   }
 

--- a/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest.unit;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Properties;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.UriUtils;
+import io.confluent.rest.RestConfigException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UriUtilsTest {
+
+  private UriInfo uriInfo;
+
+  @Before
+  public void setUp() {
+    uriInfo = EasyMock.createMock(UriInfo.class);
+  }
+
+  @Test
+  public void testAbsoluteURIBuilderDefaultHost() throws RestConfigException {
+    KafkaRestConfig config = new KafkaRestConfig();
+    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
+        .andReturn(UriBuilder.fromUri("http://foo.com"));
+    EasyMock.replay(uriInfo);
+    assertEquals("http://foo.com", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    EasyMock.verify(uriInfo);
+  }
+
+  @Test
+  public void testAbsoluteURIBuilderOverrideHost() throws RestConfigException {
+    Properties props = new Properties();
+    props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
+    KafkaRestConfig config = new KafkaRestConfig(props);
+    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
+        .andReturn(UriBuilder.fromUri("http://foo.com"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com"));
+    EasyMock.replay(uriInfo);
+    assertEquals("http://bar.net", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    EasyMock.verify(uriInfo);
+  }
+
+  @Test
+  public void testAbsoluteURIBuilderWithPort() throws RestConfigException {
+    Properties props = new Properties();
+    props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
+    props.put(KafkaRestConfig.PORT_CONFIG, 5000);
+    KafkaRestConfig config = new KafkaRestConfig(props);
+    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
+        .andReturn(UriBuilder.fromUri("http://foo.com:5000"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com:5000"));
+    EasyMock.replay(uriInfo);
+    assertEquals("http://bar.net:5000",
+                 UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    EasyMock.verify(uriInfo);
+  }
+
+}


### PR DESCRIPTION
Simple patch, should be easy to review. We might eventually want to move this into rest-utils since it's pretty generic utility code, but I wasn't sure it's broadly useful enough yet.
