### PR TITLE
added statuscode 506 and error code 40601

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -85,6 +85,8 @@ per-request basis.
    :statuscode 404:
           * Error code 40401 -- Topic not found.
           * Error code 40402 -- Partition not found.
+   :statuscode 406: 
+          * Error code 40601 -- The requested embedded data format does not match the deserializer for this consumer instance.
    :statuscode 422: The request payload is either improperly formatted or contains semantic errors
    :statuscode 500:
           * Error code 50001 -- Zookeeper error.


### PR DESCRIPTION
additional error added, which occurs, when the embedded data format does not match the deserializer specified in the POST /consumers/ call.