### PR TITLE
CLIENTS-304: Fix AvroConsumerRecord constructors and handling of topic for v1 consumer API.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2440,12 +2440,14 @@ error.
           "value": "Y29uZmx1ZW50",
           "partition": 1,
           "offset": 100,
+          "topic": "test_topic"
         },
         {
           "key": "a2V5",
           "value": "a2Fma2E=",
           "partition": 2,
           "offset": 101,
+          "topic": "test_topic"
         }
       ]
 
@@ -2473,6 +2475,7 @@ error.
           },
           "partition": 1,
           "offset": 100,
+          "topic": "test_avro_topic"
         },
         {
           "key": 2,
@@ -2482,6 +2485,7 @@ error.
           },
           "partition": 2,
           "offset": 101,
+          "topic": "test_avro_topic"
         }
       ]
 
@@ -2506,12 +2510,14 @@ error.
           "value": {"foo":"bar"},
           "partition": 1,
           "offset": 10,
+          "topic": "test_json_topic"
         },
         {
           "key": "somekey",
           "value": ["foo", "bar"],
           "partition": 2,
           "offset": 11,
+          "topic": "test_json_topic"
         }
       ]
 

--- a/src/main/java/io/confluent/kafkarest/AvroConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/AvroConsumerState.java
@@ -62,9 +62,13 @@ public class AvroConsumerState extends ConsumerState<Object, Object, JsonNode, J
       MessageAndMetadata<Object, Object> msg) {
     AvroConverter.JsonNodeAndSize keyNode = AvroConverter.toJson(msg.key());
     AvroConverter.JsonNodeAndSize valueNode = AvroConverter.toJson(msg.message());
-    return new ConsumerRecordAndSize<JsonNode, JsonNode>(
-        new AvroConsumerRecord(keyNode.json, valueNode.json, msg.partition(), msg.offset()),
-        keyNode.size + valueNode.size
+    return new ConsumerRecordAndSize<>(
+            new AvroConsumerRecord(msg.topic(),
+                                   keyNode.json,
+                                   valueNode.json,
+                                   msg.partition(),
+                                   msg.offset()),
+            keyNode.size + valueNode.size
     );
   }
 }

--- a/src/main/java/io/confluent/kafkarest/BinaryConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/BinaryConsumerState.java
@@ -51,8 +51,12 @@ public class BinaryConsumerState extends ConsumerState<byte[], byte[], byte[], b
       MessageAndMetadata<byte[], byte[]> msg) {
     long approxSize = (msg.key() != null ? msg.key().length : 0)
                       + (msg.message() != null ? msg.message().length : 0);
-    return new ConsumerRecordAndSize<byte[], byte[]>(
-        new BinaryConsumerRecord(msg.key(), msg.message(), msg.partition(), msg.offset()),
+    return new ConsumerRecordAndSize<>(
+        new BinaryConsumerRecord(msg.topic(),
+                                 msg.key(),
+                                 msg.message(),
+                                 msg.partition(),
+                                 msg.offset()),
         approxSize);
   }
 

--- a/src/main/java/io/confluent/kafkarest/JsonConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/JsonConsumerState.java
@@ -66,8 +66,8 @@ public class JsonConsumerState extends ConsumerState<byte[], byte[], Object, Obj
       value = deserialize(msg.message());
     }
 
-    return new ConsumerRecordAndSize<Object, Object>(
-        new JsonConsumerRecord(key, value, msg.partition(), msg.offset()),
+    return new ConsumerRecordAndSize<>(
+        new JsonConsumerRecord(msg.topic(), key, value, msg.partition(), msg.offset()),
         approxSize);
   }
 

--- a/src/main/java/io/confluent/kafkarest/SimpleConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/SimpleConsumerManager.java
@@ -190,8 +190,11 @@ public class SimpleConsumerManager {
                                  messageAndOffset.message(), messageAndOffset.offset(),
                                  binaryDecoder, binaryDecoder,
                                  0, TimestampType.CREATE_TIME);
-    return new BinaryConsumerRecord(messageAndMetadata.key(), messageAndMetadata.message(),
-        partitionId, messageAndOffset.offset());
+    return new BinaryConsumerRecord(topicName,
+                                    messageAndMetadata.key(),
+                                    messageAndMetadata.message(),
+                                    partitionId,
+                                    messageAndOffset.offset());
   }
 
   private AvroConsumerRecord createAvroConsumerRecord(final MessageAndOffset messageAndOffset,
@@ -202,10 +205,11 @@ public class SimpleConsumerManager {
                                  messageAndOffset.message(), messageAndOffset.offset(),
                                  avroDecoder, avroDecoder,
                                  0, TimestampType.CREATE_TIME);
-    return new AvroConsumerRecord(
-        AvroConverter.toJson(messageAndMetadata.key()).json,
-        AvroConverter.toJson(messageAndMetadata.message()).json,
-        partitionId, messageAndOffset.offset());
+    return new AvroConsumerRecord(topicName,
+                                  AvroConverter.toJson(messageAndMetadata.key()).json,
+                                  AvroConverter.toJson(messageAndMetadata.message()).json,
+                                  partitionId,
+                                  messageAndOffset.offset());
   }
 
 
@@ -217,8 +221,11 @@ public class SimpleConsumerManager {
                                  messageAndOffset.message(), messageAndOffset.offset(),
                                  jsonDecoder, jsonDecoder,
                                  0, TimestampType.CREATE_TIME);
-    return new JsonConsumerRecord(messageAndMetadata.key(), messageAndMetadata.message(),
-        partitionId, messageAndOffset.offset());
+    return new JsonConsumerRecord(topicName,
+                                  messageAndMetadata.key(),
+                                  messageAndMetadata.message(),
+                                  partitionId,
+                                  messageAndOffset.offset());
   }
 
   private ConsumerRecord createConsumerRecord(final MessageAndOffset messageAndOffset,

--- a/src/main/java/io/confluent/kafkarest/entities/AvroConsumerRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/AvroConsumerRecord.java
@@ -16,18 +16,13 @@
 
 package io.confluent.kafkarest.entities;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class AvroConsumerRecord extends ConsumerRecord<JsonNode, JsonNode> {
 
-  public AvroConsumerRecord(
-      @JsonProperty("key") JsonNode key, @JsonProperty("value") JsonNode value,
-      @JsonProperty("partition") int partition, @JsonProperty("offset") long offset
-  ) {
-    super(key, value, partition, offset);
-  }
-
+  @JsonCreator
   public AvroConsumerRecord(
       @JsonProperty("topic") String topic,
       @JsonProperty("key") JsonNode key, @JsonProperty("value") JsonNode value,

--- a/src/main/java/io/confluent/kafkarest/entities/ConsumerRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/ConsumerRecord.java
@@ -18,6 +18,8 @@ package io.confluent.kafkarest.entities;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -35,24 +37,12 @@ public abstract class ConsumerRecord<K, V> {
   @Min(0)
   protected long offset;
 
-    public ConsumerRecord(String topic, K key, V value, int partition, long offset) {
+  public ConsumerRecord(String topic, K key, V value, int partition, long offset) {
     this.topic = topic;
     this.key = key;
     this.value = value;
     this.partition = partition;
     this.offset = offset;
-  }
-
-    
-  public ConsumerRecord(K key, V value, int partition, long offset) {
-    this.key = key;
-    this.value = value;
-    this.partition = partition;
-    this.offset = offset;
-  }
-
-  public ConsumerRecord(int partition, long offset) {
-    this(null, null, partition, offset);
   }
 
   @JsonProperty
@@ -123,31 +113,17 @@ public abstract class ConsumerRecord<K, V> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    ConsumerRecord that = (ConsumerRecord) o;
-
-    if (offset != that.offset) {
-      return false;
-    }
-    if (partition != that.partition) {
-      return false;
-    }
-    if (key != null ? !key.equals(that.key) : that.key != null) {
-      return false;
-    }
-    if (value != null ? !value.equals(that.value) : that.value != null) {
-      return false;
-    }
-
-    return true;
+    ConsumerRecord<?, ?> that = (ConsumerRecord<?, ?>) o;
+    return partition == that.partition
+           && offset == that.offset
+           && Objects.equals(topic, that.topic)
+           && Objects.equals(key, that.key)
+           && Objects.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
-    int result = key != null ? key.hashCode() : 0;
-    result = 31 * result + (value != null ? value.hashCode() : 0);
-    result = 31 * result + partition;
-    result = 31 * result + (int) (offset ^ (offset >>> 32));
-    return result;
+    return Objects.hash(topic, key, value, partition, offset);
   }
+
 }

--- a/src/main/java/io/confluent/kafkarest/entities/JsonConsumerRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/JsonConsumerRecord.java
@@ -15,45 +15,18 @@
  **/
 package io.confluent.kafkarest.entities;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JsonConsumerRecord extends ConsumerRecord<Object, Object> {
 
-  public JsonConsumerRecord(@JsonProperty("key") Object key,
-                            @JsonProperty("value") Object value,
-                            @JsonProperty("partition") int partition,
-                            @JsonProperty("offset") long offset) {
-    super(key, value, partition, offset);
-  }
-
+  @JsonCreator
   public JsonConsumerRecord(@JsonProperty("topic") String topic,
-			    @JsonProperty("key") Object key,
+                            @JsonProperty("key") Object key,
                             @JsonProperty("value") Object value,
                             @JsonProperty("partition") int partition,
                             @JsonProperty("offset") long offset) {
     super(topic, key, value, partition, offset);
   }
-    
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
 
-    JsonConsumerRecord that = (JsonConsumerRecord) o;
-
-    if (partition != that.partition) return false;
-    if (offset != that.offset) return false;
-    if (key != null ? !key.equals(that.key) : that.key != null) return false;
-    return !(value != null ? !value.equals(that.value) : that.value != null);
-
-  }
-
-  @Override
-  public int hashCode() {
-    int result = key != null ? key.hashCode() : 0;
-    result = 31 * result + (value != null ? value.hashCode() : 0);
-    result = 31 * result + partition;
-    result = 31 * result + (int) (offset ^ (offset >>> 32));
-    return result;
-  }
 }

--- a/src/test/java/io/confluent/kafkarest/mock/MockConsumerQueue.java
+++ b/src/test/java/io/confluent/kafkarest/mock/MockConsumerQueue.java
@@ -126,7 +126,12 @@ public class MockConsumerQueue implements BlockingQueue<FetchedDataChunk> {
       AtomicLong fetchOffset = new AtomicLong(0);
       PartitionTopicInfo
           pti =
-          new PartitionTopicInfo("topic", c.getPartition(), null, consumedOffset, fetchOffset, null,
+          new PartitionTopicInfo(c.getTopic(),
+                                 c.getPartition(),
+                                 null,
+                                 consumedOffset,
+                                 fetchOffset,
+                                 null,
                                  "clientId");
       return new FetchedDataChunk(msgSet, pti, fetchOffset.get());
     }

--- a/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
@@ -156,9 +156,9 @@ public class ConsumerManagerTest {
     // Tests create instance, read, and delete
     final List<ConsumerRecord<byte[], byte[]>> referenceRecords
         = Arrays.<ConsumerRecord<byte[], byte[]>>asList(
-        new BinaryConsumerRecord("k1".getBytes(), "v1".getBytes(), 0, 0),
-        new BinaryConsumerRecord("k2".getBytes(), "v2".getBytes(), 1, 0),
-        new BinaryConsumerRecord("k3".getBytes(), "v3".getBytes(), 2, 0));
+        new BinaryConsumerRecord(topicName, "k1".getBytes(), "v1".getBytes(), 0, 0),
+        new BinaryConsumerRecord(topicName, "k2".getBytes(), "v2".getBytes(), 1, 0),
+        new BinaryConsumerRecord(topicName, "k3".getBytes(), "v3".getBytes(), 2, 0));
     Map<Integer, List<ConsumerRecord<byte[], byte[]>>>
         referenceSchedule =
         new HashMap<Integer, List<ConsumerRecord<byte[], byte[]>>>();
@@ -233,10 +233,11 @@ public class ConsumerManagerTest {
     // response, not all of it is returned.
     final List<ConsumerRecord<byte[], byte[]>> referenceRecords
         = Arrays.<ConsumerRecord<byte[], byte[]>>asList(
-        new BinaryConsumerRecord(null, new byte[511], 0, 0), // Don't use 512 as this happens to fall on boundary
-        new BinaryConsumerRecord(null, new byte[511], 1, 0),
-        new BinaryConsumerRecord(null, new byte[511], 2, 0),
-        new BinaryConsumerRecord(null, new byte[511], 3, 0)
+        // Don't use 512 as this happens to fall on boundary
+        new BinaryConsumerRecord(topicName, null, new byte[511], 0, 0),
+        new BinaryConsumerRecord(topicName, null, new byte[511], 1, 0),
+        new BinaryConsumerRecord(topicName, null, new byte[511], 2, 0),
+        new BinaryConsumerRecord(topicName, null, new byte[511], 3, 0)
     );
     Map<Integer, List<ConsumerRecord<byte[], byte[]>>> referenceSchedule
         = new HashMap<Integer, List<ConsumerRecord<byte[], byte[]>>>();
@@ -437,10 +438,10 @@ public class ConsumerManagerTest {
     // request that succeeds and still see all the data
     final List<ConsumerRecord<byte[], byte[]>> referenceRecords
         = Arrays.<ConsumerRecord<byte[], byte[]>>asList(
-        new BinaryConsumerRecord("k1".getBytes(), "v1".getBytes(), 0, 0),
+        new BinaryConsumerRecord(topicName, "k1".getBytes(), "v1".getBytes(), 0, 0),
         null, // trigger consumer exception
-        new BinaryConsumerRecord("k2".getBytes(), "v2".getBytes(), 1, 0),
-        new BinaryConsumerRecord("k3".getBytes(), "v3".getBytes(), 2, 0));
+        new BinaryConsumerRecord(topicName, "k2".getBytes(), "v2".getBytes(), 1, 0),
+        new BinaryConsumerRecord(topicName, "k3".getBytes(), "v3".getBytes(), 2, 0));
     Map<Integer, List<ConsumerRecord<byte[], byte[]>>>
         referenceSchedule =
         new HashMap<Integer, List<ConsumerRecord<byte[], byte[]>>>();

--- a/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceAvroTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceAvroTest.java
@@ -53,13 +53,13 @@ public class ConsumerResourceAvroTest extends AbstractConsumerResourceTest {
   public void testReadCommit() {
     List<? extends ConsumerRecord<JsonNode, JsonNode>> expectedReadLimit = Arrays.asList(
         new AvroConsumerRecord(
-            TestUtils.jsonTree("\"key1\""), TestUtils.jsonTree("\"value1\""), 0, 10)
+            topicName, TestUtils.jsonTree("\"key1\""), TestUtils.jsonTree("\"value1\""), 0, 10)
     );
     List<? extends ConsumerRecord<JsonNode, JsonNode>> expectedReadNoLimit = Arrays.asList(
         new AvroConsumerRecord(
-            TestUtils.jsonTree("\"key2\""), TestUtils.jsonTree("\"value2\""), 1, 15),
+            topicName, TestUtils.jsonTree("\"key2\""), TestUtils.jsonTree("\"value2\""), 1, 15),
         new AvroConsumerRecord(
-            TestUtils.jsonTree("\"key3\""), TestUtils.jsonTree("\"value3\""), 2, 20)
+            topicName, TestUtils.jsonTree("\"key3\""), TestUtils.jsonTree("\"value3\""), 2, 20)
     );
     List<TopicPartitionOffset> expectedOffsets = Arrays.asList(
         new TopicPartitionOffset(topicName, 0, 10, 10),

--- a/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceBinaryTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/ConsumerResourceBinaryTest.java
@@ -50,11 +50,11 @@ public class ConsumerResourceBinaryTest extends AbstractConsumerResourceTest {
   @Test
   public void testReadCommit() {
     List<? extends ConsumerRecord<byte[], byte[]>> expectedReadLimit = Arrays.asList(
-        new BinaryConsumerRecord("key1".getBytes(), "value1".getBytes(), 0, 10)
+        new BinaryConsumerRecord(topicName, "key1".getBytes(), "value1".getBytes(), 0, 10)
     );
     List<? extends ConsumerRecord<byte[], byte[]>> expectedReadNoLimit = Arrays.asList(
-        new BinaryConsumerRecord("key2".getBytes(), "value2".getBytes(), 1, 15),
-        new BinaryConsumerRecord("key3".getBytes(), "value3".getBytes(), 2, 20)
+        new BinaryConsumerRecord(topicName, "key2".getBytes(), "value2".getBytes(), 1, 15),
+        new BinaryConsumerRecord(topicName, "key3".getBytes(), "value3".getBytes(), 2, 20)
     );
     List<TopicPartitionOffset> expectedOffsets = Arrays.asList(
         new TopicPartitionOffset(topicName, 0, 10, 10),

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroConsumeTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroConsumeTest.java
@@ -43,7 +43,7 @@ public class PartitionsResourceAvroConsumeTest extends PartitionsResourceAbstrac
   public void testConsumeOk() {
     final List<? extends ConsumerRecord<JsonNode, JsonNode>> records = Arrays.asList(
         new AvroConsumerRecord(
-            TestUtils.jsonTree("\"key1\""), TestUtils.jsonTree("\"value1\""), 0, 10)
+            topicName, TestUtils.jsonTree("\"key1\""), TestUtils.jsonTree("\"value1\""), 0, 10)
     );
 
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES_AVRO) {

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryConsumeTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryConsumeTest.java
@@ -42,7 +42,7 @@ public class PartitionsResourceBinaryConsumeTest extends PartitionsResourceAbstr
   @Test
   public void testConsumeOk() {
     List<? extends ConsumerRecord<byte[], byte[]>> records = Arrays.asList(
-        new BinaryConsumerRecord("key1".getBytes(), "value1".getBytes(), 0, 10)
+        new BinaryConsumerRecord(topicName, "key1".getBytes(), "value1".getBytes(), 0, 10)
     );
 
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES_BINARY) {


### PR DESCRIPTION
AvroConsumerRecord had two constructors with @JsonProperty parameters which caused it to sometimes fail to properly
deserialize. Additionally, adding the topic field to ConsumerRecord for the v2 API resulted in null entries in the v1
API. This is confusing; instead, we should be filling that in since it is a backwards compatible addition and keeps the
output uniform.