### PR TITLE
Handle conflicting IDs and separate IDs used in the REST proxy and by Ka...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,26 +36,34 @@ the REST Proxy running using the default settings and some topics already create
       {"value_schema_id":0,"offsets":[{"partition":0,"offset":0}]}
 
     # Create a consumer for binary data, starting at the beginning of the topic's
-    # log. Then consume some data from a topic.
+    # log. Then consume some data from a topic using the base URL in the first response.
+    # Finally, close the consumer with a DELETE to make it leave the group and clean up
+    # its resources.
     $ curl -X POST -H "Content-Type: application/vnd.kafka.v1+json" \
-          --data '{"id": "my_instance", "format": "binary", "auto.offset.reset": "smallest"}' \
+          --data '{"format": "binary", "auto.offset.reset": "smallest"}' \
           http://localhost:8082/consumers/my_binary_consumer
-      {"instance_id":"my_instance","base_uri":"http://localhost:8082/consumers/my_binary_consumer/instances/my_instance"}
+      {"instance_id":"rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6","base_uri":"http://localhost:8082/consumers/my_binary_consumer/instances/rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6"}
     $ curl -X GET -H "Accept: application/vnd.kafka.binary.v1+json" \
-          http://localhost:8082/consumers/my_binary_consumer/instances/my_instance/topics/test
-      [{"value":"S2Fma2E=","partition":0,"offset":0},{"value":"S2Fma2E=","partition":0,"offset":1}]
+          http://localhost:8082/consumers/my_binary_consumer/instances/rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6/topics/test
+      [{"key":null,"value":"S2Fma2E=","partition":0,"offset":0}]
+    $ curl -X DELETE \
+          http://localhost:8082/consumers/my_binary_consumer/instances/rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6
+      # No content in response
 
     # Create a consumer for Avro data, starting at the beginning of the topic's
     # log. Then consume some data from a topic, which is decoded, translated to
     # JSON, and included in the response. The schema used for deserialization is
-    # fetched automatically from the schema registry.
+    # fetched automatically from the schema registry. Finally, clean up.
     $ curl -X POST -H "Content-Type: application/vnd.kafka.v1+json" \
-          --data '{"id": "my_instance", "format": "avro", "auto.offset.reset": "smallest"}' \
+          --data '{"format": "avro", "auto.offset.reset": "smallest"}' \
           http://localhost:8082/consumers/my_avro_consumer
-      {"instance_id":"my_instance","base_uri":"http://localhost:8082/consumers/my_avro_consumer/instances/my_instance"}
+      {"instance_id":"rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b","base_uri":"http://localhost:8082/consumers/my_avro_consumer/instances/rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b"}
     $ curl -X GET -H "Accept: application/vnd.kafka.avro.v1+json" \
-          http://localhost:8082/consumers/my_avro_consumer/instances/my_instance/topics/avrotest
-      [{"value":{"name":"testUser"},"partition":0,"offset":0},{"value":{"name":"testUser2"},"partition":0,"offset":1}]
+          http://localhost:8082/consumers/my_avro_consumer/instances/rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b/topics/avrotest
+      [{"key":null,"value":{"name":"testUser"},"partition":0,"offset":0}]
+    $ curl -X DELETE \
+          http://localhost:8082/consumers/my_avro_consumer/instances/rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b
+      # No content in response
 
 Installation
 ------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -656,8 +656,12 @@ error.
    for this specific REST proxy instance.
 
    :param string group_name: The name of the consumer group to join
-   :<json string id: Unique ID for the consumer instance in this group. If omitted, one will be automatically generated
-                     using the REST proxy ID and an auto-incrementing number
+   :<json string id: **DEPRECATED** Unique ID for the consumer instance in this group. If omitted,
+                     one will be automatically generated
+   :<json string name: Name for the consumer instance, which will be used in URLs for the
+                       consumer. This must be unique, at least within the proxy process handling
+                       the request. If omitted, falls back on the automatically generated ID. Using
+                       automatically generated names is recommended for most use cases.
    :<json string format: The format of consumed messages, which is used to convert messages into
                          a JSON-compatible form. Valid values: "binary", "avro". If unspecified,
                          defaults to "binary".
@@ -669,6 +673,8 @@ error.
    :>json string base_uri: Base URI used to construct URIs for subsequent requests against this consumer instance. This
                            will be of the form ``http://hostname:port/consumers/consumer_group/instances/instance_id``.
 
+   :statuscode 409:
+          * Error code 40902 -- Consumer instance with the specified name already exists.
    :statuscode 422:
           * Error code 42204 -- Invalid consumer configuration. One of the settings specified in
             the request contained an invalid value.
@@ -682,7 +688,7 @@ error.
       Accept: application/vnd.kafka.v1+json, application/vnd.kafka+json, application/json
 
       {
-        "id": "my_consumer",
+        "name": "my_consumer",
         "format": "binary",
         "auto.offset.reset": "smallest",
         "auto.commit.enable": "false"

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -40,26 +40,34 @@ the REST Proxy running using the default settings and some topics already create
      {"offsets":[{"partition":0,"offset":0,"error_code":null,"error":null}],"key_schema_id":null,"value_schema_id":21}
 
    # Create a consumer for binary data, starting at the beginning of the topic's
-   # log. Then consume some data from a topic.
+   # log. Then consume some data from a topic using the base URL in the first response.
+   # Finally, close the consumer with a DELETE to make it leave the group and clean up
+   # its resources.
    $ curl -X POST -H "Content-Type: application/vnd.kafka.v1+json" \
-         --data '{"id": "my_instance", "format": "binary", "auto.offset.reset": "smallest"}' \
+         --data '{"format": "binary", "auto.offset.reset": "smallest"}' \
          http://localhost:8082/consumers/my_binary_consumer
-     {"instance_id":"my_instance","base_uri":"http://localhost:8082/consumers/my_binary_consumer/instances/my_instance"}
+     {"instance_id":"rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6","base_uri":"http://localhost:8082/consumers/my_binary_consumer/instances/rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6"}
    $ curl -X GET -H "Accept: application/vnd.kafka.binary.v1+json" \
-         http://localhost:8082/consumers/my_binary_consumer/instances/my_instance/topics/test
+         http://localhost:8082/consumers/my_binary_consumer/instances/rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6/topics/test
      [{"key":null,"value":"S2Fma2E=","partition":0,"offset":0}]
+   $ curl -X DELETE \
+         http://localhost:8082/consumers/my_binary_consumer/instances/rest-consumer-11561681-8ba5-4b46-bed0-905ae1769bc6
+     # No content in response
 
    # Create a consumer for Avro data, starting at the beginning of the topic's
    # log. Then consume some data from a topic, which is decoded, translated to
    # JSON, and included in the response. The schema used for deserialization is
-   # fetched automatically from the schema registry.
+   # fetched automatically from the schema registry. Finally, clean up.
    $ curl -X POST -H "Content-Type: application/vnd.kafka.v1+json" \
-         --data '{"id": "my_instance", "format": "avro", "auto.offset.reset": "smallest"}' \
+         --data '{"format": "avro", "auto.offset.reset": "smallest"}' \
          http://localhost:8082/consumers/my_avro_consumer
-     {"instance_id":"my_instance","base_uri":"http://localhost:8082/consumers/my_avro_consumer/instances/my_instance"}
+     {"instance_id":"rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b","base_uri":"http://localhost:8082/consumers/my_avro_consumer/instances/rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b"}
    $ curl -X GET -H "Accept: application/vnd.kafka.avro.v1+json" \
-         http://localhost:8082/consumers/my_avro_consumer/instances/my_instance/topics/avrotest
+         http://localhost:8082/consumers/my_avro_consumer/instances/rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b/topics/avrotest
      [{"key":null,"value":{"name":"testUser"},"partition":0,"offset":0}]
+   $ curl -X DELETE \
+         http://localhost:8082/consumers/my_avro_consumer/instances/rest-consumer-11392f3a-efbe-4fe2-b0bf-5c85d7b25e7b
+     # No content in response
 
 
 Features

--- a/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/src/main/java/io/confluent/kafkarest/Errors.java
@@ -75,6 +75,16 @@ public class Errors {
                              CONSUMER_ALREADY_SUBSCRIBED_ERROR_CODE);
   }
 
+  public final static String CONSUMER_ALREADY_EXISTS_MESSAGE =
+      "Consumer with specified consumer ID already exists in the specified consumer group.";
+  public final static int CONSUMER_ALREADY_EXISTS_ERROR_CODE = 40902;
+
+  public static RestException consumerAlreadyExistsException() {
+    return new RestException(CONSUMER_ALREADY_EXISTS_MESSAGE,
+                             Response.Status.CONFLICT.getStatusCode(),
+                             CONSUMER_ALREADY_EXISTS_ERROR_CODE);
+  }
+
 
   public final static String KEY_SCHEMA_MISSING_MESSAGE = "Request includes keys but does not "
                                                           + "include key schema";

--- a/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
+++ b/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
@@ -27,6 +27,7 @@ public class ConsumerInstanceConfig {
   private static final EmbeddedFormat DEFAULT_FORMAT = EmbeddedFormat.BINARY;
 
   private String id;
+  private String name;
   @NotNull
   private EmbeddedFormat format;
   private String autoOffsetReset;
@@ -38,14 +39,16 @@ public class ConsumerInstanceConfig {
 
   public ConsumerInstanceConfig(EmbeddedFormat format) {
     // This constructor is only for tests so reparsing the format name is ok
-    this(null, format.name(), null, null);
+    this(null, null, format.name(), null, null);
   }
 
   public ConsumerInstanceConfig(@JsonProperty("id") String id,
+                                @JsonProperty("name") String name,
                                 @JsonProperty("format") String format,
                                 @JsonProperty("auto.offset.reset") String autoOffsetReset,
                                 @JsonProperty("auto.commit.enable") String autoCommitEnable) {
     this.id = id;
+    this.name = name;
     if (format == null) {
       this.format = DEFAULT_FORMAT;
     } else {
@@ -74,6 +77,16 @@ public class ConsumerInstanceConfig {
   @JsonProperty
   public void setId(String id) {
     this.id = id;
+  }
+
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
+
+  @JsonProperty
+  public void setName(String name) {
+    this.name = name;
   }
 
   @JsonIgnore

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
@@ -107,7 +107,6 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   @Test
   public void testConsumeOnlyValues() {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.AVRO,
-                                              Versions.KAFKA_V1_JSON_AVRO,
                                               Versions.KAFKA_V1_JSON_AVRO);
     produceAvroMessages(recordsOnlyValues);
     consumeMessages(instanceUri, topicName, recordsOnlyValues,
@@ -119,7 +118,6 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   @Test
   public void testConsumeWithKeys() {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.AVRO,
-                                              Versions.KAFKA_V1_JSON_AVRO,
                                               Versions.KAFKA_V1_JSON_AVRO);
     produceAvroMessages(recordsWithKeys);
     consumeMessages(instanceUri, topicName, recordsWithKeys,
@@ -131,13 +129,12 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   @Test
   public void testConsumeInvalidTopic() {
     startConsumeMessages(groupName, "nonexistenttopic", EmbeddedFormat.AVRO,
-                         Versions.KAFKA_V1_JSON_AVRO, Versions.KAFKA_V1_JSON_AVRO, true);
+                         Versions.KAFKA_V1_JSON_AVRO, true);
   }
 
   @Test
   public void testConsumeTimeout() {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.AVRO,
-                                              Versions.KAFKA_V1_JSON_AVRO,
                                               Versions.KAFKA_V1_JSON_AVRO);
     produceAvroMessages(recordsWithKeys);
     consumeMessages(instanceUri, topicName, recordsWithKeys,
@@ -151,7 +148,6 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   @Test
   public void testDeleteConsumer() {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.AVRO,
-                                              Versions.KAFKA_V1_JSON_AVRO,
                                               Versions.KAFKA_V1_JSON_AVRO);
     produceAvroMessages(recordsWithKeys);
     consumeMessages(instanceUri, topicName, recordsWithKeys,

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
@@ -86,7 +86,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
     // Between these tests we either leave the config null or request the binary embedded format
     // so we can test that both will result in binary consumers. We also us varying accept
     // parameters to test that we default to Binary for various values.
-    String instanceUri = startConsumeMessages(groupName, topicName, null, null,
+    String instanceUri = startConsumeMessages(groupName, topicName, null,
                                               Versions.KAFKA_V1_JSON_BINARY);
     produceBinaryMessages(recordsOnlyValues);
     consumeMessages(instanceUri, topicName, recordsOnlyValues,
@@ -98,7 +98,6 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testConsumeWithKeys() {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.BINARY,
-                                              Versions.KAFKA_V1_JSON_BINARY,
                                               Versions.KAFKA_V1_JSON_BINARY);
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(instanceUri, topicName, recordsWithKeys,
@@ -110,13 +109,12 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testConsumeInvalidTopic() {
     startConsumeMessages(groupName, "nonexistenttopic", null,
-                         Versions.KAFKA_V1_JSON_BINARY, Versions.KAFKA_V1_JSON_BINARY, true);
+                         Versions.KAFKA_V1_JSON_BINARY, true);
   }
 
   @Test
   public void testConsumeTimeout() {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.BINARY,
-                                              Versions.KAFKA_V1_JSON,
                                               Versions.KAFKA_V1_JSON_BINARY);
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(instanceUri, topicName, recordsWithKeys,
@@ -131,7 +129,6 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testDeleteConsumer() {
     String instanceUri = startConsumeMessages(groupName, topicName, null,
-                                              Versions.KAFKA_DEFAULT_JSON,
                                               Versions.KAFKA_V1_JSON_BINARY);
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(instanceUri, topicName, recordsWithKeys,
@@ -145,12 +142,29 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   // that isn't specific to the type of embedded data, but since they need
   @Test
   public void testInvalidKafkaConsumerConfig() {
-    ConsumerInstanceConfig config = new ConsumerInstanceConfig("id", "binary", "bad-config", null);
+    ConsumerInstanceConfig config = new ConsumerInstanceConfig("id", "name", "binary",
+                                                               "bad-config", null);
     Response response = request("/consumers/" + groupName)
         .post(Entity.entity(config, Versions.KAFKA_V1_JSON));
     assertErrorResponse(ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY, response,
                         Errors.INVALID_CONSUMER_CONFIG_ERROR_CODE,
                         Errors.INVALID_CONSUMER_CONFIG_MESSAGE,
                         Versions.KAFKA_V1_JSON);
+  }
+
+
+  @Test
+  public void testDuplicateConsumerID() {
+    String instanceUrl = startConsumeMessages(groupName, topicName, null,
+                                              Versions.KAFKA_V1_JSON_BINARY);
+    produceBinaryMessages(recordsWithKeys);
+
+    // Duplicate the same instance, which should cause a conflict
+    String name = consumerNameFromInstanceUrl(instanceUrl);
+    Response createResponse = createConsumerInstance(groupName, null, name, null);
+    assertErrorResponse(Response.Status.CONFLICT, createResponse,
+                        Errors.CONSUMER_ALREADY_EXISTS_ERROR_CODE,
+                        Errors.CONSUMER_ALREADY_EXISTS_MESSAGE,
+                        Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
   }
 }

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -55,7 +55,6 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
   @Test
   public void testConsumerTimeout() throws InterruptedException {
     String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.BINARY,
-                                              Versions.KAFKA_V1_JSON_BINARY,
                                               Versions.KAFKA_V1_JSON_BINARY);
     // Even with identical timeouts, should be able to consume multiple times without the
     // instance timing out


### PR DESCRIPTION
...fka's consumer implementation.

Add a check for duplicate IDs before creating a consumer and adding it to the
map in ConsumerManager. Also add a "name" field to ConsumerInstanceConfig to
allow control over the naming of the instance config within the single REST
proxy without setting the ID of the underlying Kafka consumer, since this can be
useful if a limited set of consumer instances within a group is desired. Update
the documentation to mark the "id" field as deprecated since it probably doesn't
provide the behavior users expect and without this fix it can cause problems if
the user ends up with duplicates. Kafka doesn't expect it to be used this way
except for testing anyway. Also add the name field and update all the example
cURL requests to use the recommended default where both "id" and "name" are
omitted, and consumers are deleted properly when they are no longer needed.

Fixes #65.

@junrao Maybe you could review this? I want to be especially careful here since this affects the existing API rather than just adding to it, so backwards compatibility is particularly important.