### PR TITLE
Remove kafka from list of production directories to include in CLASSPATH.

### DIFF
--- a/bin/kafka-rest-run-class
+++ b/bin/kafka-rest-run-class
@@ -21,8 +21,8 @@ for dir in $base_dir/target/kafka-rest-*-development; do
   CLASSPATH=$CLASSPATH:$dir/share/java/kafka-rest/*
 done
 
-# Production jars, including kafka, rest-utils, and kafka-rest
-for library in "kafka" "confluent-common" "rest-utils" "kafka-rest"; do
+# Production jars
+for library in "confluent-common" "rest-utils" "kafka-rest"; do
   CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*
 done
 


### PR DESCRIPTION
The packaging intentionally pulls in a copy of the Kafka jars so that kafka-rest
doesn't need Scala versioning. The inclusion of the Kafka directory was leftover
from before our packaging setup supported different Scala versions of
Kafka. Fixes #77.