### PR TITLE
Apply cached schema id fix from master to 2.x

### DIFF
--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -62,14 +62,26 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
         keySchema = keySerializer.getByID(keySchemaId);
       } else if (schemaHolder.getKeySchema() != null) {
         keySchema = new Schema.Parser().parse(schemaHolder.getKeySchema());
-        keySchemaId = keySerializer.register(topic + "-key", keySchema);
+        if (schemaIdCache.containsKey(keySchema)){
+          keySchemaId = schemaIdCache.get(keySchema);
+          keySchema = keySerializer.getByID(keySchemaId);
+        } else {
+          keySchemaId = keySerializer.register(topic + "-key", keySchema);
+          schemaIdCache.put(keySchema, keySchemaId);
+        }
       }
 
       if (valueSchemaId != null) {
         valueSchema = valueSerializer.getByID(valueSchemaId);
       } else if (schemaHolder.getValueSchema() != null) {
         valueSchema = new Schema.Parser().parse(schemaHolder.getValueSchema());
-        valueSchemaId = valueSerializer.register(topic + "-value", valueSchema);
+        if (schemaIdCache.containsKey(valueSchema)) {
+          valueSchemaId = schemaIdCache.get(valueSchema);
+          valueSchema = valueSerializer.getByID(valueSchemaId);
+        } else {
+          valueSchemaId = valueSerializer.register(topic + "-value", valueSchema);
+          schemaIdCache.put(valueSchema, valueSchemaId);
+        }
       }
     } catch (RestClientException e) {
       // FIXME We should return more specific error codes (unavailable vs registration failed in

--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -47,6 +48,7 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
     this.producer = producer;
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;
+    this.schemaIdCache = new ConcurrentHashMap<>(100);
   }
 
   public void produce(ProduceTask task, String topic, Integer partition,

--- a/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
+++ b/src/main/java/io/confluent/kafkarest/AvroRestProducer.java
@@ -26,6 +26,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -41,6 +43,7 @@ public class AvroRestProducer implements RestProducer<JsonNode, JsonNode> {
   protected final KafkaProducer<Object, Object> producer;
   protected final KafkaAvroSerializer keySerializer;
   protected final KafkaAvroSerializer valueSerializer;
+  protected final Map<Schema, Integer> schemaIdCache;
 
   public AvroRestProducer(KafkaProducer<Object, Object> producer,
                           KafkaAvroSerializer keySerializer,

--- a/src/test/java/io/confluent/kafkarest/unit/AvroRestProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/AvroRestProducerTest.java
@@ -104,13 +104,15 @@ public class AvroRestProducerTest {
 
   @Test
   public void testRepeatedProducer() throws Exception {
+    String valueSchema = "{\"type\": \"record\", \"name\": \"User\", \"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+    Schema schema = new Schema.Parser().parse(valueSchema);
     // This is the key part of the test, we should only call register once with the same schema
     EasyMock.expect(valueSerializer.register(EasyMock.isA(String.class), EasyMock.isA(Schema.class))).andReturn(1);
+    EasyMock.expect(valueSerializer.getByID(1)).andReturn(schema).times(9999);
     EasyMock.replay(valueSerializer);
     Future f = EasyMock.createMock(Future.class);
     EasyMock.expect(producer.send(EasyMock.isA(ProducerRecord.class), EasyMock.isA(Callback.class))).andStubReturn(f);
     EasyMock.replay(producer);
-    String valueSchema = "{\"type\": \"record\", \"name\": \"User\", \"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
     schemaHolder = new SchemaHolder(null, valueSchema);
     for (int i = 0; i < 10000; ++i) {
       restProducer.produce(


### PR DESCRIPTION
Apply cached schema id fix from master to 2.x. Also tweak AvroRestProducerTest.testRepeatedProducer to ensure that it passes. 
