### PR TITLE
Add incompatible error

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -83,6 +83,8 @@ per-request basis.
    :statuscode 404:
           * Error code 40401 -- Topic not found.
           * Error code 40402 -- Partition not found.
+   :statuscode 409:
+          * Error code 40903 -- Incompatible Avro Schema.
    :statuscode 422: The request payload is either improperly formatted or contains semantic errors
    :statuscode 500:
           * Error code 50001 -- Zookeeper error.

--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -90,7 +90,7 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
     } catch (RestClientException e) {
       // FIXME We should return more specific error codes (unavailable vs registration failed in
       // a way that isn't retriable?).
-      if (e.getStatus() =409){
+      if (e.getStatus() == 409){
         throw Errors.IncompatibleAvroSchema();
       } else {
         throw new RestException("Schema registration or lookup failed", 408, 40801, e);

--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -90,7 +90,11 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
     } catch (RestClientException e) {
       // FIXME We should return more specific error codes (unavailable vs registration failed in
       // a way that isn't retriable?).
-      throw new RestException("Schema registration or lookup failed", 408, 40801, e);
+      if (e.getStatus() =409){
+        throw Errors.IncompatibleAvroSchema();
+      } else {
+        throw new RestException("Schema registration or lookup failed", 408, 40801, e);
+      }
     } catch (SchemaParseException e) {
       throw Errors.invalidSchemaException(e);
     } catch (IOException e) {

--- a/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/src/main/java/io/confluent/kafkarest/Errors.java
@@ -71,6 +71,16 @@ public class Errors {
                              CONSUMER_FORMAT_MISMATCH_ERROR_CODE);
   }
 
+  public final static String INCOMPATIBLE_AVRO_SCHEMA =
+          "Incompatible Avro schema";
+  public final static int INCOMPATIBLE_AVRO_SCHEMA_ERROR_CODE = 40903;
+
+  public static RestException IncompatibleAvroSchema() {
+    return new RestException(INCOMPATIBLE_AVRO_SCHEMA,
+            Response.Status.CONFLICT.getStatusCode(),
+            INCOMPATIBLE_AVRO_SCHEMA_ERROR_CODE);
+  }
+
 
   public final static String CONSUMER_ALREADY_SUBSCRIBED_MESSAGE =
       "Consumer cannot subscribe the the specified target because it has already subscribed to "


### PR DESCRIPTION
I need to know the compatibility is broken or not, because if compatibility is broken, and then I would like to produce to "error" topic.
In the current code, client cannot know why schema registration fails because error code "408" is very ambiguous.

Thanks, 
