### PR TITLE
Allowing Null Values

### DIFF
--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -94,7 +94,7 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
         // if there isn't a schema. Validation will have already checked that all the keys/values
         // were NullNodes.
         Object key = (keySchema != null ? AvroConverter.toAvro(record.getKey(), keySchema) : null);
-        Object value = (valueSchema != null
+        Object value = ((valueSchema != null && !record.getValue().isNull())
                         ? AvroConverter.toAvro(record.getValue(), valueSchema) : null);
         Integer recordPartition = partition;
         if (recordPartition == null) {

--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -94,7 +94,7 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
         // if there isn't a schema. Validation will have already checked that all the keys/values
         // were NullNodes.
         Object key = (keySchema != null ? AvroConverter.toAvro(record.getKey(), keySchema) : null);
-        Object value = ((valueSchema != null && !record.getValue().isNull())
+        Object value = (valueSchema != null
                         ? AvroConverter.toAvro(record.getValue(), valueSchema) : null);
         Integer recordPartition = partition;
         if (recordPartition == null) {

--- a/src/main/java/io/confluent/kafkarest/converters/AvroConverter.java
+++ b/src/main/java/io/confluent/kafkarest/converters/AvroConverter.java
@@ -66,6 +66,8 @@ public class AvroConverter {
 
   public static Object toAvro(JsonNode value, Schema schema) {
     try {
+      if (value.isNull())
+         return null;
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       jsonMapper.writeValue(out, value);
       DatumReader<Object> reader = new GenericDatumReader<Object>(schema);


### PR DESCRIPTION
Allows value to be null even if a value schema has been defined for the request. This allows someone to have multiple inserts and deletes in the same request.

Currently the only way to have a null value is to not pass a value schema or schema id. If someone wanted to send a request with a large number of records, some records being inserts, some deletes; they could not just pass a key and a null value for the deletes, because a value schema would be defined. This allows them to send a null value for the deletes and still have a value schema in place for the inserts.