### PR TITLE
Convert MessageStreamsExistException into a 409 RestException. Fixes #37.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -742,6 +742,9 @@ any consumers before it is terminated.
    :statuscode 406:
       * Error code 40601 -- Consumer format does not match the embedded format requested by the
         ``Accept`` header.
+   :statuscode 409:
+      * Error code 40901 -- Consumer has already initiated a subscription. Consumers may
+        subscribe to multiple topics, but all subscriptions must be initiated in a single request.
 
    **Example binary request**:
 

--- a/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -203,13 +203,10 @@ public class ConsumerManager {
         state, topic, maxBytes,
         new ConsumerWorkerReadCallback<ClientK, ClientV>() {
           @Override
-          public void onCompletion(List<? extends ConsumerRecord<ClientK, ClientV>> records) {
+          public void onCompletion(
+              List<? extends ConsumerRecord<ClientK, ClientV>> records, Exception e) {
             updateExpiration(state);
-            if (records == null) {
-              callback.onCompletion(null, Errors.consumerInstanceNotFoundException());
-            } else {
-              callback.onCompletion(records, null);
-            }
+            callback.onCompletion(records, e);
           }
         }
     );

--- a/src/main/java/io/confluent/kafkarest/ConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerState.java
@@ -24,6 +24,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
+import kafka.common.MessageStreamsExistException;
 import kafka.consumer.KafkaStream;
 import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.message.MessageAndMetadata;
@@ -190,6 +191,8 @@ public abstract class ConsumerState<KafkaK, KafkaV, ClientK, ClientV>
       state = new ConsumerTopicState<KafkaK, KafkaV>(stream);
       topics.put(topic, state);
       return state;
+    } catch (MessageStreamsExistException e) {
+      throw Errors.consumerAlreadySubscribedException();
     } finally {
       lock.writeLock().unlock();
     }

--- a/src/main/java/io/confluent/kafkarest/ConsumerWorkerReadCallback.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerWorkerReadCallback.java
@@ -22,5 +22,5 @@ import io.confluent.kafkarest.entities.ConsumerRecord;
 
 public interface ConsumerWorkerReadCallback<K, V> {
 
-  public void onCompletion(List<? extends ConsumerRecord<K, V>> records);
+  public void onCompletion(List<? extends ConsumerRecord<K, V>> records, Exception e);
 }

--- a/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/src/main/java/io/confluent/kafkarest/Errors.java
@@ -59,6 +59,18 @@ public class Errors {
   }
 
 
+  public final static String CONSUMER_ALREADY_SUBSCRIBED_MESSAGE =
+      "Consumer cannot subscribe the the specified target because it has already subscribed to "
+      + "other topics.";
+  public final static int CONSUMER_ALREADY_SUBSCRIBED_ERROR_CODE = 40901;
+
+  public static RestException consumerAlreadySubscribedException() {
+    return new RestException(CONSUMER_ALREADY_SUBSCRIBED_MESSAGE,
+                             Response.Status.CONFLICT.getStatusCode(),
+                             CONSUMER_ALREADY_SUBSCRIBED_ERROR_CODE);
+  }
+
+
   public final static String KEY_SCHEMA_MISSING_MESSAGE = "Request includes keys but does not "
                                                           + "include key schema";
   public final static int KEY_SCHEMA_MISSING_ERROR_CODE = 42201;

--- a/src/test/java/io/confluent/kafkarest/unit/AbstractConsumerResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/AbstractConsumerResourceTest.java
@@ -50,6 +50,7 @@ public class AbstractConsumerResourceTest
 
   protected static final String groupName = "testgroup";
   protected static final String topicName = "testtopic";
+  protected static final String secondTopicName = "testtopic2";
   protected static final String instanceId = "uniqueid";
   protected static final String instancePath
       = "/consumers/" + groupName + "/instances/" + instanceId;


### PR DESCRIPTION
Pretty minor change, but required some updates to the MockConsumer implementation to make it unit-testable.
