### PR TITLE
Make installation instructions point users to the Confluent download and...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ into a stream processing framework that doesn't yet support Kafka, and scripting
 Installation
 ------------
 
-Release versions are available from the [Central Repository](http://search.maven.org/#search|ga|1|g%3A%22io.confluent%22%20AND%20a%3A%22kafka-rest%22).
+You can download prebuilt versions of the Kafka REST Proxy as part of the
+[Confluent Platform](http://confluent.io/downloads/). To install from source,
+follow the instructions in the Development section.
 
 Deployment
 ----------
@@ -28,9 +30,11 @@ at `localhost:9092`.
 Development
 -----------
 
-To build a development version, you may need a development version of [io.confluent.rest-utils](https://github.com/confluentinc/rest-utils).
-After installing `rest-utils` and compiling with Maven, you can run an instance of the proxy against a local Kafka cluster
-(using the default configuration included with Kafka):
+To build a development version, you may need a development version of
+[io.confluent.common](https://github.com/confluentinc/common) and [io.confluent.rest-utils](https://github.com/confluentinc/rest-utils).
+After installing `common` and `rest-utils` and compiling `kafka-rest` with
+Maven, you can run an instance of the proxy against a local Kafka cluster (using
+the default configuration included with Kafka):
 
     mvn exec:java
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,13 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.httpdomain']
+extensions = ['sphinx.ext.ifconfig', 'sphinxcontrib.httpdomain']
+
+def setup(app):
+    app.add_config_value('platform_docs', True, 'env')
+
+# Even if it has a default, these options need to be specified
+platform_docs = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -45,8 +45,15 @@ Assuming you have the Kafka and Kafka REST Proxy code checked out:
 Installation
 ------------
 
-Release versions are available from the `Central
-Repository <http://search.maven.org/#search|ga|1|g%3A%22io.confluent%22%20AND%20a%3A%22kafka-rest%22>`_.
+.. ifconfig:: platform_docs
+
+   See the :ref:`installation instructions<installation>` for the Confluent Platform.
+
+.. ifconfig:: not platform_docs
+
+   You can download prebuilt versions of the Kafka REST Proxy as part of the
+   `Confluent Platform <http://confluent.io/downloads/>`_. To install from
+   source, follow the instructions in the `Development`_ section.
 
 Deployment
 ----------
@@ -72,13 +79,39 @@ Development
 To build a development version, you may need a development versions of
 `io.confluent.common <https://github.com/confluentinc/common>`_ and
 `io.confluent.rest-utils <https://github.com/confluentinc/rest-utils>`_.  After
-installing ``common`` and ``rest-utils`` and compiling with Maven, you can run an instance of the
-proxy against a local Kafka cluster (using the default configuration included
-with Kafka):
+installing ``common`` and ``rest-utils``, you can build the Kafka REST Proxy
+with Maven. All the standard lifecycle phases work. During development, use
 
 .. sourcecode:: bash
 
-    $ mvn exec:java
+   $ mvn compile
+
+to build,
+
+.. sourcecode:: bash
+
+   $ mvn test
+
+to run the unit and integration tests, and
+
+.. sourcecode:: bash
+
+     $ mvn exec:java
+
+to run an instance of the proxy against a local Kafka cluster (using the default
+configuration included with Kafka).
+
+To create a packaged version, optionally skipping the tests:
+
+.. sourcecode:: bash
+
+    $ mvn package [-DskipTests]
+
+This will produce two versions ready for production:
+``target/kafka-rest-0.1-SNAPSHOT-package`` contains a directory layout similar
+to the packaged binary versions and
+``target/kafka-rest-0.1-SNAPSHOT-standalone.jar`` is an uber-jar including all
+the dependencies.
 
 Contribute
 ----------


### PR DESCRIPTION
... make the Development section more complete.

This addresses confluentinc/docs#6 for this repository and we can use this as a template for the other repositories.
