### PR TITLE
REST-116: Catching exception due to NONE from ZkUtils in Kafka.

### DIFF
--- a/src/main/java/io/confluent/kafkarest/MetadataObserver.java
+++ b/src/main/java/io/confluent/kafkarest/MetadataObserver.java
@@ -180,20 +180,24 @@ public class MetadataObserver {
 
       Partition p = new Partition();
       p.setPartition(partId);
-      LeaderAndIsr leaderAndIsr =
-          zkUtils.getLeaderAndIsrForPartition(topic, partId).get();
-      p.setLeader(leaderAndIsr.leader());
-      scala.collection.immutable.Set<Integer> isr = leaderAndIsr.isr().toSet();
-      List<PartitionReplica> partReplicas = new Vector<PartitionReplica>();
-      for (Object brokerObj : JavaConversions.asJavaCollection(part.getValue())) {
-        int broker = (Integer) brokerObj;
-        PartitionReplica
-            r =
-            new PartitionReplica(broker, (leaderAndIsr.leader() == broker), isr.contains(broker));
-        partReplicas.add(r);
+      try {
+        LeaderAndIsr leaderAndIsr =
+                zkUtils.getLeaderAndIsrForPartition(topic, partId).get();
+        p.setLeader(leaderAndIsr.leader());
+        scala.collection.immutable.Set<Integer> isr = leaderAndIsr.isr().toSet();
+        List<PartitionReplica> partReplicas = new Vector<PartitionReplica>();
+        for (Object brokerObj : JavaConversions.asJavaCollection(part.getValue())) {
+          int broker = (Integer) brokerObj;
+          PartitionReplica
+                  r =
+                  new PartitionReplica(broker, (leaderAndIsr.leader() == broker), isr.contains(broker));
+          partReplicas.add(r);
+        }
+        p.setReplicas(partReplicas);
+        partitions.add(p);
+      } catch (NoSuchElementException e) {
+        log.warn(e);
       }
-      p.setReplicas(partReplicas);
-      partitions.add(p);
     }
     return partitions;
   }

--- a/src/main/java/io/confluent/kafkarest/MetadataObserver.java
+++ b/src/main/java/io/confluent/kafkarest/MetadataObserver.java
@@ -197,7 +197,7 @@ public class MetadataObserver {
         p.setReplicas(partReplicas);
         partitions.add(p);
       } catch (NoSuchElementException e) {
-        log.warn(e);
+        log.warn("No leader and ISR information for partition {}", partId);
       }
     }
     return partitions;

--- a/src/main/java/io/confluent/kafkarest/MetadataObserver.java
+++ b/src/main/java/io/confluent/kafkarest/MetadataObserver.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Vector;
 


### PR DESCRIPTION
Adding code to catch the exception. My understanding is that we should be adding no partition if we get NONE in the `getLeaderAndIsrForPartition` call, but if that's an error and we should be throwing an exception, then we should at least transform it into a more meaningful message.
