### PR TITLE
CLIENTS-305: Use max.block.ms instead of metadata.fetch.timeout.ms since the latter was deprecated and now removed in KAFKA-3763

### DIFF
--- a/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
@@ -15,6 +15,7 @@
  **/
 package io.confluent.kafkarest.integration;
 
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.security.JaasUtils;
 import org.junit.Before;
@@ -130,7 +131,7 @@ public class ProducerTest extends AbstractProducerTest {
     Properties overrides = new Properties();
     // Reduce the metadata fetch timeout so requests for topics that don't exist timeout much
     // faster than the default
-    overrides.setProperty("metadata.fetch.timeout.ms", "5000");
+    overrides.setProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
     return new ProducerPool(appConfig, testZkUtils, overrides);
   }
 


### PR DESCRIPTION
This also uses the field defined in ProducerConfig instead of the string constant so we'll see any future deprecation
warnings.