### PR TITLE
aligns schema registry url with default schema registry url

### DIFF
--- a/config/kafka-rest.properties
+++ b/config/kafka-rest.properties
@@ -15,5 +15,5 @@
 ##
 
 #id=kafka-rest-test-server
-#schema.registry.url=http://localhost:8081
+#schema.registry.url=http://0.0.0.0:8081
 #zookeeper.connect=localhost:2181


### PR DESCRIPTION
This is very minor, but it fixes an issue where I could not simply change the port number in the configuration file to run schema registry on a different port.  Another process was running on port 8081.  If I only changed the port in the URL to match the one I changed in schema-registry.properties, the process would not be able to connect to the schema registry. Once I matched the entire URL, the quickstart guide steps worked just fine.  This change will allow someone to simply change the port number to run schema registry on another port instead of fiddling with the IP address.