### PR TITLE
Fix for issue confluentinc/kafka-rest/issues/118

### DIFF
--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -94,6 +94,9 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
         // if there isn't a schema. Validation will have already checked that all the keys/values
         // were NullNodes.
         Object key = (keySchema != null ? AvroConverter.toAvro(record.getKey(), keySchema) : null);
+        if (key instanceof org.apache.avro.util.Utf8) {
+          key = key.toString();
+        }
         Object value = (valueSchema != null
                         ? AvroConverter.toAvro(record.getValue(), valueSchema) : null);
         Integer recordPartition = partition;

--- a/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
@@ -64,7 +64,8 @@ public class AvroProducerTest extends ClusterTestHarness {
 
   // This test assumes that AvroConverterTest is good enough and testing one primitive type for
   // keys and one complex type for records is sufficient.
-  private static final String keySchemaStr = "{\"name\":\"int\",\"type\": \"int\"}";
+  private static final String intKeySchemaStr = "{\"name\":\"int\",\"type\": \"int\"}";
+  private static final String stringKeySchemaStr = "{\"name\":\"string\",\"type\": \"string\"}";
   private static final String valueSchemaStr = "{\"type\": \"record\", "
                                                + "\"name\":\"test\","
                                                + "\"fields\":[{"
@@ -73,11 +74,18 @@ public class AvroProducerTest extends ClusterTestHarness {
                                                + "}]}";
   private static final Schema valueSchema = new Schema.Parser().parse(valueSchemaStr);
 
-  private final static JsonNode[] testKeys = {
+  private final static JsonNode[] testIntKeys = {
       TestUtils.jsonTree("1"),
       TestUtils.jsonTree("2"),
       TestUtils.jsonTree("3"),
       TestUtils.jsonTree("4")
+  };
+
+  private final static JsonNode[] testStringKeys = {
+      TestUtils.jsonTree("\"A\""),
+      TestUtils.jsonTree("\"B\""),
+      TestUtils.jsonTree("\"C\""),
+      TestUtils.jsonTree("\"D\"")
   };
 
   private final static JsonNode[] testValues = {
@@ -89,11 +97,17 @@ public class AvroProducerTest extends ClusterTestHarness {
 
   // Produce to topic inputs & results
 
-  private final List<AvroTopicProduceRecord> topicRecordsWithPartitionsAndKeys = Arrays.asList(
-      new AvroTopicProduceRecord(testKeys[0], testValues[0], 0),
-      new AvroTopicProduceRecord(testKeys[1], testValues[1], 1),
-      new AvroTopicProduceRecord(testKeys[2], testValues[2], 1),
-      new AvroTopicProduceRecord(testKeys[3], testValues[3], 2)
+  private final List<AvroTopicProduceRecord> topicRecordsWithPartitionsAndIntKeys = Arrays.asList(
+      new AvroTopicProduceRecord(testIntKeys[0], testValues[0], 0),
+      new AvroTopicProduceRecord(testIntKeys[1], testValues[1], 1),
+      new AvroTopicProduceRecord(testIntKeys[2], testValues[2], 1),
+      new AvroTopicProduceRecord(testIntKeys[3], testValues[3], 2)
+  );
+  private final List<AvroTopicProduceRecord> topicRecordsWithPartitionsAndStringKeys = Arrays.asList(
+      new AvroTopicProduceRecord(testStringKeys[0], testValues[0], 0),
+      new AvroTopicProduceRecord(testStringKeys[1], testValues[1], 1),
+      new AvroTopicProduceRecord(testStringKeys[2], testValues[2], 1),
+      new AvroTopicProduceRecord(testStringKeys[3], testValues[3], 2)
   );
   private final List<PartitionOffset> partitionOffsetsWithPartitionsAndKeys = Arrays.asList(
       new PartitionOffset(0, 0L, null, null),
@@ -136,7 +150,8 @@ public class AvroProducerTest extends ClusterTestHarness {
   }
 
   private <K, V> void testProduceToTopic(List<? extends TopicProduceRecord> records,
-                                         List<PartitionOffset> offsetResponses) {
+                                         List<PartitionOffset> offsetResponses,
+                                         String keySchemaStr) {
     TopicProduceRequest payload = new TopicProduceRequest();
     payload.setRecords(records);
     payload.setKeySchema(keySchemaStr);
@@ -155,8 +170,13 @@ public class AvroProducerTest extends ClusterTestHarness {
 
 
   @Test
-  public void testProduceToTopicWithPartitionsAndKeys() {
-    testProduceToTopic(topicRecordsWithPartitionsAndKeys, partitionOffsetsWithPartitionsAndKeys);
+  public void testProduceToTopicWithPartitionsAndIntKeys() {
+    testProduceToTopic(topicRecordsWithPartitionsAndIntKeys, partitionOffsetsWithPartitionsAndKeys, intKeySchemaStr);
+  }
+
+  @Test
+  public void testProduceToTopicWithPartitionsAndStringKeys() {
+    testProduceToTopic(topicRecordsWithPartitionsAndStringKeys, partitionOffsetsWithPartitionsAndKeys, stringKeySchemaStr);
   }
 
   private <K, V> void testProduceToPartition(List<? extends ProduceRecord<K, V>> records,


### PR DESCRIPTION
This is a quick fix, not intended to be the best solution, for solving the issue with string partition keys in avro messages.

When we try to convert the [key to avro](https://github.com/confluentinc/kafka-rest/blob/v2.0.1/src/main/java/io/confluent/kafkarest/AvroRestProducer.java#L96), we end up using the `JsonDecoder` class in Apache Avro. From that class we return an `org.apache.avro.util.Utf8` that later on [we send to the KafkaProducer](https://github.com/confluentinc/kafka-rest/blob/v2.0.1/src/main/java/io/confluent/kafkarest/AvroRestProducer.java#L109).

The problem is, Kafka-rest is [injecting a SchemaRegistry's `KafkaAvroSerializer` class instance](https://github.com/confluentinc/kafka-rest/blob/v2.0.1/src/main/java/io/confluent/kafkarest/ProducerPool.java#L109-L114) for decoding, which ends up using [this code](https://github.com/confluentinc/schema-registry/blob/v2.0.1/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java#L92):

```java
protected Schema getSchema(Object object) {
    if (object == null) {
      return primitiveSchemas.get("Null");
    } else if (object instanceof Boolean) {
      return primitiveSchemas.get("Boolean");
    } else if (object instanceof Integer) {
      return primitiveSchemas.get("Integer");
    } else if (object instanceof Long) {
      return primitiveSchemas.get("Long");
    } else if (object instanceof Float) {
      return primitiveSchemas.get("Float");
    } else if (object instanceof Double) {
      return primitiveSchemas.get("Double");
    } else if (object instanceof String) {
      return primitiveSchemas.get("String");
    } else if (object instanceof byte[]) {
      return primitiveSchemas.get("Bytes");
    } else if (object instanceof GenericContainer) {
      return ((GenericContainer) object).getSchema();
    } else {
      throw new IllegalArgumentException(
          "Unsupported Avro type. Supported types are null, Boolean, Integer, Long, " +
          "Float, Double, String, byte[] and IndexedRecord");
    }
  }
```
The class `org.apache.avro.util.Utf8` is not inheriting from `java.lang.String`, so we end up with an `IllegalArgumentException` error.

This PR just casts the `org.apache.avro.util.Utf8` to a `java.lang.String` as a fast fix. Probably the proper fix should be done in other place.
