### PR TITLE
Adding RAW type support (support for StringSerializer records)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -39,4 +39,24 @@
             checks="(MethodLength)"
             files="(KafkaRestConfig).java"
     />
+    <suppress
+            checks="(ClassDataAbstractionCoupling)"
+            files="(ProducerPool).java"
+    />
+    <suppress
+        checks="(RegexpHeader)"
+        files="(RawConsumerState).java"
+    />
+    <suppress
+            checks="(Indentation)"
+            files="(ConsumersResource).java"
+    />
+    <suppress
+            checks="(Indentation)"
+            files="(PartitionsResource).java"
+    />
+    <suppress
+            checks="(AvoidStarImport)"
+            files="(PartitionsResource|ConsumersResource|TopicsResource|SimpleConsumerManager).java"
+    />
 </suppressions>

--- a/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -193,6 +193,9 @@ public class ConsumerManager {
         case JSON:
           state = new JsonConsumerState(this.config, cid, consumer);
           break;
+        case RAW:
+          state = new RawConsumerState(this.config, cid, consumer);
+          break;
         default:
           throw new RestServerErrorException(
               "Invalid embedded format for new consumer.",

--- a/src/main/java/io/confluent/kafkarest/ProducerPool.java
+++ b/src/main/java/io/confluent/kafkarest/ProducerPool.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +72,10 @@ public class ProducerPool {
         buildStandardConfig(appConfig, bootstrapBrokers, producerConfigOverrides);
     producers.put(EmbeddedFormat.JSON, buildJsonProducer(jsonProps));
 
+    Map<String, Object> rawProps =
+            buildStandardConfig(appConfig, bootstrapBrokers, producerConfigOverrides);
+    producers.put(EmbeddedFormat.RAW, buildRawProducer(rawProps));
+
     Map<String, Object> avroProps =
         buildAvroConfig(appConfig, bootstrapBrokers, producerConfigOverrides);
     producers.put(EmbeddedFormat.AVRO, buildAvroProducer(avroProps));
@@ -97,6 +102,10 @@ public class ProducerPool {
 
   private NoSchemaRestProducer<Object, Object> buildJsonProducer(Map<String, Object> jsonProps) {
     return buildNoSchemaProducer(jsonProps, new KafkaJsonSerializer(), new KafkaJsonSerializer());
+  }
+
+  private NoSchemaRestProducer<String, String> buildRawProducer(Map<String, Object> rawProps) {
+    return buildNoSchemaProducer(rawProps, new StringSerializer(), new StringSerializer());
   }
 
   private <K, V> NoSchemaRestProducer<K, V> buildNoSchemaProducer(

--- a/src/main/java/io/confluent/kafkarest/RawConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/RawConsumerState.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Xeotek GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafkarest.entities.RawConsumerRecord;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.MessageAndMetadata;
+import kafka.serializer.Decoder;
+import kafka.serializer.DefaultDecoder;
+import kafka.utils.VerifiableProperties;
+import org.apache.kafka.common.errors.SerializationException;
+
+public class RawConsumerState extends ConsumerState<byte[], byte[], String, String> {
+
+  private static final Decoder<byte[]> decoder = new DefaultDecoder(new VerifiableProperties());
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  public RawConsumerState(
+          KafkaRestConfig config,
+          ConsumerInstanceId instanceId,
+          ConsumerConnector consumer
+  ) {
+    super(config, instanceId, consumer);
+  }
+
+  @Override
+  protected Decoder<byte[]> getKeyDecoder() {
+    return decoder;
+  }
+
+  @Override
+  protected Decoder<byte[]> getValueDecoder() {
+    return decoder;
+  }
+
+  @Override
+  public ConsumerRecordAndSize<String, String> createConsumerRecord(
+          MessageAndMetadata<byte[], byte[]> msg
+  ) {
+    long approxSize = 0;
+
+    String key = null;
+    String value = null;
+
+    // The extra serialization here is unfortunate. We could use @JsonRawValue
+    // and just use the raw bytes, but that risks returning invalid data to the user
+    // if their data is not actually JSON encoded.
+
+    if (msg.key() != null) {
+      approxSize += msg.key().length;
+      key = deserialize(msg.key());
+    }
+
+    if (msg.message() != null) {
+      approxSize += msg.message().length;
+      value = deserialize(msg.message());
+    }
+
+    return new ConsumerRecordAndSize<>(
+            new RawConsumerRecord(msg.topic(), key, value, msg.partition(), msg.offset()),
+            approxSize
+    );
+  }
+
+  private String deserialize(byte[] data) {
+    try {
+      return new String(data);
+    } catch (Exception e) {
+      throw new SerializationException(e);
+    }
+  }
+}

--- a/src/main/java/io/confluent/kafkarest/Versions.java
+++ b/src/main/java/io/confluent/kafkarest/Versions.java
@@ -38,12 +38,25 @@ public class Versions {
   public static final String KAFKA_V2_JSON_JSON_WEIGHTED = KAFKA_V2_JSON_JSON;
   public static final String KAFKA_V2_JSON_JSON_WEIGHTED_LOW = KAFKA_V2_JSON_JSON + "; qs=0.1";
 
+  public static final String KAFKA_V2_JSON_RAW =  "application/vnd.kafka.raw.v2+json";
+  public static final String KAFKA_V2_JSON_RAW_WEIGHTED = KAFKA_V2_JSON_RAW;
+  public static final String KAFKA_V2_JSON_RAW_WEIGHTED_LOW = KAFKA_V2_JSON_RAW + "; qs=0.1";
+
+
+  public static final String KAFKA_V2_RAW_RAW = "application/vnd.kafka.raw.v2+raw";
+  public static final String KAFKA_V2_RAW_RAW_WEIGHTED = KAFKA_V2_RAW_RAW;
+  public static final String KAFKA_V2_RAW_RAW_WEIGHTED_LOW = KAFKA_V2_RAW_RAW + "; qs=0.1";
   // Constants for version 1
   public static final String KAFKA_V1_JSON = "application/vnd.kafka.v1+json";
   // This is set < 1 because it is only the most-specific type if there isn't an embedded data type.
   public static final String KAFKA_V1_JSON_WEIGHTED = KAFKA_V1_JSON + "; qs=0.9";
   public static final String KAFKA_V1_JSON_BINARY = "application/vnd.kafka.binary.v1+json";
   public static final String KAFKA_V1_JSON_BINARY_WEIGHTED = KAFKA_V1_JSON_BINARY;
+
+  public static final String KAFKA_V1_JSON_RAW = "application/vnd.kafka.raw.v1+json";
+  public static final String KAFKA_V1_JSON_RAW_WEIGHTED = KAFKA_V1_JSON_RAW;
+  public static final String KAFKA_V1_JSON_RAW_WEIGHTED_LOW = KAFKA_V1_JSON_RAW + "; qs=0.1";
+
   // "LOW" weightings are used to permit using these for resources like consumer where it might
   // be convenient to always use the same type, but where their use should really be discouraged
   public static final String KAFKA_V1_JSON_BINARY_WEIGHTED_LOW = KAFKA_V1_JSON_BINARY + "; qs=0.1";

--- a/src/main/java/io/confluent/kafkarest/entities/EmbeddedFormat.java
+++ b/src/main/java/io/confluent/kafkarest/entities/EmbeddedFormat.java
@@ -32,5 +32,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public enum EmbeddedFormat {
   BINARY,
   AVRO,
-  JSON
+  JSON,
+  RAW
 }

--- a/src/main/java/io/confluent/kafkarest/entities/RawConsumerRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/RawConsumerRecord.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RawConsumerRecord extends ConsumerRecord<String, String> {
+
+  @JsonCreator
+  public RawConsumerRecord(
+      @JsonProperty("topic") String topic,
+      @JsonProperty("key") String key,
+      @JsonProperty("value") String value,
+      @JsonProperty("partition") int partition,
+      @JsonProperty("offset") long offset
+  ) {
+    super(topic, key, value, partition, offset);
+  }
+
+}

--- a/src/main/java/io/confluent/kafkarest/entities/RawProduceRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/RawProduceRecord.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RawProduceRecord extends ProduceRecordBase<String, String> {
+
+  @JsonCreator
+  public RawProduceRecord(
+          @JsonProperty("key") String key,
+          @JsonProperty("value") String value
+  ) {
+    super(key, value);
+  }
+
+  @JsonCreator
+  public RawProduceRecord(
+          @JsonProperty("key") Object key,
+          @JsonProperty("value") Object value
+  ) {
+    super(key != null ? key.toString() : null, value != null ? value.toString() : null);
+  }
+
+  public RawProduceRecord(String value) {
+    this(null, value);
+  }
+
+  public RawProduceRecord(Object value) {
+    this(null, value != null ? value.toString() : null);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RawProduceRecord that = (RawProduceRecord) o;
+
+    return key != null
+            ? key.equals(that.key)
+            : that.key == null && !(value != null ? !value.equals(that.value) : that.value != null);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = key != null ? key.hashCode() : 0;
+    result = 31 * result + (value != null ? value.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/io/confluent/kafkarest/entities/RawTopicProduceRecord.java
+++ b/src/main/java/io/confluent/kafkarest/entities/RawTopicProduceRecord.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+
+public class RawTopicProduceRecord extends RawProduceRecord
+        implements TopicProduceRecord<String, String> {
+
+  // When producing to a topic, a partition may be explicitly requested.
+  @Min(0)
+  protected Integer partition;
+
+  @JsonCreator
+  public RawTopicProduceRecord(
+          @JsonProperty("key") String key,
+          @JsonProperty("value") String value,
+          @JsonProperty("partition") Integer partition
+  ) {
+    super(key, value);
+    this.partition = partition;
+  }
+
+
+  @JsonCreator
+  public RawTopicProduceRecord(
+          @JsonProperty("key") Object key,
+          @JsonProperty("value") Object value,
+          @JsonProperty("partition") Integer partition
+  ) {
+    super(key != null ? key.toString() : null, value != null ? value.toString() : null);
+    this.partition = partition;
+  }
+
+  public RawTopicProduceRecord(String value, Integer partition) {
+    this(null, value, partition);
+  }
+
+  public RawTopicProduceRecord(Object value, Integer partition) {
+    this(null, value != null ? value.toString() : null, partition);
+  }
+
+  @Override
+  public Integer getPartition() {
+    return partition;
+  }
+
+  @Override
+  public Integer partition() {
+    return partition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    RawTopicProduceRecord that = (RawTopicProduceRecord) o;
+
+    return !(partition != null ? !partition.equals(that.partition) : that.partition != null);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (partition != null ? partition.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/io/confluent/kafkarest/resources/ConsumersResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/ConsumersResource.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Confluent Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,14 +32,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.UriInfo;
 
-import io.confluent.kafkarest.AvroConsumerState;
-import io.confluent.kafkarest.BinaryConsumerState;
-import io.confluent.kafkarest.ConsumerManager;
-import io.confluent.kafkarest.ConsumerState;
-import io.confluent.kafkarest.KafkaRestContext;
-import io.confluent.kafkarest.JsonConsumerState;
-import io.confluent.kafkarest.UriUtils;
-import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.*;
 import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
 import io.confluent.kafkarest.entities.ConsumerRecord;
 import io.confluent.kafkarest.entities.CreateConsumerInstanceResponse;
@@ -50,11 +43,11 @@ import io.confluent.rest.annotations.PerformanceMetric;
 // We include embedded formats here so you can always use these headers when interacting with
 // a consumers resource. The few cases where it isn't safe are overridden per-method
 @Produces({Versions.KAFKA_V1_JSON_BINARY_WEIGHTED_LOW, Versions.KAFKA_V1_JSON_AVRO_WEIGHTED_LOW,
-           Versions.KAFKA_V1_JSON_JSON_WEIGHTED_LOW, Versions.KAFKA_V1_JSON_WEIGHTED,
-           Versions.KAFKA_DEFAULT_JSON_WEIGHTED, Versions.JSON_WEIGHTED})
+        Versions.KAFKA_V1_JSON_JSON_WEIGHTED_LOW, Versions.KAFKA_V1_JSON_WEIGHTED,
+        Versions.KAFKA_DEFAULT_JSON_WEIGHTED, Versions.JSON_WEIGHTED})
 @Consumes({Versions.KAFKA_V1_JSON_BINARY, Versions.KAFKA_V1_JSON_AVRO, Versions.KAFKA_V1_JSON_JSON,
-           Versions.KAFKA_V1_JSON, Versions.KAFKA_DEFAULT_JSON, Versions.JSON,
-           Versions.GENERIC_REQUEST})
+        Versions.KAFKA_V1_JSON, Versions.KAFKA_DEFAULT_JSON, Versions.JSON,
+        Versions.GENERIC_REQUEST})
 public class ConsumersResource {
 
   private final KafkaRestContext ctx;
@@ -68,9 +61,9 @@ public class ConsumersResource {
   @Path("/{group}")
   @PerformanceMetric("consumer.create")
   public CreateConsumerInstanceResponse createGroup(
-      @javax.ws.rs.core.Context UriInfo uriInfo,
-      final @PathParam("group") String group,
-      @Valid ConsumerInstanceConfig config
+          @javax.ws.rs.core.Context UriInfo uriInfo,
+          final @PathParam("group") String group,
+          @Valid ConsumerInstanceConfig config
   ) {
 
     if (config == null) {
@@ -78,7 +71,7 @@ public class ConsumersResource {
     }
     String instanceId = ctx.getConsumerManager().createConsumer(group, config);
     String instanceBaseUri = UriUtils.absoluteUriBuilder(ctx.getConfig(), uriInfo)
-        .path("instances").path(instanceId).build().toString();
+            .path("instances").path(instanceId).build().toString();
     return new CreateConsumerInstanceResponse(instanceId, instanceBaseUri);
   }
 
@@ -86,9 +79,9 @@ public class ConsumersResource {
   @Path("/{group}/instances/{instance}/offsets")
   @PerformanceMetric("consumer.commit")
   public void commitOffsets(
-      final @Suspended AsyncResponse asyncResponse,
-      final @PathParam("group") String group,
-      final @PathParam("instance") String instance
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance
   ) {
     ctx.getConsumerManager().commitOffsets(group, instance, new ConsumerManager.CommitCallback() {
       @Override
@@ -106,8 +99,8 @@ public class ConsumersResource {
   @Path("/{group}/instances/{instance}")
   @PerformanceMetric("consumer.delete")
   public void deleteGroup(
-      final @PathParam("group") String group,
-      final @PathParam("instance") String instance
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance
   ) {
     ctx.getConsumerManager().deleteConsumer(group, instance);
   }
@@ -116,17 +109,31 @@ public class ConsumersResource {
   @Path("/{group}/instances/{instance}/topics/{topic}")
   @PerformanceMetric("consumer.topic.read-binary")
   @Produces({Versions.KAFKA_V1_JSON_BINARY_WEIGHTED,
-             Versions.KAFKA_V1_JSON_WEIGHTED,
-             Versions.KAFKA_DEFAULT_JSON_WEIGHTED,
-             Versions.JSON_WEIGHTED})
+          Versions.KAFKA_V1_JSON_WEIGHTED,
+          Versions.KAFKA_DEFAULT_JSON_WEIGHTED,
+          Versions.JSON_WEIGHTED})
   public void readTopicBinary(
-      final @Suspended AsyncResponse asyncResponse,
-      final @PathParam("group") String group,
-      final @PathParam("instance") String instance,
-      final @PathParam("topic") String topic,
-      @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance,
+          final @PathParam("topic") String topic,
+          @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
   ) {
     readTopic(asyncResponse, group, instance, topic, maxBytes, BinaryConsumerState.class);
+  }
+
+  @GET
+  @Path("/{group}/instances/{instance}/topics/{topic}")
+  @PerformanceMetric("consumer.topic.read-raw")
+  @Produces({Versions.KAFKA_V1_JSON_RAW_WEIGHTED})
+  public void readTopicRaw(
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance,
+          final @PathParam("topic") String topic,
+          @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
+  ) {
+    readTopic(asyncResponse, group, instance, topic, maxBytes, RawConsumerState.class);
   }
 
   @GET
@@ -134,54 +141,55 @@ public class ConsumersResource {
   @PerformanceMetric("consumer.topic.read-json")
   @Produces({Versions.KAFKA_V1_JSON_JSON_WEIGHTED_LOW})// Using low weight ensures binary is default
   public void readTopicJson(
-      final @Suspended AsyncResponse asyncResponse,
-      final @PathParam("group") String group,
-      final @PathParam("instance") String instance,
-      final @PathParam("topic") String topic,
-      @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance,
+          final @PathParam("topic") String topic,
+          @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
   ) {
     readTopic(asyncResponse, group, instance, topic, maxBytes, JsonConsumerState.class);
   }
+
 
   @GET
   @Path("/{group}/instances/{instance}/topics/{topic}")
   @PerformanceMetric("consumer.topic.read-avro")
   @Produces({Versions.KAFKA_V1_JSON_AVRO_WEIGHTED_LOW})// Using low weight ensures binary is default
   public void readTopicAvro(
-      final @Suspended AsyncResponse asyncResponse,
-      final @PathParam("group") String group,
-      final @PathParam("instance") String instance,
-      final @PathParam("topic") String topic,
-      @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance,
+          final @PathParam("topic") String topic,
+          @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
   ) {
     readTopic(asyncResponse, group, instance, topic, maxBytes, AvroConsumerState.class);
   }
 
   private <KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> void readTopic(
-      final @Suspended AsyncResponse asyncResponse,
-      final @PathParam("group") String group,
-      final @PathParam("instance") String instance,
-      final @PathParam("topic") String topic,
-      @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes,
-      Class<? extends ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>>
-          consumerStateType
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance,
+          final @PathParam("topic") String topic,
+          @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes,
+          Class<? extends ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>>
+                  consumerStateType
   ) {
     maxBytes = (maxBytes <= 0) ? Long.MAX_VALUE : maxBytes;
     ctx.getConsumerManager().readTopic(
-        group, instance, topic, consumerStateType, maxBytes,
-        new ConsumerManager.ReadCallback<ClientKeyT, ClientValueT>() {
-          @Override
-          public void onCompletion(
-              List<? extends ConsumerRecord<ClientKeyT, ClientValueT>> records,
-              Exception e
-          ) {
-            if (e != null) {
-              asyncResponse.resume(e);
-            } else {
-              asyncResponse.resume(records);
+            group, instance, topic, consumerStateType, maxBytes,
+            new ConsumerManager.ReadCallback<ClientKeyT, ClientValueT>() {
+              @Override
+              public void onCompletion(
+                      List<? extends ConsumerRecord<ClientKeyT, ClientValueT>> records,
+                      Exception e
+              ) {
+                if (e != null) {
+                  asyncResponse.resume(e);
+                } else {
+                  asyncResponse.resume(records);
+                }
+              }
             }
-          }
-        }
     );
   }
 }

--- a/src/main/java/io/confluent/kafkarest/resources/TopicsResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/TopicsResource.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafkarest.resources;
 
+import io.confluent.kafkarest.entities.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,15 +40,6 @@ import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.ProducerPool;
 import io.confluent.kafkarest.RecordMetadataOrException;
 import io.confluent.kafkarest.Versions;
-import io.confluent.kafkarest.entities.AvroTopicProduceRecord;
-import io.confluent.kafkarest.entities.BinaryTopicProduceRecord;
-import io.confluent.kafkarest.entities.EmbeddedFormat;
-import io.confluent.kafkarest.entities.JsonTopicProduceRecord;
-import io.confluent.kafkarest.entities.PartitionOffset;
-import io.confluent.kafkarest.entities.ProduceResponse;
-import io.confluent.kafkarest.entities.Topic;
-import io.confluent.kafkarest.entities.TopicProduceRecord;
-import io.confluent.kafkarest.entities.TopicProduceRequest;
 import io.confluent.rest.annotations.PerformanceMetric;
 
 @Path("/topics")
@@ -106,6 +98,18 @@ public class TopicsResource {
       @Valid @NotNull TopicProduceRequest<JsonTopicProduceRecord> request
   ) {
     produce(asyncResponse, topicName, EmbeddedFormat.JSON, request);
+  }
+
+  @POST
+  @Path("/{topic}")
+  @PerformanceMetric("topic.produce-raw")
+  @Consumes({Versions.KAFKA_V1_JSON_RAW, Versions.KAFKA_V2_JSON_RAW})
+  public void produceRaw(
+          final @Suspended AsyncResponse asyncResponse,
+          @PathParam("topic") String topicName,
+          @Valid @NotNull TopicProduceRequest<RawTopicProduceRecord> request
+  ) {
+    produce(asyncResponse, topicName, EmbeddedFormat.RAW, request);
   }
 
   @POST

--- a/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
@@ -50,13 +50,10 @@ import io.confluent.kafkarest.entities.ConsumerSubscriptionRecord;
 import io.confluent.kafkarest.entities.ConsumerSubscriptionResponse;
 import io.confluent.kafkarest.entities.CreateConsumerInstanceResponse;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
-import io.confluent.kafkarest.v2.AvroKafkaConsumerState;
-import io.confluent.kafkarest.v2.BinaryKafkaConsumerState;
-import io.confluent.kafkarest.v2.JsonKafkaConsumerState;
-import io.confluent.kafkarest.v2.KafkaConsumerManager;
-import io.confluent.kafkarest.v2.KafkaConsumerState;
+import io.confluent.kafkarest.v2.*;
 import io.confluent.rest.annotations.PerformanceMetric;
 
+@SuppressWarnings("RSReferenceInspection")
 @Path("/consumers")
 // We include embedded formats here so you can always use these headers when interacting with
 // a consumers resource. The few cases where it isn't safe are overridden per-method
@@ -163,6 +160,23 @@ public class ConsumersResource {
   ) {
     readRecords(asyncResponse, group, instance, timeout, maxBytes, BinaryKafkaConsumerState.class);
   }
+
+
+  @GET
+  @Path("/{group}/instances/{instance}/records")
+  @PerformanceMetric("consumer.records.read-raw+v2")
+  @Produces({Versions.KAFKA_V2_RAW_RAW_WEIGHTED,
+          Versions.KAFKA_V2_RAW_RAW_WEIGHTED})
+  public void readRecordRaw(
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("group") String group,
+          final @PathParam("instance") String instance,
+          @QueryParam("timeout") @DefaultValue("-1") long timeout,
+          @QueryParam("max_bytes") @DefaultValue("-1") long maxBytes
+  ) {
+    readRecords(asyncResponse, group, instance, timeout, maxBytes, RawKafkaConsumerState.class);
+  }
+
 
   @GET
   @Path("/{group}/instances/{instance}/records")

--- a/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
+++ b/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
@@ -16,41 +16,24 @@
 
 package io.confluent.kafkarest.resources.v2;
 
+import io.confluent.kafkarest.*;
+import io.confluent.kafkarest.entities.*;
+import io.confluent.rest.annotations.PerformanceMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.*;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
 import java.util.List;
 import java.util.Vector;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.Suspended;
-
-import io.confluent.kafkarest.KafkaRestContext;
-import io.confluent.kafkarest.Errors;
-import io.confluent.kafkarest.ProducerPool;
-import io.confluent.kafkarest.RecordMetadataOrException;
-import io.confluent.kafkarest.Versions;
-import io.confluent.kafkarest.entities.AvroProduceRecord;
-import io.confluent.kafkarest.entities.BinaryProduceRecord;
-import io.confluent.kafkarest.entities.EmbeddedFormat;
-import io.confluent.kafkarest.entities.JsonProduceRecord;
-import io.confluent.kafkarest.entities.Partition;
-import io.confluent.kafkarest.entities.PartitionOffset;
-import io.confluent.kafkarest.entities.PartitionProduceRequest;
-import io.confluent.kafkarest.entities.ProduceRecord;
-import io.confluent.kafkarest.entities.ProduceResponse;
-import io.confluent.rest.annotations.PerformanceMetric;
-
 @Path("/topics/{topic}/partitions")
-@Produces({Versions.KAFKA_V2_JSON_BINARY_WEIGHTED_LOW, Versions.KAFKA_V2_JSON_AVRO_WEIGHTED_LOW,
+@Produces({Versions.KAFKA_V2_JSON_BINARY_WEIGHTED_LOW,
+        Versions.KAFKA_V2_JSON_RAW_WEIGHTED_LOW,
+        Versions.KAFKA_V2_JSON_AVRO_WEIGHTED_LOW,
            Versions.KAFKA_V2_JSON_WEIGHTED})
 @Consumes({Versions.KAFKA_V2_JSON})
 public class PartitionsResource {
@@ -98,6 +81,21 @@ public class PartitionsResource {
   ) {
     produce(asyncResponse, topic, partition, EmbeddedFormat.BINARY, request);
   }
+
+  @POST
+  @Path("/{partition}")
+  @PerformanceMetric("partition.produce-raw+v2")
+  @Consumes({Versions.KAFKA_V2_JSON_RAW})
+  public void produceRaw(
+          final @Suspended AsyncResponse asyncResponse,
+          final @PathParam("topic") String topic,
+          final @PathParam("partition") int partition,
+          @Valid @NotNull PartitionProduceRequest<RawProduceRecord> request
+  ) {
+    produce(asyncResponse, topic, partition, EmbeddedFormat.RAW, request);
+  }
+
+
 
   @POST
   @Path("/{partition}")

--- a/src/main/java/io/confluent/kafkarest/v2/RawKafkaConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/v2/RawKafkaConsumerState.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest.v2;
+
+import io.confluent.kafkarest.ConsumerInstanceId;
+import io.confluent.kafkarest.ConsumerRecordAndSize;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.entities.RawConsumerRecord;
+import kafka.serializer.Decoder;
+import kafka.serializer.DefaultDecoder;
+import kafka.utils.VerifiableProperties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.errors.SerializationException;
+
+public class RawKafkaConsumerState extends KafkaConsumerState<byte[], byte[], String, String> {
+
+  private static final Decoder<byte[]> decoder = new DefaultDecoder(new VerifiableProperties());
+
+  public RawKafkaConsumerState(KafkaRestConfig config,
+                               ConsumerInstanceId instanceId,
+                               Consumer consumer) {
+    super(config, instanceId, consumer);
+  }
+
+  @Override
+  protected Decoder<byte[]> getKeyDecoder() {
+    return decoder;
+  }
+
+  @Override
+  protected Decoder<byte[]> getValueDecoder() {
+    return decoder;
+  }
+
+  @Override
+  public ConsumerRecordAndSize<String, String> createConsumerRecord(
+      ConsumerRecord<byte[], byte[]> record) {
+    long approxSize = 0;
+
+    String key = null;
+    String value = null;
+
+    // The extra serialization here is unfortunate. We could use @JsonRawValue
+    // and just use the raw bytes, but that risks returning invalid data to the user
+    // if their data is not actually JSON encoded.
+
+    if (record.key() != null) {
+      approxSize += record.key().length;
+      key = deserialize(record.key());
+    }
+
+    if (record.value() != null) {
+      approxSize += record.value().length;
+      value = deserialize(record.value());
+    }
+
+    return new ConsumerRecordAndSize<>(
+        new RawConsumerRecord(record.topic(), key, value, record.partition(), record.offset()),
+        approxSize);
+  }
+
+  private String deserialize(byte[] data) {
+    try {
+      return new String(data);
+    } catch (Exception e) {
+      throw new SerializationException(e);
+    }
+  }
+}

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerRawTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerRawTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.kafkarest.integration;
+
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.kafkarest.entities.RawConsumerRecord;
+import kafka.utils.TestUtils;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
+import org.junit.Test;
+import scala.collection.JavaConversions;
+
+import javax.ws.rs.core.GenericType;
+import java.util.*;
+
+public class ConsumerRawTest extends AbstractConsumerTest {
+
+  private static final String topicName = "topic1";
+  private static final String groupName = "testconsumergroup";
+
+  private Map<String, Object> exampleMapValue() {
+    Map<String, Object> res = new HashMap<String, Object>();
+    res.put("foo", "bar");
+    res.put("bar", null);
+    res.put("baz", 53.4);
+    res.put("taz", 45);
+    return res;
+  }
+
+  private List<Object> exampleListValue() {
+    List<Object> res = new ArrayList<Object>();
+    res.add("foo");
+    res.add(null);
+    res.add(53.4);
+    res.add(45);
+    return res;
+  }
+
+  private final List<ProducerRecord<Object, Object>> recordsWithKeys = Arrays.asList(
+      new ProducerRecord<Object, Object>(topicName, "key", "value"),
+      new ProducerRecord<Object, Object>(topicName, "key", null),
+      new ProducerRecord<Object, Object>(topicName, "key", 43.2),
+      new ProducerRecord<Object, Object>(topicName, "key", 999),
+      new ProducerRecord<Object, Object>(topicName, "key", exampleMapValue()),
+      new ProducerRecord<Object, Object>(topicName, "key", exampleListValue())
+  );
+
+  private final List<ProducerRecord<Object, Object>> recordsOnlyValues = Arrays.asList(
+      new ProducerRecord<Object, Object>(topicName, "value"),
+      new ProducerRecord<Object, Object>(topicName, null),
+      new ProducerRecord<Object, Object>(topicName, 43.2),
+      new ProducerRecord<Object, Object>(topicName, 999),
+      new ProducerRecord<Object, Object>(topicName, exampleMapValue()),
+      new ProducerRecord<Object, Object>(topicName, exampleListValue())
+  );
+
+  private static final GenericType<List<RawConsumerRecord>> rawConsumerRecordType
+      = new GenericType<List<RawConsumerRecord>>() {
+  };
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    final int numPartitions = 3;
+    final int replicationFactor = 1;
+    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+        JavaConversions.asScalaBuffer(this.servers), new Properties());
+  }
+
+  @Test
+  public void testConsumeWithKeys() {
+
+    String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.RAW,
+        Versions.KAFKA_V1_JSON_RAW_WEIGHTED);
+    produceRawMessages(recordsWithKeys);
+
+    consumeMessages(instanceUri, topicName, recordsWithKeys,
+            Versions.KAFKA_V1_JSON_RAW_WEIGHTED, Versions.KAFKA_V1_JSON_RAW_WEIGHTED,
+            rawConsumerRecordType, new Converter() {
+              @Override
+              public String convert(Object obj) {
+                return obj!=null?obj.toString():obj+"";
+              }
+            });
+    commitOffsets(instanceUri);
+  }
+
+  @Test
+  public void testConsumeOnlyValues() {
+    String instanceUri = startConsumeMessages(groupName, topicName, EmbeddedFormat.RAW,
+        Versions.KAFKA_V1_JSON_RAW_WEIGHTED);
+    produceRawMessages(recordsOnlyValues);
+    consumeMessages(instanceUri, topicName, recordsOnlyValues,
+        Versions.KAFKA_V1_JSON_RAW, Versions.KAFKA_V1_JSON_RAW,
+            rawConsumerRecordType, new Converter() {
+              @Override
+              public String convert(Object obj) {
+                return obj!=null?obj.toString():obj+"";
+              }
+            });
+    commitOffsets(instanceUri);
+  }
+
+}

--- a/src/test/java/io/confluent/kafkarest/integration/RawProducerTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/RawProducerTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.kafkarest.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.*;
+import kafka.serializer.Decoder;
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.Before;
+import org.junit.Test;
+import scala.collection.JavaConversions;
+
+import java.util.*;
+
+public class RawProducerTest extends AbstractProducerTest {
+
+  private String topicName = "topic1";
+  private KafkaRawDecoder decoder = new KafkaRawDecoder();
+
+  public class KafkaRawDecoder implements Decoder<String> {
+
+
+    @Override
+    public String fromBytes(byte[] bytes) {
+      try {
+        return new String(bytes);
+      } catch (Exception e) {
+        throw new SerializationException(e);
+      }
+    }
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    final int numPartitions = 3;
+    final int replicationFactor = 1;
+    kafka.utils.TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+        JavaConversions.asScalaBuffer(this.servers),
+        new Properties());
+  }
+
+  @Override
+  protected String getEmbeddedContentType() {
+    return Versions.KAFKA_V1_JSON_RAW;
+  }
+
+  private Map<String, Object> exampleMapValue() {
+    Map<String, Object> res = new HashMap<String, Object>();
+    res.put("foo", "bar");
+    res.put("bar", null);
+    res.put("baz", 53.4);
+    res.put("taz", 45);
+    return res;
+  }
+
+  private List<Object> exampleListValue() {
+    List<Object> res = new ArrayList<Object>();
+    res.add("foo");
+    res.add(null);
+    res.add(53.4);
+    res.add(45);
+    res.add(exampleMapValue());
+    return res;
+  }
+
+  private final List<RawTopicProduceRecord> topicRecordsWithKeys = Arrays.asList(
+      new RawTopicProduceRecord("key", "value", 0),
+      new RawTopicProduceRecord("key", null, 0),
+      new RawTopicProduceRecord("key", 53.4, 0),
+      new RawTopicProduceRecord("key", 45, 0),
+      new RawTopicProduceRecord("key", exampleMapValue(), 0),
+      new RawTopicProduceRecord("key", exampleListValue(), 0)
+  );
+
+  private final List<RawTopicProduceRecord> topicRecordsWithoutKeys = Arrays.asList(
+      new RawTopicProduceRecord("value", 0),
+      new RawTopicProduceRecord(null, 0),
+      new RawTopicProduceRecord(53.4, 0),
+      new RawTopicProduceRecord(45, 0),
+      new RawTopicProduceRecord(exampleMapValue(), 0),
+      new RawTopicProduceRecord(exampleListValue(), 0)
+  );
+
+  private final List<RawProduceRecord> partitionRecordsWithKeys = Arrays.asList(
+      new RawProduceRecord("key", "value"),
+      new RawProduceRecord("key", null),
+      new RawProduceRecord("key", 53.4),
+      new RawProduceRecord("key", 45),
+      new RawProduceRecord("key", exampleMapValue()),
+      new RawProduceRecord("key", exampleListValue())
+  );
+
+  private final List<RawProduceRecord> partitionRecordsWithoutKeys = Arrays.asList(
+      new RawProduceRecord("value"),
+      new RawProduceRecord(null),
+      new RawProduceRecord(53.4),
+      new RawProduceRecord(45),
+      new RawProduceRecord(exampleMapValue()),
+      new RawProduceRecord(exampleListValue())
+  );
+
+  private final List<PartitionOffset> produceOffsets = Arrays.asList(
+      new PartitionOffset(0, 0L, null, null),
+      new PartitionOffset(0, 1L, null, null),
+      new PartitionOffset(0, 2L, null, null),
+      new PartitionOffset(0, 3L, null, null),
+      new PartitionOffset(0, 4L, null, null),
+      new PartitionOffset(0, 5L, null, null)
+  );
+
+  @Test
+  public void testProduceToTopicKeyAndValue() {
+    testProduceToTopic(topicName, topicRecordsWithKeys, decoder, decoder,
+        produceOffsets, true);
+  }
+
+  @Test
+  public void testProduceToTopicNoKey() {
+    testProduceToTopic(topicName, topicRecordsWithoutKeys, decoder, decoder,
+        produceOffsets, true);
+  }
+
+  @Test
+  public void testProduceToPartitionKeyAndValue() {
+    testProduceToPartition(topicName, 0, partitionRecordsWithKeys, decoder, decoder,
+        produceOffsets);
+  }
+
+  @Test
+  public void testProduceToPartitionNoKey() {
+    testProduceToPartition(topicName, 0, partitionRecordsWithoutKeys, decoder, decoder,
+        produceOffsets);
+  }
+
+}

--- a/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerRawTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/SimpleConsumerRawTest.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.kafkarest.integration;
+
+import io.confluent.kafkarest.Errors;
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.RawConsumerRecord;
+import jersey.repackaged.com.google.common.collect.ImmutableMap;
+import kafka.utils.TestUtils;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
+import org.junit.Test;
+import scala.collection.JavaConversions;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.*;
+
+import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
+
+public class SimpleConsumerRawTest extends AbstractConsumerTest {
+
+  private static final String topicName = "topic1";
+  private final Converter rawConverter = new Converter() {
+    @Override
+    public Object convert(Object obj) {
+      return obj!=null?obj.toString():"";
+    }
+  };
+
+  private Map<String, Object> exampleMapValue() {
+    Map<String, Object> res = new HashMap<String, Object>();
+    res.put("foo", "bar");
+    res.put("bar", null);
+    res.put("baz", 53.4);
+    res.put("taz", 45);
+    return res;
+  }
+
+  private List<Object> exampleListValue() {
+    List<Object> res = new ArrayList<Object>();
+    res.add("foo");
+    res.add(null);
+    res.add(53.4);
+    res.add(45);
+    return res;
+  }
+
+  private final List<ProducerRecord<Object, Object>> recordsWithKeys = Arrays.asList(
+      new ProducerRecord<Object, Object>(topicName, "key", "value"),
+      new ProducerRecord<Object, Object>(topicName, "key", null),
+      new ProducerRecord<Object, Object>(topicName, "key", 43.2),
+      new ProducerRecord<Object, Object>(topicName, "key", 999),
+      new ProducerRecord<Object, Object>(topicName, "key", exampleMapValue()),
+      new ProducerRecord<Object, Object>(topicName, "key", exampleListValue())
+  );
+
+  private final List<ProducerRecord<Object, Object>> recordsOnlyValues = Arrays.asList(
+      new ProducerRecord<Object, Object>(topicName, "value"),
+      new ProducerRecord<Object, Object>(topicName, null),
+      new ProducerRecord<Object, Object>(topicName, 43.2),
+      new ProducerRecord<Object, Object>(topicName, 999),
+      new ProducerRecord<Object, Object>(topicName, exampleMapValue()),
+      new ProducerRecord<Object, Object>(topicName, exampleListValue())
+  );
+
+  private static final GenericType<List<RawConsumerRecord>> rawConsumerRecordType
+      = new GenericType<List<RawConsumerRecord>>() {
+  };
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    final int numPartitions = 1;
+    final int replicationFactor = 1;
+    TestUtils.createTopic(zkUtils, topicName, numPartitions, replicationFactor,
+        JavaConversions.asScalaBuffer(this.servers), new Properties());
+  }
+
+  @Test
+  public void testConsumeOnlyValuesByOffset() {
+    produceRawMessages(recordsOnlyValues);
+
+    simpleConsumeMessages(
+            topicName,
+            0,
+            null, // No "count" parameter in the query
+            recordsOnlyValues.subList(0, 1), // We expect only the first record in the response
+            Versions.KAFKA_V1_JSON_RAW,
+            Versions.KAFKA_V1_JSON_RAW,
+            rawConsumerRecordType,
+            rawConverter
+
+    );
+  }
+
+  @Test
+  public void testConsumeOnlyValuesByOffsetAndCount() {
+    produceRawMessages(recordsOnlyValues);
+
+    simpleConsumeMessages(
+        topicName,
+        0,
+        recordsOnlyValues.size(),
+        recordsOnlyValues,
+        Versions.KAFKA_V1_JSON_RAW,
+        Versions.KAFKA_V1_JSON_RAW,
+            rawConsumerRecordType,
+            rawConverter
+    );
+  }
+
+  @Test
+  public void testConsumeWithKeysByOffsetAndCount() {
+    produceRawMessages(recordsWithKeys);
+
+    simpleConsumeMessages(
+        topicName,
+        0,
+        recordsWithKeys.size(),
+        recordsWithKeys,
+        Versions.KAFKA_V1_JSON_RAW,
+        Versions.KAFKA_V1_JSON_RAW,
+            rawConsumerRecordType,
+            rawConverter
+    );
+  }
+
+  @Test(timeout = 1000)
+  public void testConsumeMoreMessagesThanAvailable() {
+    produceRawMessages(recordsOnlyValues);
+
+    simpleConsumeMessages(
+        topicName,
+        0,
+        recordsOnlyValues.size()+1, // Ask for more than there is
+        recordsOnlyValues,
+        Versions.KAFKA_V1_JSON_RAW,
+        Versions.KAFKA_V1_JSON_RAW,
+            rawConsumerRecordType,
+            rawConverter
+    );
+  }
+
+  @Test
+  public void testConsumeInvalidTopic() {
+
+    Response response = request("/topics/nonexistenttopic/partitions/0/messages",
+        ImmutableMap.of("offset", "0")).accept(Versions.KAFKA_V1_JSON_RAW).get();
+
+    assertErrorResponse(Response.Status.NOT_FOUND, response,
+        Errors.TOPIC_NOT_FOUND_ERROR_CODE,
+        Errors.TOPIC_NOT_FOUND_MESSAGE,
+        Versions.KAFKA_V1_JSON_RAW);
+  }
+
+  @Test
+  public void testConsumeInvalidPartition() {
+
+    Response response = request("/topics/topic1/partitions/1/messages",
+        ImmutableMap.of("offset", "0")).accept(Versions.KAFKA_V1_JSON_RAW).get();
+
+    assertErrorResponse(Response.Status.NOT_FOUND, response,
+        Errors.PARTITION_NOT_FOUND_ERROR_CODE,
+        Errors.PARTITION_NOT_FOUND_MESSAGE,
+        Versions.KAFKA_V1_JSON_RAW);
+  }
+
+}


### PR DESCRIPTION
This is an enhanced version of the Kafka REST Proxy with an additional RAW type which enables for consumption and production of Kafka records with key and/or value of type string.

The new RAW type can be used from within the same REST api that the original REST Proxy offers.

### Creation of RAW Consumer

curl -X POST \
  http://rest-proxy.dev.aareality.aareal.org/consumers/myconsumergroup \
  -H 'Content-Type: application/vnd.kafka.v2+json' \
  -d '{"name": "myconsumerinstance", "format": "raw", "auto.offset.reset": "smallest"}'

### Reading records from RAW Consumer

curl -X GET \
  http://rest-proxy.dev.aareality.aareal.org/consumers/myconsumergroup/instances/myconsumerinstance/records \
  -H 'Accept: application/vnd.kafka.raw.v2+json' 
