### PR TITLE
Don't use deprecated RecordMetadata constructor

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
@@ -102,8 +102,8 @@ public class PartitionsResourceAvroProduceTest
     );
     TopicPartition tp0 = new TopicPartition(topicName, 0);
     produceResults = Arrays.asList(
-        new RecordMetadataOrException(new RecordMetadata(tp0, 0, 0, 0, 0, 1, 1), null),
-        new RecordMetadataOrException(new RecordMetadata(tp0, 0, 1, 0, 0, 1, 1), null)
+        new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 0L, 0L, 0L, 1, 1), null),
+        new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 1L, 0L, 0L, 1, 1), null)
     );
     offsetResults = Arrays.asList(
         new PartitionOffset(0, 0L, null, null),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
@@ -96,8 +96,8 @@ public class PartitionsResourceBinaryProduceTest
     );
     TopicPartition tp0 = new TopicPartition(topicName, 0);
     produceResults = Arrays.asList(
-        new RecordMetadataOrException(new RecordMetadata(tp0, 0, 0, 0, 0, 1, 1), null),
-        new RecordMetadataOrException(new RecordMetadata(tp0, 0, 1, 0, 0, 1, 1), null)
+        new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 0L, 0L, 0L, 1, 1), null),
+        new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 1L, 0L, 0L, 1, 1), null)
     );
     offsetResults = Arrays.asList(
         new PartitionOffset(0, 0L, null, null),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
@@ -93,9 +93,9 @@ public class TopicsResourceAvroProduceTest
   private static final TopicPartition tp0 = new TopicPartition(topicName, 0);
   private static final TopicPartition tp1 = new TopicPartition(topicName, 1);
   private List<RecordMetadataOrException> produceResults = Arrays.asList(
-      new RecordMetadataOrException(new RecordMetadata(tp0, 0, 0, 0, 0, 1, 1), null),
-      new RecordMetadataOrException(new RecordMetadata(tp0, 0, 1, 0, 0, 1, 1), null),
-      new RecordMetadataOrException(new RecordMetadata(tp1, 0, 0, 0, 0, 1, 1), null)
+      new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 0L, 0L, 0L, 1, 1), null),
+      new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 1L, 0L, 0L, 1, 1), null),
+      new RecordMetadataOrException(new RecordMetadata(tp1, 0L, 0L, 0L, 0L, 1, 1), null)
   );
   private static final List<PartitionOffset> offsetResults = Arrays.asList(
       new PartitionOffset(0, 0L, null, null),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
@@ -115,8 +115,8 @@ public class TopicsResourceBinaryProduceTest
 
     TopicPartition tp0 = new TopicPartition(topicName, 0);
     produceResults = Arrays.asList(
-        new RecordMetadataOrException(new RecordMetadata(tp0, 0, 0, 0, 0, 1, 1), null),
-        new RecordMetadataOrException(new RecordMetadata(tp0, 0, 1, 0, 0, 1, 1), null)
+        new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 0L, 0L, 0L, 1, 1), null),
+        new RecordMetadataOrException(new RecordMetadata(tp0, 0L, 1L, 0L, 0L, 1, 1), null)
     );
 
     offsetResults = Arrays.asList(


### PR DESCRIPTION
This constructor has been removed in Apache Kafka 2.0.