### PR TITLE
DOCS-339 - Fix config hyperlink

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -271,7 +271,7 @@ running:
 
 If you installed Debian or RPM packages, you can simply run ``kafka-rest-start``
 as it will be on your ``PATH``. The ``kafka-rest.properties`` file contains
-:ref:`configuration settings<schemaregistry_config>`. The default configuration
+:ref:`configuration settings<kafkarest_config>`. The default configuration
 included with the REST Proxy includes convenient defaults for a local testing setup
 and should be modified for a production deployment. By default the server starts bound to port
 8082, does not specify a unique instance ID (required to safely run multiple


### PR DESCRIPTION
Fix wrong link in kafka rest doc

https://confluentinc.atlassian.net/browse/DOCS-339