### PR TITLE
Support kafka-rest.base_uri configuration that defines a custom base URI for all the URLs returned by API

### DIFF
--- a/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -43,6 +43,13 @@ public class KafkaRestConfig extends RestConfig {
       + " hostname is used";
   public static final String HOST_NAME_DEFAULT = "";
 
+  public static final String BASE_URI_CONFIG = "kafka-rest.base_uri";
+  private static final String BASE_URI_DOC =
+      "The base uri used to generate absolute URLs in responses. Defaults to empty. If this value is "
+      + "set, host.name and port configuration will be ignored. This configuration is useful when kafka-rest "
+      + "is running behind another HTTP web server.";
+  public static final String BASE_URI_DEFAULT = "";
+
   public static final String ZOOKEEPER_CONNECT_CONFIG = "zookeeper.connect";
   private static final String
       ZOOKEEPER_CONNECT_DOC =
@@ -149,6 +156,7 @@ public class KafkaRestConfig extends RestConfig {
                         METRICS_JMX_PREFIX_DEFAULT_OVERRIDE, Importance.LOW, METRICS_JMX_PREFIX_DOC)
         .define(ID_CONFIG, Type.STRING, ID_DEFAULT, Importance.HIGH, ID_CONFIG_DOC)
         .define(HOST_NAME_CONFIG, Type.STRING, HOST_NAME_DEFAULT, Importance.MEDIUM, HOST_NAME_DOC)
+        .define(BASE_URI_CONFIG, Type.STRING, BASE_URI_DEFAULT, Importance.MEDIUM, BASE_URI_DOC)
         .define(ZOOKEEPER_CONNECT_CONFIG, Type.STRING, ZOOKEEPER_CONNECT_DEFAULT,
                 Importance.HIGH, ZOOKEEPER_CONNECT_DOC)
         .define(SCHEMA_REGISTRY_URL_CONFIG, Type.STRING, SCHEMA_REGISTRY_URL_DEFAULT,

--- a/src/main/java/io/confluent/kafkarest/UriUtils.java
+++ b/src/main/java/io/confluent/kafkarest/UriUtils.java
@@ -24,19 +24,24 @@ import javax.ws.rs.core.UriInfo;
 public class UriUtils {
 
   public static UriBuilder absoluteUriBuilder(KafkaRestConfig config, UriInfo uriInfo) {
-    String hostname = config.getString(KafkaRestConfig.HOST_NAME_CONFIG);
-    UriBuilder builder = uriInfo.getAbsolutePathBuilder();
-    if (hostname.length() > 0) {
-      builder.host(hostname);
-      // Resetting the hostname removes the scheme and port for some reason, so they may need to
-      // be reset.
-      URI origAbsoluteUri = uriInfo.getAbsolutePath();
-      builder.scheme(origAbsoluteUri.getScheme());
-      // Only reset the port if it was set in the original URI
-      if (origAbsoluteUri.getPort() != -1) {
-        builder.port(config.getInt(KafkaRestConfig.PORT_CONFIG));
+    String baseURI = config.getString(KafkaRestConfig.BASE_URI_CONFIG);
+    if (baseURI.length() > 0) {
+      return UriBuilder.fromUri(baseURI);
+    } else {
+      String hostname = config.getString(KafkaRestConfig.HOST_NAME_CONFIG);
+      UriBuilder builder = uriInfo.getAbsolutePathBuilder();
+      if (hostname.length() > 0) {
+        builder.host(hostname);
+        // Resetting the hostname removes the scheme and port for some reason, so they may need to
+        // be reset.
+        URI origAbsoluteUri = uriInfo.getAbsolutePath();
+        builder.scheme(origAbsoluteUri.getScheme());
+        // Only reset the port if it was set in the original URI
+        if (origAbsoluteUri.getPort() != -1) {
+          builder.port(config.getInt(KafkaRestConfig.PORT_CONFIG));
+        }
       }
+      return builder;
     }
-    return builder;
   }
 }

--- a/src/main/java/io/confluent/kafkarest/UriUtils.java
+++ b/src/main/java/io/confluent/kafkarest/UriUtils.java
@@ -26,7 +26,7 @@ public class UriUtils {
   public static UriBuilder absoluteUriBuilder(KafkaRestConfig config, UriInfo uriInfo) {
     String baseURI = config.getString(KafkaRestConfig.BASE_URI_CONFIG);
     if (baseURI.length() > 0) {
-      return UriBuilder.fromUri(baseURI);
+      return UriBuilder.fromUri(baseURI).path(uriInfo.getPath());
     } else {
       String hostname = config.getString(KafkaRestConfig.HOST_NAME_CONFIG);
       UriBuilder builder = uriInfo.getAbsolutePathBuilder();

--- a/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
@@ -85,6 +85,10 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.BASE_URI_CONFIG, "http://foo.com");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    assertEquals("http://foo.com", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    EasyMock.expect(uriInfo.getPath()).andReturn("consumers/my_random_consumer");
+    EasyMock.replay(uriInfo);
+    // HOST_NAME_CONFIG should be ignored since BASE_URI_CONFIG is not empty
+    assertEquals("http://foo.com/consumers/my_random_consumer", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    EasyMock.verify(uriInfo);
   }
 }

--- a/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
@@ -79,4 +79,12 @@ public class UriUtilsTest {
     EasyMock.verify(uriInfo);
   }
 
+  @Test
+  public void testAbsoluteURIBuilderWithBaseURI() throws RestConfigException {
+    Properties props = new Properties();
+    props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
+    props.put(KafkaRestConfig.BASE_URI_CONFIG, "http://foo.com");
+    KafkaRestConfig config = new KafkaRestConfig(props);
+    assertEquals("http://foo.com", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+  }
 }


### PR DESCRIPTION
When we run kafka-rest behind an HTTP Web Server (e.g. Nginx or Apache), we would expect it to use the public facing URL instead of the local one. That can be achieved by having this configuration and giving it higher priority than scheme, host, and port configurations.

This PR also partially solved the issue #75: one can setup SSL at the Web Server (which runs in front of Kafka Rest API) and use an URI with `https` scheme for `kafka-rest.base_uri` configuration.
