### PR TITLE
PLAT-77: Include monitoring-interceptors in CLASSPATH

### DIFF
--- a/bin/kafka-rest-run-class
+++ b/bin/kafka-rest-run-class
@@ -22,7 +22,7 @@ for dir in $base_dir/target/kafka-rest-*-development; do
 done
 
 # Production jars
-for library in "confluent-common" "rest-utils" "kafka-rest"; do
+for library in "confluent-common" "rest-utils" "kafka-rest" "monitoring-interceptors"; do
   CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*
 done
 


### PR DESCRIPTION
Producing to a topic with REST proxy fails in CP with `ClassNotFoundException`. This is because monitoring interceptors are not included in the CLASSPATH. Verified that the patch works as expected on confluent-5.0.0-SNAPSHOT.

```
$ bin/confluent start kafka-rest
This CLI is intended for development only, not for production
https://docs.confluent.io/current/cli/index.html

Using CONFLUENT_CURRENT: /var/folders/sp/24h2p81j4zvcg73d1z25rfym0000gp/T/confluent.Hh6OHtnY
Starting zookeeper
zookeeper is [UP]
Starting kafka
kafka is [UP]
Starting schema-registry
schema-registry is [UP]
Starting kafka-rest
kafka-rest is [UP]

$ curl -X POST -H "Content-Type: application/vnd.kafka.json.v2+json" \
>       -H "Accept: application/vnd.kafka.v2+json" \
>       --data '{"records":[{"value":{"foo":"bar"}}]}' "http://localhost:8082/topics/jsontest"
{"offsets":[{"partition":0,"offset":1,"error_code":null,"error":null}],"key_schema_id":null,"value_schema_id":null}
```