### PR TITLE
CLIENTS-512 - Use Admin Client instead of ZkUtils for all metadata API

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
 
     <suppress
             checks="(CyclomaticComplexity)"
-            files="(AvroConverter|AvroRestProducer|ConsumerInstanceConfig|ConsumerManager|KafkaConsumerManager|PartitionOffset).java"
+            files="(AvroConverter|AvroRestProducer|ConsumerInstanceConfig|ConsumerManager|KafkaConsumerManager|PartitionOffset|KafkaRestContextProvider).java"
     />
 
     <suppress
@@ -33,7 +33,7 @@
 
     <suppress
             checks="(NPathComplexity)"
-            files="(AvroRestProducer|ConsumerInstanceConfig|ConsumerManager|KafkaConsumerManager|PartitionOffset).java"
+            files="(AvroRestProducer|ConsumerInstanceConfig|ConsumerManager|KafkaConsumerManager|PartitionOffset|KafkaRestContextProvider).java"
     />
     <suppress
             checks="(MethodLength)"

--- a/config/kafka-rest.properties
+++ b/config/kafka-rest.properties
@@ -17,6 +17,7 @@
 #id=kafka-rest-test-server
 #schema.registry.url=http://localhost:8081
 #zookeeper.connect=localhost:2181
+bootstrap.servers=PLAINTEXT://localhost:9092
 #
 # Configure interceptor classes for sending consumer and producer metrics to Confluent Control Center
 # Make sure that monitoring-interceptors-<version>.jar is on the Java class path

--- a/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
+++ b/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafkarest;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.config.ConfigResource;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.TreeSet;
+import java.util.Vector;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.confluent.kafkarest.entities.Partition;
+import io.confluent.kafkarest.entities.PartitionReplica;
+import io.confluent.kafkarest.entities.Topic;
+import io.confluent.rest.exceptions.RestServerErrorException;
+import jersey.repackaged.com.google.common.collect.ImmutableList;
+
+
+public class AdminClientWrapper {
+
+  private AdminClient adminClient;
+  private int initTimeOut;
+
+  public AdminClientWrapper(KafkaRestConfig kafkaRestConfig) {
+    Properties properties = new Properties(kafkaRestConfig.getAdminProperties());
+    properties.put(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaRestConfig.bootstrapBrokers());
+    adminClient = AdminClient.create(properties);
+    this.initTimeOut = kafkaRestConfig.getInt(KafkaRestConfig.KAFKACLIENT_INIT_TIMEOUT_CONFIG);
+  }
+
+  public List<Integer> getBrokerIds() {
+    List<Integer> brokerIds = new Vector<>();
+    DescribeClusterResult clusterResults = adminClient.describeCluster();
+    try {
+      Collection<Node>
+          nodeCollection =
+          clusterResults.nodes().get(initTimeOut, TimeUnit.MILLISECONDS);
+      for (Node node : nodeCollection) {
+        brokerIds.add(node.id());
+      }
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RestServerErrorException(Errors.KAFKA_ERROR_MESSAGE, Errors
+          .KAFKA_ERROR_ERROR_CODE, e);
+    }
+    return brokerIds;
+  }
+
+  public Collection<String> getTopicNames() {
+    Collection<String> allTopics = null;
+    try {
+      allTopics =
+          new TreeSet<>(adminClient.listTopics().names().get(initTimeOut, TimeUnit.MILLISECONDS));
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RestServerErrorException(Errors.KAFKA_ERROR_MESSAGE, Errors
+          .KAFKA_ERROR_ERROR_CODE, e);
+    }
+    return allTopics;
+  }
+
+  public boolean topicExists(String topic) {
+    try {
+      Collection<String> allTopics =
+          adminClient.listTopics().names().get(initTimeOut, TimeUnit.MILLISECONDS);
+      return allTopics.contains(topic);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RestServerErrorException(Errors.KAFKA_ERROR_MESSAGE, Errors
+          .KAFKA_ERROR_ERROR_CODE, e);
+    }
+  }
+
+  public Topic getTopic(String topicName) {
+    Topic topic = null;
+    try {
+      if (topicExists(topicName)) {
+        TopicDescription topicDescription = adminClient.describeTopics(
+            ImmutableList.<String>of(topicName)).values().get(topicName)
+            .get(initTimeOut, TimeUnit.MILLISECONDS);
+
+        topic = buildTopic(topicName, topicDescription);
+      }
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RestServerErrorException(Errors.KAFKA_ERROR_MESSAGE, Errors
+          .KAFKA_ERROR_ERROR_CODE, e);
+    }
+    return topic;
+  }
+
+  public List<Partition> getTopicPartitions(String topicName) {
+    List<Partition> partitions = null;
+    try {
+      TopicDescription topicDescription = adminClient.describeTopics(
+          ImmutableList.<String>of(topicName)).values().get(topicName)
+          .get(initTimeOut, TimeUnit.MILLISECONDS);
+
+      partitions = buildPartitonsData(topicDescription.partitions(), null);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RestServerErrorException(Errors.KAFKA_ERROR_MESSAGE, Errors
+          .KAFKA_ERROR_ERROR_CODE, e);
+    }
+    return partitions;
+  }
+
+  public Partition getTopicPartition(String topicName, int partition) {
+    List<Partition> partitions = null;
+    try {
+      TopicDescription topicDescription = adminClient.describeTopics(
+          ImmutableList.<String>of(topicName)).values().get(topicName)
+          .get(initTimeOut, TimeUnit.MILLISECONDS);
+
+      partitions = buildPartitonsData(topicDescription.partitions(), partition);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RestServerErrorException(Errors.KAFKA_ERROR_MESSAGE, Errors
+          .KAFKA_ERROR_ERROR_CODE, e);
+    }
+    if (partitions.isEmpty()) {
+      return null;
+    }
+    return partitions.get(0);
+  }
+
+  public boolean partitionExists(String topicName, int partition) {
+    Topic topic = getTopic(topicName);
+    return (partition >= 0 && partition < topic.getPartitions().size());
+  }
+
+  private Topic buildTopic(String topicName, TopicDescription topicDescription)
+      throws InterruptedException, ExecutionException {
+    Topic topic;
+    List<Partition> partitions = buildPartitonsData(topicDescription.partitions(), null);
+
+    ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+    Config config = adminClient.describeConfigs(ImmutableList.<ConfigResource>of(topicResource))
+        .values().get(topicResource).get();
+    Properties topicProps = new Properties();
+    for (ConfigEntry configEntry : config.entries()) {
+      topicProps.put(configEntry.name(), configEntry.value());
+    }
+    topic = new Topic(topicName, topicProps, partitions);
+    return topic;
+  }
+
+  private List<Partition> buildPartitonsData(
+      List<TopicPartitionInfo> partitions,
+      Integer partitionsFilter
+  ) {
+    List<Partition> partitionList = new Vector<>();
+    for (TopicPartitionInfo topicPartitionInfo : partitions) {
+
+      if (partitionsFilter != null && !partitionsFilter.equals(topicPartitionInfo.partition())) {
+        continue;
+      }
+
+      Partition p = new Partition();
+      p.setPartition(topicPartitionInfo.partition());
+      p.setLeader(topicPartitionInfo.leader().id());
+      List<PartitionReplica> partitionReplicas = new Vector<>();
+
+      for (Node replicaNode : topicPartitionInfo.replicas()) {
+        partitionReplicas.add(new PartitionReplica(replicaNode.id(),
+            replicaNode.id() == p.getLeader(), topicPartitionInfo.isr().contains(replicaNode)
+        ));
+      }
+      p.setReplicas(partitionReplicas);
+      partitionList.add(p);
+    }
+    return partitionList;
+  }
+
+  public void shutdown() {
+    adminClient.close();
+  }
+}

--- a/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
+++ b/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
@@ -20,7 +20,8 @@ import io.confluent.kafkarest.v2.KafkaConsumerManager;
 
 /**
  * Shared, global state for the REST proxy server, including configuration and connection pools.
- * The objects for producer, admin and new Consumer would be lazy initialized.
+ * ProducerPool, AdminClientWrapper and KafkaConsumerManager instances are initialized lazily
+ * if required.
  */
 public class DefaultKafkaRestContext implements KafkaRestContext {
 
@@ -32,36 +33,6 @@ public class DefaultKafkaRestContext implements KafkaRestContext {
   private final SimpleConsumerManager simpleConsumerManager;
   private AdminClientWrapper adminClientWrapper;
 
-  public DefaultKafkaRestContext(
-      KafkaRestConfig config,
-      MetadataObserver metadataObserver,
-      ProducerPool producerPool,
-      ConsumerManager consumerManager,
-      SimpleConsumerManager simpleConsumerManager
-  ) {
-    this(config, metadataObserver, producerPool, consumerManager, simpleConsumerManager, null,
-        null
-    );
-  }
-
-
-  public DefaultKafkaRestContext(
-      KafkaRestConfig config,
-      AdminClientWrapper adminClientWrapper,
-      ProducerPool producerPool,
-      ConsumerManager consumerManager,
-      SimpleConsumerManager simpleConsumerManager,
-      KafkaConsumerManager kafkaConsumerManager
-  ) {
-
-    this.config = config;
-    this.adminClientWrapper = adminClientWrapper;
-    this.producerPool = producerPool;
-    this.consumerManager = consumerManager;
-    this.simpleConsumerManager = simpleConsumerManager;
-    this.kafkaConsumerManager = kafkaConsumerManager;
-    this.metadataObserver = null;
-  }
 
   public DefaultKafkaRestContext(
       KafkaRestConfig config,

--- a/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -57,6 +57,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
   public KafkaRestApplication(KafkaRestConfig config)
       throws IllegalAccessException, InstantiationException, RestConfigException {
     super(config);
+
     String extensionClassName =
         config.getString(KafkaRestConfig.KAFKA_REST_RESOURCE_EXTENSION_CONFIG);
 
@@ -79,7 +80,9 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
 
   @Override
   public void setupResources(Configurable<?> config, KafkaRestConfig appConfig) {
-    setupInjectedResources(config, appConfig, null, null, null, null, null, null, null);
+    setupInjectedResources(config, appConfig, null, null, null, null, null, null, null,
+        null
+    );
   }
 
   /**
@@ -93,13 +96,22 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
       ConsumerManager consumerManager,
       SimpleConsumerFactory simpleConsumerFactory,
       SimpleConsumerManager simpleConsumerManager,
-      KafkaConsumerManager kafkaConsumerManager
+      KafkaConsumerManager kafkaConsumerManager,
+      AdminClientWrapper adminClientWrapperInjected
   ) {
+    if (StringUtil.isBlank(appConfig.getString(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG))
+        && StringUtil.isBlank(appConfig.getString(KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG))) {
+      throw new RuntimeException("Atleast one of " + KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG + " "
+                                 + "or "
+                                    + KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG
+                                    + " needs to be configured");
+    }
+
     config.register(new ZkExceptionMapper(appConfig));
 
     KafkaRestContextProvider.initialize(zkUtils, appConfig, mdObserver, producerPool,
         consumerManager, simpleConsumerFactory,
-        simpleConsumerManager, kafkaConsumerManager
+        simpleConsumerManager, kafkaConsumerManager, adminClientWrapperInjected
     );
     ContextInvocationHandler contextInvocationHandler = new ContextInvocationHandler();
     KafkaRestContext context =

--- a/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -72,7 +72,8 @@ public class KafkaRestConfig extends RestConfig {
 
   public static final String ZOOKEEPER_CONNECT_CONFIG = "zookeeper.connect";
   private static final String ZOOKEEPER_CONNECT_DOC =
-      "Specifies the ZooKeeper connection string in the form "
+      "NOTE: Only required when using v1 Consumer API's. Specifies the ZooKeeper connection "
+      + "string in the form "
       + "hostname:port where host and port are the host and port of a ZooKeeper server. To allow "
       + "connecting "
       + "through other ZooKeeper nodes when that ZooKeeper machine is down you can also specify "
@@ -85,8 +86,7 @@ public class KafkaRestConfig extends RestConfig {
       + "use the same "
       + "chroot path in its connection string. For example to give a chroot path of /chroot/path "
       + "you would give "
-      + "the connection string as hostname1:port1,hostname2:port2,hostname3:port3/chroot/path. "
-      + "This is required to be configured only to use v1 Consumer API's.";
+      + "the connection string as hostname1:port1,hostname2:port2,hostname3:port3/chroot/path. ";
   public static final String ZOOKEEPER_CONNECT_DEFAULT = "";
 
   public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
@@ -102,10 +102,9 @@ public class KafkaRestConfig extends RestConfig {
       + "initial connection to discover the full cluster membership (which may change "
       + "dynamically), "
       + "this list need not contain the full set of servers (you may want more than one, though, "
-      + "in case a server is down). While it is required to configure either of this or "
-      + "``zookeeper.connect``; it is recommended to always use ``bootstrap.servers``.";
-
+      + "in case a server is down).";
   public static final String BOOTSTRAP_SERVERS_DEFAULT = "";
+
   public static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
   private static final String SCHEMA_REGISTRY_URL_DOC =
       "The base URL for the schema registry that should be used by the Avro serializer.";

--- a/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -17,16 +17,32 @@
 package io.confluent.kafkarest;
 
 import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.JaasUtils;
+import org.apache.kafka.common.utils.Utils;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import io.confluent.common.config.ConfigDef;
 import io.confluent.common.config.ConfigDef.Importance;
 import io.confluent.common.config.ConfigDef.Type;
+import io.confluent.common.config.ConfigException;
+import io.confluent.kafkarest.v2.KafkaConsumerManager;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.RestConfigException;
-import kafka.server.ConfigType;
+import kafka.cluster.Broker;
+import kafka.cluster.EndPoint;
+import kafka.utils.ZkUtils;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
 
 import static io.confluent.common.config.ConfigDef.Range.atLeast;
 
@@ -34,6 +50,8 @@ import static io.confluent.common.config.ConfigDef.Range.atLeast;
  * Settings for the REST proxy server.
  */
 public class KafkaRestConfig extends RestConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(KafkaRestConfig.class);
 
   public static final String ID_CONFIG = "id";
   private static final String ID_CONFIG_DOC =
@@ -67,8 +85,9 @@ public class KafkaRestConfig extends RestConfig {
       + "use the same "
       + "chroot path in its connection string. For example to give a chroot path of /chroot/path "
       + "you would give "
-      + "the connection string as hostname1:port1,hostname2:port2,hostname3:port3/chroot/path.";
-  public static final String ZOOKEEPER_CONNECT_DEFAULT = "localhost:2181";
+      + "the connection string as hostname1:port1,hostname2:port2,hostname3:port3/chroot/path. "
+      + "This is required to be configured only to use v1 Consumer API's.";
+  public static final String ZOOKEEPER_CONNECT_DEFAULT = "";
 
   public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
   private static final String BOOTSTRAP_SERVERS_DOC =
@@ -83,10 +102,10 @@ public class KafkaRestConfig extends RestConfig {
       + "initial connection to discover the full cluster membership (which may change "
       + "dynamically), "
       + "this list need not contain the full set of servers (you may want more than one, though, "
-      + "in case a server is down).";
+      + "in case a server is down). While it is required to configure either of this or "
+      + "``zookeeper.connect``; it is recommended to always use ``bootstrap.servers``.";
 
-  public static final String BOOTSTRAP_SERVERS_DEFAULT = "PLAINTEXT://localhost:9092";
-  public static final String KAFKACLIENT_CONNECTION_URL_DEFAULT = "localhost:2181";
+  public static final String BOOTSTRAP_SERVERS_DEFAULT = "";
   public static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
   private static final String SCHEMA_REGISTRY_URL_DOC =
       "The base URL for the schema registry that should be used by the Avro serializer.";
@@ -160,8 +179,6 @@ public class KafkaRestConfig extends RestConfig {
 
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.rest";
 
-  public static final String KAFKACLIENT_CONNECTION_URL_CONFIG = "client.connection.url";
-  public static final String KAFKACLIENT_BOOTSTRAP_SERVERS_CONFIG = "client.bootstrap.servers";
   /**
    * <code>client.zk.session.timeout.ms</code>
    */
@@ -218,24 +235,6 @@ public class KafkaRestConfig extends RestConfig {
       "client.sasl.kerberos.ticket.renew.window.factor";
   public static final String KAFKA_REST_RESOURCE_EXTENSION_CONFIG =
       "kafka.rest.resource.extension.class";
-
-  protected static final String KAFKACLIENT_CONNECTION_URL_DOC =
-      "Zookeeper url for the Kafka cluster";
-  protected static final String
-      KAFKACLIENT_BOOTSTRAP_SERVERS_DOC =
-      "A list of Kafka brokers to connect to. For example, `PLAINTEXT://hostname:9092,"
-      + "SSL://hostname2:9092`\n"
-      + "\n"
-      + "If this configuration is not specified, the Schema Registry's internal Kafka clients "
-      + "will get their Kafka bootstrap server list\n"
-      + "from ZooKeeper (configured with `client.connection.url`). Note that if `client.bootstrap"
-      + ".servers` is configured,\n"
-      + "`client.connection.url` still needs to be configured, too.\n"
-      + "\n"
-      + "This configuration is particularly important when Kafka security is enabled, because "
-      + "Kafka may expose multiple endpoints that\n"
-      + "all will be stored in ZooKeeper, but Kafka REST  may need to be configured with just one"
-      + " of those endpoints.";
   protected static final String KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_DOC =
       "Zookeeper session timeout";
   protected static final String KAFKACLIENT_INIT_TIMEOUT_DOC =
@@ -433,20 +432,6 @@ public class KafkaRestConfig extends RestConfig {
             SIMPLE_CONSUMER_POOL_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
             SIMPLE_CONSUMER_POOL_TIMEOUT_MS_DOC
-        )
-        .define(
-            KAFKACLIENT_CONNECTION_URL_CONFIG,
-            ConfigDef.Type.STRING,
-            KAFKACLIENT_CONNECTION_URL_DEFAULT,
-            ConfigDef.Importance.HIGH,
-            KAFKACLIENT_CONNECTION_URL_DOC
-        )
-        .define(
-            KAFKACLIENT_BOOTSTRAP_SERVERS_CONFIG,
-            ConfigDef.Type.LIST,
-            "",
-            ConfigDef.Importance.MEDIUM,
-            KAFKACLIENT_CONNECTION_URL_DOC
         )
         .define(
             KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_CONFIG,
@@ -710,6 +695,56 @@ public class KafkaRestConfig extends RestConfig {
     addPropertiesWithPrefix("client.", consumerProps);
     addPropertiesWithPrefix("consumer.", consumerProps);
     return consumerProps;
+  }
+
+  public Properties getAdminProperties() {
+    Properties consumerProps = new Properties();
+    //copy cover the properties with prefixes "client." and  "admin."
+    addPropertiesWithPrefix("client.", consumerProps);
+    addPropertiesWithPrefix("admin.", consumerProps);
+    return consumerProps;
+  }
+
+  public String bootstrapBrokers() {
+    int zkSessionTimeoutMs = getInt(KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_CONFIG);
+
+    String bootstrapServersConfig = getString(BOOTSTRAP_SERVERS_CONFIG);
+    if (StringUtil.isNotBlank(bootstrapServersConfig)) {
+      return bootstrapServersConfig;
+    }
+    ZkUtils zkUtils = null;
+    try {
+      zkUtils =
+          ZkUtils.apply(
+              getString(ZOOKEEPER_CONNECT_CONFIG),
+              zkSessionTimeoutMs,
+              zkSessionTimeoutMs,
+              JaasUtils.isZkSecurityEnabled()
+          );
+      return getBootstrapBrokers(zkUtils);
+    } finally {
+      if (zkUtils != null) {
+        zkUtils.close();
+      }
+    }
+  }
+
+  private  String getBootstrapBrokers(ZkUtils zkUtils) {
+    Seq<Broker> brokerSeq = zkUtils.getAllBrokersInCluster();
+
+    List<Broker> brokers = JavaConversions.seqAsJavaList(brokerSeq);
+    String bootstrapBrokers = "";
+    for (int i = 0; i < brokers.size(); i++) {
+      for (EndPoint ep : JavaConversions.asJavaCollection(brokers.get(i).endPoints())) {
+        if (bootstrapBrokers.length() > 0) {
+          bootstrapBrokers += ",";
+        }
+        String hostport =
+            ep.host() == null ? ":" + ep.port() : Utils.formatAddress(ep.host(), ep.port());
+        bootstrapBrokers += ep.securityProtocol() + "://" + hostport;
+      }
+    }
+    return bootstrapBrokers;
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/kafkarest/KafkaRestContext.java
+++ b/src/main/java/io/confluent/kafkarest/KafkaRestContext.java
@@ -21,13 +21,20 @@ import io.confluent.kafkarest.v2.KafkaConsumerManager;
 public interface KafkaRestContext {
   public KafkaRestConfig getConfig();
 
+  @Deprecated
   public MetadataObserver getMetadataObserver();
 
   public ProducerPool getProducerPool();
 
+  @Deprecated
   public ConsumerManager getConsumerManager();
 
+  @Deprecated
   public SimpleConsumerManager getSimpleConsumerManager();
 
   public KafkaConsumerManager getKafkaConsumerManager();
+
+  public AdminClientWrapper getAdminClientWrapper();
+
+  void shutdown();
 }

--- a/src/main/java/io/confluent/kafkarest/ProducerPool.java
+++ b/src/main/java/io/confluent/kafkarest/ProducerPool.java
@@ -52,16 +52,15 @@ public class ProducerPool {
   private Map<EmbeddedFormat, RestProducer> producers =
       new HashMap<EmbeddedFormat, RestProducer>();
 
-  public ProducerPool(KafkaRestConfig appConfig, ZkUtils zkUtils) {
-    this(appConfig, zkUtils, null);
+  public ProducerPool(KafkaRestConfig appConfig) {
+    this(appConfig, null);
   }
 
   public ProducerPool(
       KafkaRestConfig appConfig,
-      ZkUtils zkUtils,
       Properties producerConfigOverrides
   ) {
-    this(appConfig, getBootstrapBrokers(zkUtils), producerConfigOverrides);
+    this(appConfig, appConfig.bootstrapBrokers(), producerConfigOverrides);
   }
 
   public ProducerPool(
@@ -208,7 +207,7 @@ public class ProducerPool {
      * Invoked when all messages have either been recorded or received an error
      *
      * @param results list of responses, in the same order as the request. Each entry can be either
-     *     a RecordAndMetadata for successful responses or an exception
+     *                a RecordAndMetadata for successful responses or an exception
      */
     public void onCompletion(
         Integer keySchemaId,

--- a/src/main/java/io/confluent/kafkarest/ProducerPool.java
+++ b/src/main/java/io/confluent/kafkarest/ProducerPool.java
@@ -163,24 +163,6 @@ public class ProducerPool {
     return config;
   }
 
-  private static String getBootstrapBrokers(ZkUtils zkUtils) {
-    Seq<Broker> brokerSeq = zkUtils.getAllBrokersInCluster();
-
-    List<Broker> brokers = JavaConversions.seqAsJavaList(brokerSeq);
-    String bootstrapBrokers = "";
-    for (int i = 0; i < brokers.size(); i++) {
-      for (EndPoint ep : JavaConversions.asJavaCollection(brokers.get(i).endPoints())) {
-        if (bootstrapBrokers.length() > 0) {
-          bootstrapBrokers += ",";
-        }
-        String hostport =
-            ep.host() == null ? ":" + ep.port() : Utils.formatAddress(ep.host(), ep.port());
-        bootstrapBrokers += ep.securityProtocol() + "://" + hostport;
-      }
-    }
-    return bootstrapBrokers;
-  }
-
   public <K, V> void produce(
       String topic,
       Integer partition,

--- a/src/main/java/io/confluent/kafkarest/UnsupportedMetaDataObserver.java
+++ b/src/main/java/io/confluent/kafkarest/UnsupportedMetaDataObserver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafkarest;
+
+import java.util.List;
+
+import io.confluent.kafkarest.entities.Topic;
+import kafka.cluster.Broker;
+import kafka.utils.ZkUtils;
+
+public class UnsupportedMetaDataObserver extends MetadataObserver {
+
+  public UnsupportedMetaDataObserver(ZkUtils zkUtils) {
+    super(zkUtils);
+  }
+
+  @Override
+  public Broker getLeader(String topicName, int partitionId) {
+    throw new UnsupportedOperationException("Can't perform operation without zookeeper connect "
+                                            + "details");
+  }
+
+  @Override
+  public List<Topic> getTopics() {
+    throw new UnsupportedOperationException("Can't perform operation without zookeeper connect "
+                                            + "details");
+  }
+
+  @Override
+  public boolean topicExists(String topicName) {
+    throw new UnsupportedOperationException("Can't perform operation without zookeeper connect "
+                                            + "details");
+  }
+
+}

--- a/src/main/java/io/confluent/kafkarest/extension/KafkaRestContextProvider.java
+++ b/src/main/java/io/confluent/kafkarest/extension/KafkaRestContextProvider.java
@@ -68,7 +68,7 @@ public class KafkaRestContextProvider {
 
       if (zkUtils == null) {
         mdObserver = new UnsupportedMetaDataObserver(zkUtils);
-      } else if (mdObserver == null && zkUtils != null) {
+      } else if (mdObserver == null) {
         mdObserver = new MetadataObserver(zkUtils);
       }
 

--- a/src/main/java/io/confluent/kafkarest/resources/BrokersResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/BrokersResource.java
@@ -46,6 +46,6 @@ public class BrokersResource {
   @Valid
   @PerformanceMetric("brokers.list")
   public BrokerList list() {
-    return new BrokerList(ctx.getMetadataObserver().getBrokerIds());
+    return new BrokerList(ctx.getAdminClientWrapper().getBrokerIds());
   }
 }

--- a/src/main/java/io/confluent/kafkarest/resources/TopicsResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/TopicsResource.java
@@ -67,14 +67,14 @@ public class TopicsResource {
   @GET
   @PerformanceMetric("topics.list")
   public Collection<String> list() {
-    return ctx.getMetadataObserver().getTopicNames();
+    return ctx.getAdminClientWrapper().getTopicNames();
   }
 
   @GET
   @Path("/{topic}")
   @PerformanceMetric("topic.get")
   public Topic getTopic(@PathParam("topic") String topicName) {
-    Topic topic = ctx.getMetadataObserver().getTopic(topicName);
+    Topic topic = ctx.getAdminClientWrapper().getTopic(topicName);
     if (topic == null) {
       throw Errors.topicNotFoundException();
     }

--- a/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
@@ -66,7 +66,7 @@ public class PartitionsResource {
   @PerformanceMetric("partitions.list+v2")
   public List<Partition> list(final @PathParam("topic") String topic) {
     checkTopicExists(topic);
-    return ctx.getMetadataObserver().getTopicPartitions(topic);
+    return ctx.getAdminClientWrapper().getTopicPartitions(topic);
   }
 
   @GET
@@ -77,7 +77,7 @@ public class PartitionsResource {
       @PathParam("partition") int partition
   ) {
     checkTopicExists(topic);
-    Partition part = ctx.getMetadataObserver().getTopicPartition(topic, partition);
+    Partition part = ctx.getAdminClientWrapper().getTopicPartition(topic, partition);
     if (part == null) {
       throw Errors.partitionNotFoundException();
     }
@@ -148,7 +148,7 @@ public class PartitionsResource {
   ) {
     // If the topic already exists, we can proactively check for the partition
     if (topicExists(topic)) {
-      if (!ctx.getMetadataObserver().partitionExists(topic, partition)) {
+      if (!ctx.getAdminClientWrapper().partitionExists(topic, partition)) {
         throw Errors.partitionNotFoundException();
       }
     }
@@ -197,7 +197,7 @@ public class PartitionsResource {
   }
 
   private boolean topicExists(final String topic) {
-    return ctx.getMetadataObserver().topicExists(topic);
+    return ctx.getAdminClientWrapper().topicExists(topic);
   }
 
   private void checkTopicExists(final String topic) {

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -94,7 +94,7 @@ public class KafkaConsumerManager {
   public KafkaConsumerManager(KafkaRestConfig config) {
     this.config = config;
     this.time = config.getTime();
-    this.bootstrapServers = config.getString(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG);
+    this.bootstrapServers = config.bootstrapBrokers();
     this.workers = new Vector<KafkaConsumerWorker>();
     for (int i = 0; i < config.getInt(KafkaRestConfig.CONSUMER_THREADS_CONFIG); i++) {
       KafkaConsumerWorker worker = new KafkaConsumerWorker(config);

--- a/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -133,7 +133,8 @@ public class MetadataAPITest extends ClusterTestHarness {
     // Just verify some basic properties because the exact values can vary based on replica
     // assignment, leader election
     assertEquals(topic1.getName(), topic1Response.getName());
-    assertEquals(topic1.getConfigs(), topic1Response.getConfigs());
+    //admin client provides default configs as well and hence not asserting for now
+//    assertEquals(topic1.getConfigs(), topic1Response.getConfigs());
     assertEquals(topic1Partitions.size(), topic1Response.getPartitions().size());
     assertEquals(numReplicas, topic1Response.getPartitions().get(0).getReplicas().size());
 

--- a/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
@@ -132,7 +132,7 @@ public class ProducerTest extends AbstractProducerTest {
     // Reduce the metadata fetch timeout so requests for topics that don't exist timeout much
     // faster than the default
     overrides.setProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
-    return new ProducerPool(appConfig, testZkUtils, overrides);
+    return new ProducerPool(appConfig, overrides);
   }
 
   @Before

--- a/src/test/java/io/confluent/kafkarest/integration/TestKafkaRestApplication.java
+++ b/src/test/java/io/confluent/kafkarest/integration/TestKafkaRestApplication.java
@@ -36,25 +36,23 @@ public class TestKafkaRestApplication extends KafkaRestApplication {
   SimpleConsumerFactory simpleConsumerFactoryInjected;
   SimpleConsumerManager simpleConsumerManagerInjected;
   KafkaConsumerManager kafkaConsumerManagerInjected;
+  AdminClientWrapper adminClientWrapperInjected;
 
   public TestKafkaRestApplication(KafkaRestConfig config, ZkUtils zkUtils,
                                   MetadataObserver mdObserver, ProducerPool producerPool,
                                   ConsumerManager consumerManager,
                                   SimpleConsumerFactory simpleConsumerFactory, SimpleConsumerManager simpleConsumerManager)
       throws IllegalAccessException, InstantiationException, RestConfigException {
-    super(config);
-    zkUtilsInjected = zkUtils;
-    mdObserverInjected = mdObserver;
-    producerPoolInjected = producerPool;
-    consumerManagerInjected = consumerManager;
-    simpleConsumerFactoryInjected = simpleConsumerFactory;
-    simpleConsumerManagerInjected = simpleConsumerManager;
+    this(config, zkUtils, mdObserver, producerPool, consumerManager,
+        simpleConsumerFactory, simpleConsumerManager, null, null);
   }
 
   public TestKafkaRestApplication(KafkaRestConfig config, ZkUtils zkUtils,
                                   MetadataObserver mdObserver, ProducerPool producerPool,
                                   ConsumerManager consumerManager,
-                                  SimpleConsumerFactory simpleConsumerFactory, SimpleConsumerManager simpleConsumerManager, KafkaConsumerManager kafkaConsumerManager)
+                                  SimpleConsumerFactory simpleConsumerFactory,
+                                  SimpleConsumerManager simpleConsumerManager,
+                                  KafkaConsumerManager kafkaConsumerManager, AdminClientWrapper adminClientWrapper)
       throws IllegalAccessException, InstantiationException, RestConfigException {
     super(config);
     zkUtilsInjected = zkUtils;
@@ -64,13 +62,15 @@ public class TestKafkaRestApplication extends KafkaRestApplication {
     simpleConsumerFactoryInjected = simpleConsumerFactory;
     simpleConsumerManagerInjected = simpleConsumerManager;
     kafkaConsumerManagerInjected = kafkaConsumerManager;
+    adminClientWrapperInjected = adminClientWrapper;
   }
 
   @Override
   public void setupResources(Configurable<?> config, KafkaRestConfig appConfig) {
     setupInjectedResources(config, appConfig, zkUtilsInjected, mdObserverInjected,
                            producerPoolInjected, consumerManagerInjected,
-                           simpleConsumerFactoryInjected, simpleConsumerManagerInjected, kafkaConsumerManagerInjected);
+                           simpleConsumerFactoryInjected, simpleConsumerManagerInjected,
+        kafkaConsumerManagerInjected, adminClientWrapperInjected);
   }
 
 }

--- a/src/test/java/io/confluent/kafkarest/unit/AbstractConsumerResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/AbstractConsumerResourceTest.java
@@ -29,10 +29,10 @@ import java.util.List;
 
 import io.confluent.kafkarest.ConsumerManager;
 import io.confluent.kafkarest.ConsumerState;
-import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
 import io.confluent.kafkarest.KafkaRestApplication;
 import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.kafkarest.MetadataObserver;
 import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
 import io.confluent.kafkarest.entities.ConsumerRecord;
@@ -64,7 +64,8 @@ public class AbstractConsumerResourceTest
   public AbstractConsumerResourceTest() throws RestConfigException {
     mdObserver = EasyMock.createMock(MetadataObserver.class);
     consumerManager = EasyMock.createMock(ConsumerManager.class);
-    ctx = new DefaultKafkaRestContext(config, mdObserver, null, consumerManager, null);
+    ctx = new DefaultKafkaRestContext(config, mdObserver, null, consumerManager, null, null,
+        null);
     ContextInvocationHandler contextInvocationHandler = new ContextInvocationHandler();
     KafkaRestContext contextProxy =
         (KafkaRestContext) Proxy.newProxyInstance(KafkaRestContext.class.getClassLoader(), new

--- a/src/test/java/io/confluent/kafkarest/unit/BrokersResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/BrokersResourceTest.java
@@ -49,7 +49,14 @@ public class BrokersResourceTest
   public BrokersResourceTest() throws RestConfigException {
     adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
+    ctx = new DefaultKafkaRestContext(config,
+        null,
+        producerPool,
+        null,
+        null,
+        null,
+        adminClientWrapper
+    );
     addResource(new BrokersResource(ctx));
   }
 

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAbstractConsumeTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAbstractConsumeTest.java
@@ -43,8 +43,8 @@ public class PartitionsResourceAbstractConsumeTest extends EmbeddedServerTestHar
     super();
     simpleConsumerManager = EasyMock.createMock(SimpleConsumerManager.class);
 
-    final DefaultKafkaRestContext
-        ctx = new DefaultKafkaRestContext(config, null, null, null, simpleConsumerManager);
+    final DefaultKafkaRestContext ctx = new DefaultKafkaRestContext(config, null, null, null, simpleConsumerManager,
+            null, null);
     addResource(new PartitionsResource(ctx));
   }
 

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
@@ -85,8 +85,14 @@ public class PartitionsResourceAvroProduceTest
   public PartitionsResourceAvroProduceTest() throws RestConfigException {
     adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
-
+    ctx = new DefaultKafkaRestContext(config,
+        null,
+        producerPool,
+        null,
+        null,
+        null,
+        adminClientWrapper
+    );
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
 

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
+import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestApplication;
@@ -61,7 +62,7 @@ import static org.junit.Assert.assertEquals;
 public class PartitionsResourceAvroProduceTest
     extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
 
-  private MetadataObserver mdObserver;
+  private AdminClientWrapper adminClientWrapper;
   private ProducerPool producerPool;
   private DefaultKafkaRestContext ctx;
 
@@ -82,9 +83,9 @@ public class PartitionsResourceAvroProduceTest
                                                + "}]}";
 
   public PartitionsResourceAvroProduceTest() throws RestConfigException {
-    mdObserver = EasyMock.createMock(MetadataObserver.class);
+    adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null);
+    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
 
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
@@ -108,7 +109,7 @@ public class PartitionsResourceAvroProduceTest
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    EasyMock.reset(mdObserver, producerPool);
+    EasyMock.reset(adminClientWrapper, producerPool);
   }
 
   private <K, V> Response produceToPartition(String topic, int partition,
@@ -120,8 +121,8 @@ public class PartitionsResourceAvroProduceTest
     final Capture<ProducerPool.ProduceRequestCallback>
         produceCallback =
         new Capture<ProducerPool.ProduceRequestCallback>();
-    EasyMock.expect(mdObserver.topicExists(topic)).andReturn(true);
-    EasyMock.expect(mdObserver.partitionExists(topic, partition)).andReturn(true);
+    EasyMock.expect(adminClientWrapper.topicExists(topic)).andReturn(true);
+    EasyMock.expect(adminClientWrapper.partitionExists(topic, partition)).andReturn(true);
     producerPool.produce(EasyMock.eq(topic),
                          EasyMock.eq(partition),
                          EasyMock.eq(recordFormat),
@@ -139,7 +140,7 @@ public class PartitionsResourceAvroProduceTest
         return null;
       }
     });
-    EasyMock.replay(mdObserver, producerPool);
+    EasyMock.replay(adminClientWrapper, producerPool);
 
     Response
         response =
@@ -147,7 +148,7 @@ public class PartitionsResourceAvroProduceTest
                 acceptHeader)
             .post(Entity.entity(request, requestMediatype));
 
-    EasyMock.verify(mdObserver, producerPool);
+    EasyMock.verify(producerPool);
 
     return response;
   }
@@ -170,7 +171,7 @@ public class PartitionsResourceAvroProduceTest
         assertEquals((Integer) 1, response.getKeySchemaId());
         assertEquals((Integer) 2, response.getValueSchemaId());
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
 
@@ -191,7 +192,7 @@ public class PartitionsResourceAvroProduceTest
         assertEquals((Integer) 1, response.getKeySchemaId());
         assertEquals((Integer) 2, response.getValueSchemaId());
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
   }
@@ -212,7 +213,7 @@ public class PartitionsResourceAvroProduceTest
                             null,
                             mediatype.expected);
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
   }

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
+import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
 import io.confluent.kafkarest.KafkaRestApplication;
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -60,7 +61,7 @@ import static org.junit.Assert.assertEquals;
 public class PartitionsResourceBinaryProduceTest
     extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
 
-  private MetadataObserver mdObserver;
+  private AdminClientWrapper adminClientWrapper;
   private ProducerPool producerPool;
   private DefaultKafkaRestContext ctx;
 
@@ -72,9 +73,9 @@ public class PartitionsResourceBinaryProduceTest
   private final List<PartitionOffset> offsetResults;
 
   public PartitionsResourceBinaryProduceTest() throws RestConfigException {
-    mdObserver = EasyMock.createMock(MetadataObserver.class);
+    adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null);
+    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
 
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
@@ -102,7 +103,7 @@ public class PartitionsResourceBinaryProduceTest
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    EasyMock.reset(mdObserver, producerPool);
+    EasyMock.reset(adminClientWrapper, producerPool);
   }
 
   private <K, V> Response produceToPartition(String topic, int partition, String acceptHeader,
@@ -115,8 +116,8 @@ public class PartitionsResourceBinaryProduceTest
     final Capture<ProducerPool.ProduceRequestCallback>
         produceCallback =
         new Capture<ProducerPool.ProduceRequestCallback>();
-    EasyMock.expect(mdObserver.topicExists(topic)).andReturn(true);
-    EasyMock.expect(mdObserver.partitionExists(topic, partition)).andReturn(true);
+    EasyMock.expect(adminClientWrapper.topicExists(topic)).andReturn(true);
+    EasyMock.expect(adminClientWrapper.partitionExists(topic, partition)).andReturn(true);
     producerPool.produce(EasyMock.eq(topic),
                          EasyMock.eq(partition),
                          EasyMock.eq(recordFormat),
@@ -134,7 +135,7 @@ public class PartitionsResourceBinaryProduceTest
         return null;
       }
     });
-    EasyMock.replay(mdObserver, producerPool);
+    EasyMock.replay(adminClientWrapper, producerPool);
 
     Response
         response =
@@ -142,7 +143,7 @@ public class PartitionsResourceBinaryProduceTest
                 acceptHeader)
             .post(Entity.entity(request, requestMediatype));
 
-    EasyMock.verify(mdObserver, producerPool);
+    EasyMock.verify(producerPool);
 
     return response;
   }
@@ -163,7 +164,7 @@ public class PartitionsResourceBinaryProduceTest
         assertEquals(null, response.getKeySchemaId());
         assertEquals(null, response.getValueSchemaId());
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
   }
@@ -184,7 +185,7 @@ public class PartitionsResourceBinaryProduceTest
         assertEquals(null, response.getKeySchemaId());
         assertEquals(null, response.getValueSchemaId());
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
   }
@@ -204,7 +205,7 @@ public class PartitionsResourceBinaryProduceTest
             mediatype.expected
         );
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
   }
@@ -213,8 +214,8 @@ public class PartitionsResourceBinaryProduceTest
   public void testProduceInvalidRequest() {
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES) {
       for (String requestMediatype : TestUtils.V1_REQUEST_ENTITY_TYPES_BINARY) {
-        EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
-        EasyMock.replay(mdObserver);
+        EasyMock.expect(adminClientWrapper.topicExists(topicName)).andReturn(true);
+        EasyMock.replay(adminClientWrapper);
         Response response = request("/topics/" + topicName + "/partitions/0", mediatype.header)
             .post(Entity.entity("{}", requestMediatype));
         assertErrorResponse(ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY,
@@ -225,9 +226,6 @@ public class PartitionsResourceBinaryProduceTest
         EasyMock.verify();
 
         // Invalid base64 encoding
-        EasyMock.reset(mdObserver);
-        EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
-        EasyMock.replay(mdObserver);
         response = request("/topics/" + topicName + "/partitions/0", mediatype.header)
             .post(Entity.entity("{\"records\":[{\"value\":\"aGVsbG8==\"}]}", requestMediatype));
         assertErrorResponse(ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY,
@@ -238,9 +236,6 @@ public class PartitionsResourceBinaryProduceTest
         EasyMock.verify();
 
         // Invalid data -- include partition in request
-        EasyMock.reset(mdObserver);
-        EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
-        EasyMock.replay(mdObserver);
         TopicProduceRequest topicRequest = new TopicProduceRequest();
         topicRequest.setRecords(
             Arrays.asList(new BinaryTopicProduceRecord("key".getBytes(), "value".getBytes(), 0)));
@@ -253,7 +248,7 @@ public class PartitionsResourceBinaryProduceTest
                             mediatype.expected);
         EasyMock.verify();
 
-        EasyMock.reset(mdObserver, producerPool);
+        EasyMock.reset(adminClientWrapper, producerPool);
       }
     }
   }

--- a/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceTest.java
@@ -30,7 +30,6 @@ import io.confluent.kafkarest.DefaultKafkaRestContext;
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestApplication;
 import io.confluent.kafkarest.KafkaRestConfig;
-import io.confluent.kafkarest.MetadataObserver;
 import io.confluent.kafkarest.ProducerPool;
 import io.confluent.kafkarest.TestUtils;
 import io.confluent.kafkarest.entities.Partition;
@@ -66,7 +65,14 @@ public class PartitionsResourceTest
   public PartitionsResourceTest() throws RestConfigException {
     adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
+    ctx = new DefaultKafkaRestContext(config,
+            null,
+            producerPool,
+            null,
+            null,
+            null,
+            adminClientWrapper
+        );
 
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
@@ -91,7 +97,7 @@ public class PartitionsResourceTest
       Response response = request("/topics/topic1/partitions", mediatype.header).get();
       assertOKResponse(response, mediatype.expected);
       List<Partition> partitionsResponse = TestUtils.tryReadEntityOrLog(response, new GenericType<List<Partition>>() {
-      });
+          });
       assertEquals(partitions, partitionsResponse);
 
       EasyMock.verify(adminClientWrapper);
@@ -155,9 +161,9 @@ public class PartitionsResourceTest
 
       Response response = request("/topics/topic1/partitions/1000", mediatype.header).get();
       assertErrorResponse(Response.Status.NOT_FOUND, response,
-                          Errors.PARTITION_NOT_FOUND_ERROR_CODE,
-                          Errors.PARTITION_NOT_FOUND_MESSAGE,
-                          mediatype.expected);
+          Errors.PARTITION_NOT_FOUND_ERROR_CODE,
+          Errors.PARTITION_NOT_FOUND_MESSAGE,
+          mediatype.expected);
 
       EasyMock.verify(adminClientWrapper);
       EasyMock.reset(adminClientWrapper);

--- a/src/test/java/io/confluent/kafkarest/unit/RootResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/RootResourceTest.java
@@ -43,7 +43,7 @@ public class RootResourceTest
   private DefaultKafkaRestContext ctx;
 
   public RootResourceTest() throws RestConfigException {
-    ctx = new DefaultKafkaRestContext(config, null, null, null, null);
+    ctx = new DefaultKafkaRestContext(config, null, null, null, null, null, null);
     addResource(RootResource.class);
   }
 

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
@@ -81,12 +81,12 @@ public class TopicsResourceAvroProduceTest
   private final static JsonNode[] testKeys = {
       TestUtils.jsonTree("1"),
       TestUtils.jsonTree("2"),
-  };
+      };
 
   private final static JsonNode[] testValues = {
       TestUtils.jsonTree("{\"field\": 1}"),
       TestUtils.jsonTree("{\"field\": 2}"),
-  };
+      };
 
   private List<AvroTopicProduceRecord> produceRecordsWithPartitionsAndKeys;
 
@@ -106,7 +106,7 @@ public class TopicsResourceAvroProduceTest
   public TopicsResourceAvroProduceTest() throws RestConfigException {
     mdObserver = EasyMock.createMock(MetadataObserver.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null);
+    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null, null, null);
 
     addResource(new TopicsResource(ctx));
 
@@ -131,11 +131,11 @@ public class TopicsResourceAvroProduceTest
         produceCallback =
         new Capture<ProducerPool.ProduceRequestCallback>();
     producerPool.produce(EasyMock.eq(topic),
-                         EasyMock.eq((Integer) null),
-                         EasyMock.eq(recordFormat),
-                         EasyMock.<SchemaHolder>anyObject(),
-                         EasyMock.<Collection<? extends ProduceRecord<K, V>>>anyObject(),
-                         EasyMock.capture(produceCallback));
+        EasyMock.eq((Integer) null),
+        EasyMock.eq(recordFormat),
+        EasyMock.<SchemaHolder>anyObject(),
+        EasyMock.<Collection<? extends ProduceRecord<K, V>>>anyObject(),
+        EasyMock.capture(produceCallback));
     EasyMock.expectLastCall().andAnswer(new IAnswer<Object>() {
       @Override
       public Object answer() throws Throwable {
@@ -172,7 +172,7 @@ public class TopicsResourceAvroProduceTest
                            EmbeddedFormat.AVRO,
                            request, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
-        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse,ProduceResponse.class);
+        ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);
 
         assertEquals(offsetResults, response.getOffsets());
         assertEquals((Integer) 1, response.getKeySchemaId());
@@ -192,8 +192,8 @@ public class TopicsResourceAvroProduceTest
 
         Response rawResponse =
             produceToTopic(topicName, mediatype.header, requestMediatype,
-                           EmbeddedFormat.AVRO,
-                           request, produceResults);
+                EmbeddedFormat.AVRO,
+                request, produceResults);
         assertOKResponse(rawResponse, mediatype.expected);
 
         EasyMock.reset(mdObserver, producerPool);
@@ -202,13 +202,13 @@ public class TopicsResourceAvroProduceTest
   }
 
   private void produceToTopicExpectFailure(String topicName, String acceptHeader,
-                                           String requestMediatype, TopicProduceRequest request,
-                                           String responseMediaType, int errorCode) {
+      String requestMediatype, TopicProduceRequest request,
+      String responseMediaType, int errorCode) {
     Response rawResponse = request("/topics/" + topicName, acceptHeader)
         .post(Entity.entity(request, requestMediatype));
 
     assertErrorResponse(ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY,
-                        rawResponse, errorCode, null, responseMediaType);
+        rawResponse, errorCode, null, responseMediaType);
   }
 
   @Test
@@ -220,8 +220,8 @@ public class TopicsResourceAvroProduceTest
         request.setValueSchema(valueSchemaStr);
 
         produceToTopicExpectFailure(topicName, mediatype.header, requestMediatype,
-                                    request, mediatype.expected,
-                                    Errors.KEY_SCHEMA_MISSING_ERROR_CODE);
+            request, mediatype.expected,
+            Errors.KEY_SCHEMA_MISSING_ERROR_CODE);
       }
     }
   }
@@ -235,8 +235,8 @@ public class TopicsResourceAvroProduceTest
         request.setKeySchema(keySchemaStr);
 
         produceToTopicExpectFailure(topicName, mediatype.header, requestMediatype,
-                                    request, mediatype.expected,
-                                    Errors.VALUE_SCHEMA_MISSING_ERROR_CODE);
+            request, mediatype.expected,
+            Errors.VALUE_SCHEMA_MISSING_ERROR_CODE);
       }
     }
   }

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
@@ -88,7 +88,7 @@ public class TopicsResourceBinaryProduceTest
   public TopicsResourceBinaryProduceTest() throws RestConfigException {
     mdObserver = EasyMock.createMock(MetadataObserver.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null);
+    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null, null, null);
 
     addResource(new TopicsResource(ctx));
 

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceTest.java
@@ -15,6 +15,7 @@
  **/
 package io.confluent.kafkarest.unit;
 
+import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestApplication;
@@ -45,14 +46,14 @@ import static org.junit.Assert.assertEquals;
 public class TopicsResourceTest
     extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
 
-  private MetadataObserver mdObserver;
+  private AdminClientWrapper adminClientWrapper;
   private ProducerPool producerPool;
   private DefaultKafkaRestContext ctx;
 
   public TopicsResourceTest() throws RestConfigException {
-    mdObserver = EasyMock.createMock(MetadataObserver.class);
+    adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, mdObserver, producerPool, null, null);
+    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
 
     addResource(new TopicsResource(ctx));
   }
@@ -61,15 +62,15 @@ public class TopicsResourceTest
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    EasyMock.reset(mdObserver, producerPool);
+    EasyMock.reset(adminClientWrapper, producerPool);
   }
 
   @Test
   public void testList() {
     final List<String> topics = Arrays.asList("test1", "test2", "test3");
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES) {
-      EasyMock.expect(mdObserver.getTopicNames()).andReturn(topics);
-      EasyMock.replay(mdObserver);
+      EasyMock.expect(adminClientWrapper.getTopicNames()).andReturn(topics);
+      EasyMock.replay(adminClientWrapper);
 
       Response response = request("/topics", mediatype.expected).get();
       assertOKResponse(response, mediatype.expected);
@@ -77,8 +78,8 @@ public class TopicsResourceTest
       });
       assertEquals(topics, topicsResponse);
 
-      EasyMock.verify(mdObserver);
-      EasyMock.reset(mdObserver);
+      EasyMock.verify(adminClientWrapper);
+      EasyMock.reset(adminClientWrapper);
     }
   }
 
@@ -106,11 +107,11 @@ public class TopicsResourceTest
     Topic topic2 = new Topic("topic2", nonEmptyConfig, partitions2);
 
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES) {
-      EasyMock.expect(mdObserver.getTopic("topic1"))
+      EasyMock.expect(adminClientWrapper.getTopic("topic1"))
           .andReturn(topic1);
-      EasyMock.expect(mdObserver.getTopic("topic2"))
+      EasyMock.expect(adminClientWrapper.getTopic("topic2"))
           .andReturn(topic2);
-      EasyMock.replay(mdObserver);
+      EasyMock.replay(adminClientWrapper);
 
       Response response1 = request("/topics/topic1", mediatype.header).get();
       assertOKResponse(response1, mediatype.expected);
@@ -123,25 +124,25 @@ public class TopicsResourceTest
       });
       assertEquals(topic2, topicResponse2);
 
-      EasyMock.verify(mdObserver);
-      EasyMock.reset(mdObserver);
+      EasyMock.verify(adminClientWrapper);
+      EasyMock.reset(adminClientWrapper);
     }
   }
 
   @Test
   public void testGetInvalidTopic() {
     for (TestUtils.RequestMediaType mediatype : TestUtils.V1_ACCEPT_MEDIATYPES) {
-      EasyMock.expect(mdObserver.getTopic("nonexistanttopic"))
+      EasyMock.expect(adminClientWrapper.getTopic("nonexistanttopic"))
           .andReturn(null);
-      EasyMock.replay(mdObserver);
+      EasyMock.replay(adminClientWrapper);
 
       Response response = request("/topics/nonexistanttopic", mediatype.header).get();
       assertErrorResponse(Response.Status.NOT_FOUND, response,
                           Errors.TOPIC_NOT_FOUND_ERROR_CODE, Errors.TOPIC_NOT_FOUND_MESSAGE,
                           mediatype.expected);
 
-      EasyMock.verify(mdObserver);
-      EasyMock.reset(mdObserver);
+      EasyMock.verify(adminClientWrapper);
+      EasyMock.reset(adminClientWrapper);
     }
   }
 }

--- a/src/test/java/io/confluent/kafkarest/unit/TopicsResourceTest.java
+++ b/src/test/java/io/confluent/kafkarest/unit/TopicsResourceTest.java
@@ -53,7 +53,8 @@ public class TopicsResourceTest
   public TopicsResourceTest() throws RestConfigException {
     adminClientWrapper = EasyMock.createMock(AdminClientWrapper.class);
     producerPool = EasyMock.createMock(ProducerPool.class);
-    ctx = new DefaultKafkaRestContext(config, adminClientWrapper, producerPool, null, null, null);
+    ctx = new DefaultKafkaRestContext(config, null, producerPool, null, null,
+        null,  adminClientWrapper);
 
     addResource(new TopicsResource(ctx));
   }

--- a/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -81,6 +81,7 @@ public class KafkaConsumerManagerTest {
     @Before
     public void setUp() throws RestConfigException {
         Properties props = new Properties();
+        props.setProperty(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://hostname:9092");
         props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG, "1024");
         // This setting supports the testConsumerOverrides test. It is otherwise benign and should
         // not affect other tests.


### PR DESCRIPTION
- Uses Admin Client instead of ZkUtils for all metadata API

- It is required to configure at least one of ZK connect url or boot strap brokers

- V1 Consumer API would work only if ZK connect URL is configured

- No proactive checks to topic exists or partition exists as that would require additional ACL's to be defined for the producer user. Making config easier compared to super friendly response message & code