### PR TITLE
Check if defaultZkUtils is null before closing.

### DIFF
--- a/src/main/java/io/confluent/kafkarest/extension/KafkaRestContextProvider.java
+++ b/src/main/java/io/confluent/kafkarest/extension/KafkaRestContextProvider.java
@@ -122,7 +122,9 @@ public class KafkaRestContextProvider {
   public static synchronized void clean() {
     defaultContext.shutdown();
     defaultContext = null;
-    defaultZkUtils.close();
+    if (defaultZkUtils != null) {
+      defaultZkUtils.close();
+    }
     initialized.set(false);
   }
 }


### PR DESCRIPTION
CLIENTS-512 made the ZkUtils in KafkaRestContextProvider optional, but the
clean() method was still assuming it was always set.