### PR TITLE
DOCS-627: Rename Confluent Kafka REST Proxy to Confluent REST Proxy

### DIFF
--- a/debian/confluent-kafka-rest.spec.in
+++ b/debian/confluent-kafka-rest.spec.in
@@ -15,7 +15,7 @@ Requires: confluent-rest-utils
 
 %description
 
-The Kafka REST Proxy provides a RESTful interface to a Kafka cluster. It makes it easy to produce and consume messages, view the state of the cluster, and perform administrative actions without using the native Kafka protocol or clients. Examples of use cases include reporting data to Kafka from any frontend app built in any language, ingesting messages into a stream processing framework that doesn't yet support Kafka, and scripting administrative actions.
+The Confluent REST Proxy provides a RESTful interface to a Kafka cluster. It makes it easy to produce and consume messages, view the state of the cluster, and perform administrative actions without using the native Kafka protocol or clients. Examples of use cases include reporting data to Kafka from any frontend app built in any language, ingesting messages into a stream processing framework that doesn't yet support Kafka, and scripting administrative actions.
 
 %define __jar_repack %{nil}
 
@@ -26,7 +26,7 @@ _group=confluent
 
 getent group $_group 2>&1 >/dev/null || groupadd -r $_group
 getent passwd $_user 2>&1 >/dev/null || \
-    useradd -r -g $_group --home-dir /tmp --no-create-home -s /sbin/nologin -c "Confluent Kafka REST proxy" $_user
+    useradd -r -g $_group --home-dir /tmp --no-create-home -s /sbin/nologin -c "Confluent REST proxy" $_user
 
 _permwarn=
 for dir in /var/log/confluent ; do

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-.. Kafka REST Proxy documentation master file, created by
+.. Confluent REST Proxy documentation master file, created by
    sphinx-quickstart on Wed Dec 17 14:17:15 2014.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Kafka REST Proxy
-================
+Confluent REST Proxy
+====================
 
 Contents:
 
@@ -19,6 +19,6 @@ Contents:
    security
 
 
-The Confluent Kafka REST Proxy is available as open source software under the
+The Confluent REST Proxy is available as open source software under the
 `Apache License v2.0 license <http://www.apache.org/licenses/LICENSE-2.0>`_.
 Source code at `https://github.com/confluentinc/kafka-rest <https://github.com/confluentinc/kafka-rest>`_.


### PR DESCRIPTION
Also for [DOCS-684](https://confluentinc.atlassian.net/browse/DOCS-684).