### PR TITLE
Fix document typo

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -84,7 +84,7 @@ Java Kafka clients.
 
 
 ``access.control.allow.methods``
-  Set value to Jetty Access-Control-Allow-Origin header for specified methods
+  Set value to Jetty Access-Control-Allow-Methods header for specified methods
 
   * Type: string
   * Default: ""


### PR DESCRIPTION
Fix document typo on access.control.allow.methods explanation