### PR TITLE
CLIENTS-304: Add test utility that logs entities if they fail to parse.

### DIFF
--- a/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -164,7 +164,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     assertOKResponse(createResponse, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
 
     CreateConsumerInstanceResponse instanceResponse =
-        createResponse.readEntity(CreateConsumerInstanceResponse.class);
+            TestUtils.tryReadEntityOrLog(createResponse, CreateConsumerInstanceResponse.class);
     assertNotNull(instanceResponse.getInstanceId());
     assertTrue(instanceResponse.getInstanceId().length() > 0);
     assertTrue("Base URI should contain the consumer instance ID",
@@ -180,7 +180,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
                           expectedMediatype);
     } else {
       assertOKResponse(response, expectedMediatype);
-      List<BinaryConsumerRecord> consumed = response.readEntity(
+      List<BinaryConsumerRecord> consumed = TestUtils.tryReadEntityOrLog(response, 
           new GenericType<List<BinaryConsumerRecord>>() {
           });
       assertEquals(0, consumed.size());
@@ -252,7 +252,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     Response response = request("/topics/" + topicName + "/partitions/0/messages", queryParams)
         .accept(accept).get();
     assertOKResponse(response, responseMediatype);
-    List<RecordType> consumed = response.readEntity(responseEntityType);
+    List<RecordType> consumed = TestUtils.tryReadEntityOrLog(response, responseEntityType);
     assertEquals(records.size(), consumed.size());
 
     assertEqualsMessages(records, consumed, converter);
@@ -267,7 +267,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     Response response = request(instanceUri + "/topics/" + topic)
         .accept(accept).get();
     assertOKResponse(response, responseMediatype);
-    List<RecordType> consumed = response.readEntity(responseEntityType);
+    List<RecordType> consumed = TestUtils.tryReadEntityOrLog(response, responseEntityType);
     assertEquals(records.size(), consumed.size());
 
     assertEqualsMessages(records, consumed, converter);
@@ -281,7 +281,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
         .accept(accept).get();
     long finished = System.currentTimeMillis();
     assertOKResponse(response, responseMediatype);
-    List<RecordType> consumed = response.readEntity(responseEntityType);
+    List<RecordType> consumed = TestUtils.tryReadEntityOrLog(response, responseEntityType);
     assertEquals(0, consumed.size());
 
     // Note that this is only approximate and really only works if you assume the read call has
@@ -310,9 +310,8 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
     // We don't verify offsets since they'll depend on how data gets distributed to partitions.
     // Just parse to check the output is formatted validly.
-    List<TopicPartitionOffset>
-        offsets =
-        response.readEntity(new GenericType<List<TopicPartitionOffset>>() {
+    List<TopicPartitionOffset> offsets =
+            TestUtils.tryReadEntityOrLog(response, new GenericType<List<TopicPartitionOffset>>() {
         });
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/AbstractProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AbstractProducerTest.java
@@ -47,7 +47,7 @@ public class AbstractProducerTest extends ClusterTestHarness {
     Response response = request("/topics/" + topicName)
         .post(Entity.entity(payload, getEmbeddedContentType()));
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final ProduceResponse produceResponse = response.readEntity(ProduceResponse.class);
+    final ProduceResponse produceResponse = TestUtils.tryReadEntityOrLog(response, ProduceResponse.class);
     if (matchPartitions) {
       TestUtils.assertPartitionsEqual(offsetResponses, produceResponse.getOffsets());
     }
@@ -69,7 +69,7 @@ public class AbstractProducerTest extends ClusterTestHarness {
         .post(Entity.entity(payload, getEmbeddedContentType()));
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
     final ProduceResponse poffsetResponse
-        = response.readEntity(ProduceResponse.class);
+        = TestUtils.tryReadEntityOrLog(response, ProduceResponse.class);
     assertEquals(offsetResponse, poffsetResponse.getOffsets());
     TestUtils.assertTopicContains(zkConnect, topicName,
         payload.getRecords(), partition,
@@ -84,7 +84,7 @@ public class AbstractProducerTest extends ClusterTestHarness {
     Response response = request("/topics/" + topicName)
         .post(Entity.entity(payload, Versions.KAFKA_MOST_SPECIFIC_DEFAULT));
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final ProduceResponse produceResponse = response.readEntity(ProduceResponse.class);
+    final ProduceResponse produceResponse = TestUtils.tryReadEntityOrLog(response, ProduceResponse.class);
     for (PartitionOffset pOffset : produceResponse.getOffsets()) {
       assertNotNull(pOffset.getError());
     }

--- a/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
@@ -144,7 +144,7 @@ public class AvroProducerTest extends ClusterTestHarness {
     Response response = request("/topics/" + topicName)
         .post(Entity.entity(payload, Versions.KAFKA_V1_JSON_AVRO));
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final ProduceResponse produceResponse = response.readEntity(ProduceResponse.class);
+    final ProduceResponse produceResponse = TestUtils.tryReadEntityOrLog(response, ProduceResponse.class);
     TestUtils.assertPartitionOffsetsEqual(offsetResponses, produceResponse.getOffsets());
     TestUtils.assertTopicContains(zkConnect, topicName,
                                   payload.getRecords(), null,
@@ -168,7 +168,7 @@ public class AvroProducerTest extends ClusterTestHarness {
         .post(Entity.entity(payload, Versions.KAFKA_V1_JSON_AVRO));
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
     final ProduceResponse poffsetResponse
-        = response.readEntity(ProduceResponse.class);
+        = TestUtils.tryReadEntityOrLog(response, ProduceResponse.class);
     assertEquals(offsetResponse, poffsetResponse.getOffsets());
     TestUtils.assertTopicContains(zkConnect, topicName,
                                   payload.getRecords(), (Integer) 0,

--- a/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -31,11 +31,11 @@ import io.confluent.kafkarest.entities.BrokerList;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
-import kafka.utils.TestUtils;
 import scala.collection.JavaConversions;
 
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static io.confluent.kafkarest.TestUtils.tryReadEntityOrLog;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -82,9 +82,9 @@ public class MetadataAPITest extends ClusterTestHarness {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    TestUtils.createTopic(zkUtils, topic1Name, topic1Partitions.size(), numReplicas,
+    kafka.utils.TestUtils.createTopic(zkUtils, topic1Name, topic1Partitions.size(), numReplicas,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
-    TestUtils.createTopic(zkUtils, topic2Name, topic2Partitions.size(), numReplicas,
+    kafka.utils.TestUtils.createTopic(zkUtils, topic2Name, topic2Partitions.size(), numReplicas,
                           JavaConversions.asScalaBuffer(this.servers), topic2Configs);
   }
 
@@ -93,7 +93,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     // Listing
     Response response = request("/brokers").get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final BrokerList brokers = response.readEntity(BrokerList.class);
+    final BrokerList brokers = tryReadEntityOrLog(response, BrokerList.class);
     assertEquals(new BrokerList(Arrays.asList(0, 1)), brokers);
   }
 
@@ -120,7 +120,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     // Listing
     Response response = request("/topics").get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final List<String> topicsResponse = response.readEntity(new GenericType<List<String>>() {
+    final List<String> topicsResponse = tryReadEntityOrLog(response, new GenericType<List<String>>() {
     });
     assertEquals(
         Arrays.asList(topic1Name, topic2Name),
@@ -129,7 +129,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     // Get topic
     Response response1 = request("/topics/{topic}", "topic", topic1Name).get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final Topic topic1Response = response1.readEntity(Topic.class);
+    final Topic topic1Response = tryReadEntityOrLog(response1, Topic.class);
     // Just verify some basic properties because the exact values can vary based on replica
     // assignment, leader election
     assertEquals(topic1.getName(), topic1Response.getName());
@@ -150,9 +150,8 @@ public class MetadataAPITest extends ClusterTestHarness {
     // Listing
     Response response = request("/topics/" + topic1Name + "/partitions").get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final List<Partition>
-        partitions1Response =
-        response.readEntity(new GenericType<List<Partition>>() {
+    final List<Partition> partitions1Response =
+            tryReadEntityOrLog(response, new GenericType<List<Partition>>() {
         });
     // Just verify some basic properties because the exact values can vary based on replica
     // assignment, leader election
@@ -161,9 +160,8 @@ public class MetadataAPITest extends ClusterTestHarness {
 
     response = request("/topics/" + topic2Name + "/partitions").get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final List<Partition>
-        partitions2Response =
-        response.readEntity(new GenericType<List<Partition>>() {
+    final List<Partition> partitions2Response =
+            tryReadEntityOrLog(response, new GenericType<List<Partition>>() {
         });
     assertEquals(topic2Partitions.size(), partitions2Response.size());
     assertEquals(numReplicas, partitions2Response.get(0).getReplicas().size());
@@ -172,7 +170,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     // Get single partition
     response = request("/topics/" + topic1Name + "/partitions/0").get();
     assertOKResponse(response, Versions.KAFKA_MOST_SPECIFIC_DEFAULT);
-    final Partition getPartitionResponse = response.readEntity(Partition.class);
+    final Partition getPartitionResponse = tryReadEntityOrLog(response, Partition.class);
     assertEquals(0, getPartitionResponse.getPartition());
     assertEquals(numReplicas, getPartitionResponse.getReplicas().size());
 

--- a/src/test/java/io/confluent/kafkarest/unit/BrokersResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/BrokersResourceTest.java
@@ -68,7 +68,7 @@ public class BrokersResourceTest
 
       Response response = request("/brokers", mediatype.header).get();
       assertOKResponse(response, mediatype.expected);
-      final BrokerList returnedBrokerIds = response.readEntity(new GenericType<BrokerList>() {
+      final BrokerList returnedBrokerIds = TestUtils.tryReadEntityOrLog(response, new GenericType<BrokerList>() {
       });
       assertEquals(brokerIds, returnedBrokerIds.getBrokers());
       EasyMock.verify(mdObserver);

--- a/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceAvroTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceAvroTest.java
@@ -78,9 +78,8 @@ public class ConsumerResourceAvroTest extends AbstractConsumerResourceTest {
         Response response = request("/consumers/" + groupName, mediatype.header)
             .post(Entity.entity(new ConsumerInstanceConfig(EmbeddedFormat.AVRO), requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final CreateConsumerInstanceResponse
-            createResponse =
-            response.readEntity(CreateConsumerInstanceResponse.class);
+        final CreateConsumerInstanceResponse createResponse =
+            TestUtils.tryReadEntityOrLog(response, CreateConsumerInstanceResponse.class);
 
         // Read with size limit
         String readUrl = instanceBasePath(createResponse) + "/topics/" + topicName;
@@ -94,18 +93,15 @@ public class ConsumerResourceAvroTest extends AbstractConsumerResourceTest {
         String expectedMediatype
             = mediatype.header != null ? mediatype.expected : Versions.KAFKA_V1_JSON_AVRO;
         assertOKResponse(readLimitResponse, expectedMediatype);
-        final List<AvroConsumerRecord>
-            readLimitResponseRecords =
-            readLimitResponse.readEntity(new GenericType<List<AvroConsumerRecord>>() {
-            });
+        final List<AvroConsumerRecord> readLimitResponseRecords =
+            TestUtils.tryReadEntityOrLog(readLimitResponse, new GenericType<List<AvroConsumerRecord>>() {});
         assertEquals(expectedReadLimit, readLimitResponseRecords);
 
         // Read without size limit
         Response readResponse = request(readUrl, mediatype.header).get();
         assertOKResponse(readResponse, expectedMediatype);
-        final List<AvroConsumerRecord>
-            readResponseRecords =
-            readResponse.readEntity(new GenericType<List<AvroConsumerRecord>>() {
+        final List<AvroConsumerRecord> readResponseRecords =
+                TestUtils.tryReadEntityOrLog(readResponse, new GenericType<List<AvroConsumerRecord>>() {
             });
         assertEquals(expectedReadNoLimit, readResponseRecords);
 
@@ -113,9 +109,8 @@ public class ConsumerResourceAvroTest extends AbstractConsumerResourceTest {
         Response commitResponse = request(commitUrl, mediatype.header)
             .post(Entity.entity(null, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final List<TopicPartitionOffset>
-            committedOffsets =
-            commitResponse.readEntity(new GenericType<List<TopicPartitionOffset>>() {
+        final List<TopicPartitionOffset> committedOffsets =
+                TestUtils.tryReadEntityOrLog(commitResponse, new GenericType<List<TopicPartitionOffset>>() {
             });
         assertEquals(expectedOffsets, committedOffsets);
 

--- a/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceBinaryTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceBinaryTest.java
@@ -73,9 +73,8 @@ public class ConsumerResourceBinaryTest extends AbstractConsumerResourceTest {
         Response response = request("/consumers/" + groupName, mediatype.header)
             .post(Entity.entity(null, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final CreateConsumerInstanceResponse
-            createResponse =
-            response.readEntity(CreateConsumerInstanceResponse.class);
+        final CreateConsumerInstanceResponse createResponse =
+                TestUtils.tryReadEntityOrLog(response,CreateConsumerInstanceResponse.class);
 
         // Read with size limit
         String readUrl = instanceBasePath(createResponse) + "/topics/" + topicName;
@@ -89,18 +88,16 @@ public class ConsumerResourceBinaryTest extends AbstractConsumerResourceTest {
         String expectedMediatype
             = mediatype.header != null ? mediatype.expected : Versions.KAFKA_V1_JSON_BINARY;
         assertOKResponse(readLimitResponse, expectedMediatype);
-        final List<BinaryConsumerRecord>
-            readLimitResponseRecords =
-            readLimitResponse.readEntity(new GenericType<List<BinaryConsumerRecord>>() {
+        final List<BinaryConsumerRecord> readLimitResponseRecords =
+                TestUtils.tryReadEntityOrLog(readLimitResponse,new GenericType<List<BinaryConsumerRecord>>() {
             });
         assertEquals(expectedReadLimit, readLimitResponseRecords);
 
         // Read without size limit
         Response readResponse = request(readUrl, mediatype.header).get();
         assertOKResponse(readResponse, expectedMediatype);
-        final List<BinaryConsumerRecord>
-            readResponseRecords =
-            readResponse.readEntity(new GenericType<List<BinaryConsumerRecord>>() {
+        final List<BinaryConsumerRecord> readResponseRecords =
+                TestUtils.tryReadEntityOrLog(readResponse,new GenericType<List<BinaryConsumerRecord>>() {
             });
         assertEquals(expectedReadNoLimit, readResponseRecords);
 
@@ -108,9 +105,8 @@ public class ConsumerResourceBinaryTest extends AbstractConsumerResourceTest {
         Response commitResponse = request(commitUrl, mediatype.header)
             .post(Entity.entity(null, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final List<TopicPartitionOffset>
-            committedOffsets =
-            commitResponse.readEntity(new GenericType<List<TopicPartitionOffset>>() {
+        final List<TopicPartitionOffset> committedOffsets =
+                TestUtils.tryReadEntityOrLog(commitResponse,new GenericType<List<TopicPartitionOffset>>() {
             });
         assertEquals(expectedOffsets, committedOffsets);
 

--- a/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceTest.java
@@ -58,9 +58,8 @@ public class ConsumerResourceTest extends AbstractConsumerResourceTest {
         Response response = request("/consumers/" + groupName, mediatype.header)
             .post(Entity.entity(null, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final CreateConsumerInstanceResponse
-            ciResponse =
-            response.readEntity(CreateConsumerInstanceResponse.class);
+        final CreateConsumerInstanceResponse ciResponse =
+                TestUtils.tryReadEntityOrLog(response, CreateConsumerInstanceResponse.class);
         assertEquals(instanceId, ciResponse.getInstanceId());
         assertThat(ciResponse.getBaseUri(),
                    allOf(startsWith("http://"), containsString(instancePath)));
@@ -84,9 +83,8 @@ public class ConsumerResourceTest extends AbstractConsumerResourceTest {
         Response response = request("/consumers/" + groupName, mediatype.header)
             .post(Entity.entity(config, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final CreateConsumerInstanceResponse
-            ciResponse =
-            response.readEntity(CreateConsumerInstanceResponse.class);
+        final CreateConsumerInstanceResponse ciResponse =
+                TestUtils.tryReadEntityOrLog(response, CreateConsumerInstanceResponse.class);
         assertEquals(instanceId, ciResponse.getInstanceId());
         assertThat(ciResponse.getBaseUri(),
                    allOf(startsWith("http://"), containsString(instancePath)));
@@ -111,9 +109,8 @@ public class ConsumerResourceTest extends AbstractConsumerResourceTest {
         Response response = request("/consumers/" + groupName, mediatype.header)
             .post(Entity.entity(null, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final CreateConsumerInstanceResponse
-            createResponse =
-            response.readEntity(CreateConsumerInstanceResponse.class);
+        final CreateConsumerInstanceResponse createResponse =
+                TestUtils.tryReadEntityOrLog(response, CreateConsumerInstanceResponse.class);
 
         final Response
             readResponse =
@@ -142,9 +139,8 @@ public class ConsumerResourceTest extends AbstractConsumerResourceTest {
         Response response = request("/consumers/" + groupName, mediatype.header)
             .post(Entity.entity(null, requestMediatype));
         assertOKResponse(response, mediatype.expected);
-        final CreateConsumerInstanceResponse
-            createResponse =
-            response.readEntity(CreateConsumerInstanceResponse.class);
+        final CreateConsumerInstanceResponse createResponse =
+                TestUtils.tryReadEntityOrLog(response, CreateConsumerInstanceResponse.class);
 
         final Response
             deleteResponse =

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroConsumeTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroConsumeTest.java
@@ -54,7 +54,7 @@ public class PartitionsResourceAvroConsumeTest extends PartitionsResourceAbstrac
       assertOKResponse(response, mediatype.expected);
 
       final List<AvroConsumerRecord> readResponseRecords =
-          response.readEntity(new GenericType<List<AvroConsumerRecord>>() {});
+              TestUtils.tryReadEntityOrLog(response, new GenericType<List<AvroConsumerRecord>>() {});
       assertEquals(records, readResponseRecords);
 
       EasyMock.verify(simpleConsumerManager);

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
@@ -164,7 +164,7 @@ public class PartitionsResourceAvroProduceTest
             produceToPartition(topicName, 0, request, mediatype.header, requestMediatype,
                                EmbeddedFormat.AVRO, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals((Integer) 1, response.getKeySchemaId());
@@ -185,7 +185,7 @@ public class PartitionsResourceAvroProduceTest
             produceToPartition(topicName, 0, request, mediatype.header, requestMediatype,
                                EmbeddedFormat.AVRO, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals((Integer) 1, response.getKeySchemaId());

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryConsumeTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryConsumeTest.java
@@ -57,7 +57,7 @@ public class PartitionsResourceBinaryConsumeTest extends PartitionsResourceAbstr
       assertOKResponse(response, expectedMediatype);
 
       final List<BinaryConsumerRecord> readResponseRecords =
-          response.readEntity(new GenericType<List<BinaryConsumerRecord>>() {});
+              TestUtils.tryReadEntityOrLog(response, new GenericType<List<BinaryConsumerRecord>>() {});
       assertEquals(records, readResponseRecords);
 
       EasyMock.verify(simpleConsumerManager);

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
@@ -157,7 +157,7 @@ public class PartitionsResourceBinaryProduceTest
                                EmbeddedFormat.BINARY,
                                produceRecordsOnlyValues, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals(null, response.getKeySchemaId());
@@ -178,7 +178,7 @@ public class PartitionsResourceBinaryProduceTest
                                EmbeddedFormat.BINARY,
                                produceRecordsWithKeys, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals(null, response.getKeySchemaId());

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceTest.java
@@ -89,7 +89,7 @@ public class PartitionsResourceTest
 
       Response response = request("/topics/topic1/partitions", mediatype.header).get();
       assertOKResponse(response, mediatype.expected);
-      List<Partition> partitionsResponse = response.readEntity(new GenericType<List<Partition>>() {
+      List<Partition> partitionsResponse = TestUtils.tryReadEntityOrLog(response, new GenericType<List<Partition>>() {
       });
       assertEquals(partitions, partitionsResponse);
 
@@ -112,13 +112,13 @@ public class PartitionsResourceTest
 
       Response response = request("/topics/topic1/partitions/0", mediatype.header).get();
       assertOKResponse(response, mediatype.expected);
-      Partition partition = response.readEntity(new GenericType<Partition>() {
+      Partition partition = TestUtils.tryReadEntityOrLog(response, new GenericType<Partition>() {
       });
       assertEquals(partitions.get(0), partition);
 
       response = request("/topics/topic1/partitions/1", mediatype.header).get();
       assertOKResponse(response, mediatype.expected);
-      partition = response.readEntity(new GenericType<Partition>() {
+      partition = TestUtils.tryReadEntityOrLog(response, new GenericType<Partition>() {
       });
       assertEquals(partitions.get(1), partition);
 

--- a/src/test/java/io/confluent/kafkarest/unit/RootResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/RootResourceTest.java
@@ -52,7 +52,7 @@ public class RootResourceTest
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES) {
       Response response = request("/", mediatype.header).get();
       assertOKResponse(response, mediatype.expected);
-      Map<String, String> decoded = response.readEntity(new GenericType<Map<String, String>>() {
+      Map<String, String> decoded = TestUtils.tryReadEntityOrLog(response, new GenericType<Map<String, String>>() {
       });
     }
   }

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
@@ -172,7 +172,7 @@ public class TopicsResourceAvroProduceTest
                            EmbeddedFormat.AVRO,
                            request, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse,ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals((Integer) 1, response.getKeySchemaId());

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
@@ -200,7 +200,7 @@ public class TopicsResourceBinaryProduceTest
             produceToTopic("topic1", mediatype.header, requestMediatype,
                            EmbeddedFormat.BINARY, records, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals(null, response.getKeySchemaId());
@@ -295,7 +295,7 @@ public class TopicsResourceBinaryProduceTest
           );
         } else {
           assertOKResponse(rawResponse, mediatype.expected);
-          ProduceResponse response = rawResponse.readEntity(ProduceResponse.class);
+          ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
           assertEquals(produceExceptionResults, response.getOffsets());
           assertEquals(null, response.getKeySchemaId());
           assertEquals(null, response.getValueSchemaId());

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceTest.java
@@ -73,7 +73,7 @@ public class TopicsResourceTest
 
       Response response = request("/topics", mediatype.expected).get();
       assertOKResponse(response, mediatype.expected);
-      final List<String> topicsResponse = response.readEntity(new GenericType<List<String>>() {
+      final List<String> topicsResponse = TestUtils.tryReadEntityOrLog(response, new GenericType<List<String>>() {
       });
       assertEquals(topics, topicsResponse);
 
@@ -114,12 +114,12 @@ public class TopicsResourceTest
 
       Response response1 = request("/topics/topic1", mediatype.header).get();
       assertOKResponse(response1, mediatype.expected);
-      final Topic topicResponse1 = response1.readEntity(new GenericType<Topic>() {
+      final Topic topicResponse1 = TestUtils.tryReadEntityOrLog(response1, new GenericType<Topic>() {
       });
       assertEquals(topic1, topicResponse1);
 
       Response response2 = request("/topics/topic2", mediatype.header).get();
-      final Topic topicResponse2 = response2.readEntity(new GenericType<Topic>() {
+      final Topic topicResponse2 = TestUtils.tryReadEntityOrLog(response2, new GenericType<Topic>() {
       });
       assertEquals(topic2, topicResponse2);
 


### PR DESCRIPTION
This will aid in debugging when unexpected responses are received.