### PR TITLE
rest-utils updates

### DIFF
--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -24,8 +24,9 @@ Global Metrics
   ``connections-active``
     Total number of active TCP connections.
 
-  ``connections-accepted-rate``
-    The average rate per second of accepted TCP connections.
+  ``connections-accepted-rate`` (deprecated since 2.0)
+    * In 1.x: The average rate per second of accepted TCP connections.
+    * In 2.x: Same as ``connections-opened-rate``.
 
   ``connections-opened-rate``
     The average rate per second of opened TCP connections.
@@ -108,5 +109,3 @@ endpoint name ``brokers.list`` with the metric name ``request-rate`` to get
                                  ``Content-Type: application/vnd.kafka.binary.v1+json`` header
   ``topics.list``                ``GET /topics``
   ============================== ===================================================================
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,10 @@
 
     <properties>
         <confluent.version>2.0-SNAPSHOT</confluent.version>
-        <jersey.version>2.6</jersey.version>
         <kafka.version>0.8.2.0-cp</kafka.version>
         <kafka.scala.version>2.10</kafka.scala.version>
         <!-- See note about workaround below. This should match the version used in the version of rest-utils you're using. -->
-        <confluent.junit.version>4.11</confluent.junit.version>
+        <confluent.junit.version>4.12</confluent.junit.version>
         <easymock.version>3.0</easymock.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Updates the documentation and JUnit version.

I am not sure how we want to format deprecations, so this is just something to start the conversation.

Should follow https://github.com/confluentinc/rest-utils/pull/21