### PR TITLE
Reduce integration test time.

### DIFF
--- a/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -51,6 +51,12 @@ import static org.junit.Assert.fail;
 
 public class AbstractConsumerTest extends ClusterTestHarness {
 
+  public AbstractConsumerTest() {
+  }
+
+  public AbstractConsumerTest(int numBrokers, boolean withSchemaRegistry) {
+    super(numBrokers, withSchemaRegistry);
+  }
   protected void produceBinaryMessages(List<ProducerRecord<byte[], byte[]>> records) {
     Properties props = new Properties();
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);

--- a/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
@@ -116,6 +116,9 @@ public class AvroProducerTest extends ClusterTestHarness {
       new PartitionOffset(0, 3L, null, null)
   );
 
+  public AvroProducerTest() {
+    super(1, true);
+  }
 
   @Before
   @Override

--- a/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -57,7 +57,7 @@ import scala.collection.JavaConversions;
  */
 public abstract class ClusterTestHarness {
 
-  public static final int DEFAULT_NUM_BROKERS = 3;
+  public static final int DEFAULT_NUM_BROKERS = 1;
 
   // Shared config
   protected Queue<Integer> ports;
@@ -90,15 +90,12 @@ public abstract class ClusterTestHarness {
   protected String restConnect = null;
 
   public ClusterTestHarness() {
-    this(DEFAULT_NUM_BROKERS);
+    this(DEFAULT_NUM_BROKERS, false);
   }
 
-  public ClusterTestHarness(int numBrokers) {
-    // 1 port per broker + ZK + SchemaReg + REST server
-    this(numBrokers, numBrokers + 3);
-  }
-
-  public ClusterTestHarness(int numBrokers, int numPorts) {
+  public ClusterTestHarness(int numBrokers, boolean withSchemaRegistry) {
+    // 1 port per broker + ZK + possibly SchemaReg + REST server
+    int numPorts = numBrokers + 3;
     ports = new ArrayDeque<Integer>();
     for (Object portObj : JavaConversions.asJavaList(TestUtils.choosePorts(numPorts))) {
       ports.add((Integer) portObj);
@@ -125,23 +122,27 @@ public abstract class ClusterTestHarness {
       bootstrapServers = bootstrapServers + "localhost:" + ((Integer) port).toString();
     }
 
-    schemaRegProperties = new Properties();
-    int schemaRegPort = ports.remove();
-    schemaRegProperties.put(SchemaRegistryConfig.PORT_CONFIG,
-                            ((Integer) schemaRegPort).toString());
-    schemaRegProperties.put(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG,
-                            zkConnect);
-    schemaRegProperties.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG,
-                            SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC);
-    schemaRegProperties.put(SchemaRegistryConfig.COMPATIBILITY_CONFIG,
-                            schemaRegCompatibility);
-    schemaRegConnect = String.format("http://localhost:%d", schemaRegPort);
+    if (withSchemaRegistry) {
+      schemaRegProperties = new Properties();
+      int schemaRegPort = ports.remove();
+      schemaRegProperties.put(SchemaRegistryConfig.PORT_CONFIG,
+                              ((Integer) schemaRegPort).toString());
+      schemaRegProperties.put(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG,
+                              zkConnect);
+      schemaRegProperties.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG,
+                              SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC);
+      schemaRegProperties.put(SchemaRegistryConfig.COMPATIBILITY_CONFIG,
+                              schemaRegCompatibility);
+      schemaRegConnect = String.format("http://localhost:%d", schemaRegPort);
+    }
 
     restProperties = new Properties();
     int restPort = ports.remove();
     restProperties.put(KafkaRestConfig.PORT_CONFIG, ((Integer) restPort).toString());
     restProperties.put(KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG, zkConnect);
-    restProperties.put(KafkaRestConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegConnect);
+    if (withSchemaRegistry) {
+      restProperties.put(KafkaRestConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegConnect);
+    }
     restConnect = String.format("http://localhost:%d", restPort);
   }
 
@@ -174,9 +175,12 @@ public abstract class ClusterTestHarness {
       servers.add(server);
     }
 
-    schemaRegApp = new SchemaRegistryRestApplication(new SchemaRegistryConfig(schemaRegProperties));
-    schemaRegServer = schemaRegApp.createServer();
-    schemaRegServer.start();
+    if (schemaRegProperties != null) {
+      schemaRegApp =
+          new SchemaRegistryRestApplication(new SchemaRegistryConfig(schemaRegProperties));
+      schemaRegServer = schemaRegApp.createServer();
+      schemaRegServer.start();
+    }
 
     restConfig = new KafkaRestConfig(restProperties);
     restApp = new TestKafkaRestApplication(restConfig, getZkClient(restConfig),

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
@@ -91,6 +91,9 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
     }
   };
 
+  public ConsumerAvroTest() {
+    super(1, true);
+  }
   @Before
   @Override
   public void setUp() throws Exception {

--- a/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.entities.BrokerList;
@@ -75,6 +74,10 @@ public class MetadataAPITest extends ClusterTestHarness {
 
   private static final int numReplicas = 2;
 
+  public MetadataAPITest() {
+    super(2, false);
+  }
+
   @Before
   @Override
   public void setUp() throws Exception {
@@ -91,7 +94,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     Response response = request("/brokers").get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
     final BrokerList brokers = response.readEntity(BrokerList.class);
-    assertEquals(new BrokerList(Arrays.asList(0, 1, 2)), brokers);
+    assertEquals(new BrokerList(Arrays.asList(0, 1)), brokers);
   }
 
   /* This should work, but due to the lack of timeouts in ZkClient, if ZK is down some calls
@@ -120,7 +123,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     final List<String> topicsResponse = response.readEntity(new GenericType<List<String>>() {
     });
     assertEquals(
-        Arrays.asList(SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, topic1Name, topic2Name),
+        Arrays.asList(topic1Name, topic2Name),
         topicsResponse);
 
     // Get topic

--- a/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
@@ -56,12 +56,6 @@ public class ProducerTest extends AbstractProducerTest {
   private ZkClient testZkClient;
 
   private static final String topicName = "topic1";
-  private static final List<Partition> partitions = Arrays.asList(
-      new Partition(0, 0, Arrays.asList(
-          new PartitionReplica(0, true, true),
-          new PartitionReplica(1, false, false)
-      ))
-  );
 
   private static final Decoder<byte[]> binaryDecoder = new DefaultDecoder(null);
 


### PR DESCRIPTION
Reduce integration test time by using fewer brokers, one most of the time, and
only starting the schema registry when required. Fixes #62.