### PR TITLE
Convert InvalidConfigExceptions when creating consumers to 422 errors.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -595,6 +595,10 @@ any consumers before it is terminated.
    :>json string base_uri: Base URI used to construct URIs for subsequent requests against this consumer instance. This
                            will be of the form ``http://hostname:port/consumers/consumer_group/instances/instance_id``.
 
+   :statuscode 422:
+          * Error code 42204 -- Invalid consumer configuration. One of the settings specified in
+            the request contained an invalid value.
+
    **Example request**:
 
    .. sourcecode:: http

--- a/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -38,6 +38,7 @@ import io.confluent.kafkarest.entities.ConsumerRecord;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.rest.exceptions.RestNotFoundException;
 import io.confluent.rest.exceptions.RestServerErrorException;
+import kafka.common.InvalidConfigException;
 import kafka.consumer.Consumer;
 import kafka.consumer.ConsumerConfig;
 import kafka.javaapi.consumer.ConsumerConnector;
@@ -137,10 +138,14 @@ public class ConsumerManager {
       props.put("auto.offset.reset", config.getAutoOffsetReset());
     }
     ConsumerConnector consumer;
-    if (consumerFactory == null) {
-      consumer = Consumer.createJavaConsumerConnector(new ConsumerConfig(props));
-    } else {
-      consumer = consumerFactory.createConsumer(new ConsumerConfig(props));
+    try {
+      if (consumerFactory == null) {
+        consumer = Consumer.createJavaConsumerConnector(new ConsumerConfig(props));
+      } else {
+        consumer = consumerFactory.createConsumer(new ConsumerConfig(props));
+      }
+    } catch (InvalidConfigException e) {
+      throw Errors.invalidConsumerConfigException(e);
     }
 
     synchronized (this) {

--- a/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/src/main/java/io/confluent/kafkarest/Errors.java
@@ -21,6 +21,7 @@ import javax.ws.rs.core.Response;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
 import io.confluent.rest.exceptions.RestException;
 import io.confluent.rest.exceptions.RestNotFoundException;
+import kafka.common.InvalidConfigException;
 
 public class Errors {
 
@@ -88,4 +89,14 @@ public class Errors {
                                                 JSON_AVRO_CONVERSION_ERROR_CODE);
 
   }
+
+  public final static String INVALID_CONSUMER_CONFIG_MESSAGE = "Invalid consumer configuration: ";
+  public final static int INVALID_CONSUMER_CONFIG_ERROR_CODE = 42204;
+
+  public static RestConstraintViolationException invalidConsumerConfigException(
+      InvalidConfigException e) {
+    return new RestConstraintViolationException(INVALID_CONSUMER_CONFIG_MESSAGE + e.getMessage(),
+                                                INVALID_CONSUMER_CONFIG_ERROR_CODE);
+  }
+
 }


### PR DESCRIPTION
Previously they were uncaught and were turned into 500s automatically.
