### PR TITLE
Use KafkaZkClient instead of ZkUtils in tests

### DIFF
--- a/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
@@ -126,7 +126,7 @@ public class AvroProducerTest extends ClusterTestHarness {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    kafka.utils.TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    kafka.utils.TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                                       JavaConversions.asScalaBuffer(this.servers),
                                       new Properties());
 

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
@@ -100,7 +100,7 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
@@ -77,7 +77,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerJsonTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerJsonTest.java
@@ -83,7 +83,7 @@ public class ConsumerJsonTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
         JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -48,7 +48,7 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/JsonProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/JsonProducerTest.java
@@ -57,7 +57,7 @@ public class JsonProducerTest extends AbstractProducerTest {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    kafka.utils.TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    kafka.utils.TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
         JavaConversions.asScalaBuffer(this.servers),
         new Properties());
   }

--- a/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -82,9 +82,9 @@ public class MetadataAPITest extends ClusterTestHarness {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    kafka.utils.TestUtils.createTopic(zkUtils, topic1Name, topic1Partitions.size(), numReplicas,
+    kafka.utils.TestUtils.createTopic(zkClient, topic1Name, topic1Partitions.size(), numReplicas,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
-    kafka.utils.TestUtils.createTopic(zkUtils, topic2Name, topic2Partitions.size(), numReplicas,
+    kafka.utils.TestUtils.createTopic(zkClient, topic2Name, topic2Partitions.size(), numReplicas,
                           JavaConversions.asScalaBuffer(this.servers), topic2Configs);
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
@@ -146,7 +146,7 @@ public class ProducerTest extends AbstractProducerTest {
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
-    kafka.utils.TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    kafka.utils.TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                                       JavaConversions.asScalaBuffer(this.servers),
                                       new Properties());
   }

--- a/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerAvroTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerAvroTest.java
@@ -91,7 +91,7 @@ public class SimpleConsumerAvroTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 1;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerBinaryTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerBinaryTest.java
@@ -61,7 +61,7 @@ public class SimpleConsumerBinaryTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 1;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
                           JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 

--- a/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerJsonTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerJsonTest.java
@@ -86,7 +86,7 @@ public class SimpleConsumerJsonTest extends AbstractConsumerTest {
     super.setUp();
     final int numPartitions = 1;
     final int replicationFactor = 1;
-    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+    TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
         JavaConversions.asScalaBuffer(this.servers), new Properties());
   }
 


### PR DESCRIPTION
This fixes build breakage caused by

https://github.com/apache/kafka/commit/89b245baa7963e908d5f22d6f53c34f14690af67