### PR TITLE
Issue #229: Add blurb on Jetty jmx metrics

### DIFF
--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -16,6 +16,9 @@ the service. Per-endpoint metrics monitor each API endpoint request method and a
 prefixed by a name of the endpoint (e.g. ``brokers.list``). These help you
 understand how the proxy is being used and track down specific performance problems.
 
+In addition to the metrics defined below, the REST proxy also exposes the
+wealth of metrics that are provided by the underlying Jetty server.
+
 Global Metrics
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Commit for #229

I'm not of the correct way to document these metrics.  There isn't really any public documentation available on the specifics on what Jetty is actually exposing so I'm not sure if this is the right place to do it.  It exposes a lot of different beans and attributes so it would be cumbersome to list them out here.

I took the tack of providing a hint for users that the data is indeed there and can be discovered via jconsole/visualvm/whatever.