### PR TITLE
Doc change to remove the expectation that a broker is running on localhost:9092.

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -251,8 +251,7 @@ Although the properties file is not required, almost all production deployments
 *should* provide one. By default the server starts bound to port
 8082, does not specify a unique instance ID (required to safely run multiple
 proxies concurrently), and expects Zookeeper to be available at
-``localhost:2181``, a Kafka broker at ``localhost:9092``, and the schema
-registry at ``http://localhost:8081``.
+``localhost:2181`` and the schema registry at ``http://localhost:8081``.
 
 Development
 -----------


### PR DESCRIPTION
The docs currently say that a broker is expected to be running on localhost:9092. This isn't true. A broker doesn't need to be running on localhost:9092, and a bootstrap list of brokers doesn't need to be configured, either.