### PR TITLE
Add file sink, similar to schema-registry configs

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=INFO, stdout, file
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
To make all Confluent Platform parts play the same tune and use the same logging conventions, the file sink is missing and needs to be added to the default rest proxy logging configs. (See https://github.com/confluentinc/schema-registry/blob/master/config/log4j.properties#L1 for the schema registry configs)