### PR TITLE
Fix API v1 /consumers documentation for HTTP Content-Type headers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2272,7 +2272,7 @@ error.
 
       POST /consumers/testgroup/ HTTP/1.1
       Host: kafkaproxy.example.com
-      Accept: application/vnd.kafka.v1+json, application/vnd.kafka+json, application/json
+      Content-Type: application/vnd.kafka.v1+json
 
       {
         "name": "my_consumer",
@@ -2323,7 +2323,7 @@ error.
 
       POST /consumers/testgroup/instances/my_consumer/offsets HTTP/1.1
       Host: proxy-instance.kafkaproxy.example.com
-      Accept: application/vnd.kafka.v1+json, application/vnd.kafka+json, application/json
+      Content-Type: application/vnd.kafka.v1+json
 
    **Example response**:
 


### PR DESCRIPTION
Current documentation is inaccurate - 'Accept' HTTP header throws the following error:
```
{"error_code":415,"message":"HTTP 415 Unsupported Media Type"}
```

This documentation fix is important for users of the v1 REST API.