### PR TITLE
Tiny code simplification

### DIFF
--- a/src/main/java/io/confluent/kafkarest/converters/AvroConverter.java
+++ b/src/main/java/io/confluent/kafkarest/converters/AvroConverter.java
@@ -162,9 +162,8 @@ public class AvroConverter {
       return primitiveSchemas.get("String");
     } else if (value instanceof byte[] || value instanceof ByteBuffer) {
       return primitiveSchemas.get("Bytes");
-    } else if (value instanceof GenericContainer) {
-      return ((GenericContainer) value).getSchema();
     }
+    
     throw new ConversionException("Couldn't determine Schema from object");
   }
 


### PR DESCRIPTION
Duplicate "else if" block because line 135 already checks `instanceof GenericContainer`.

Caught by IntelliJ.