### PR TITLE
MINOR: Add utility createConsumerProperties() test method since it was removed from AK

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -259,10 +260,9 @@ public class TestUtils {
                                                 Decoder<K> keyDecoder, Decoder<V> valueDecoder,
                                                 boolean validateContents) {
     ConsumerConnector consumer = Consumer.createJavaConsumerConnector(
-        new ConsumerConfig(
-            kafka.utils.TestUtils.createConsumerProperties(zkConnect, "testgroup", "consumer0",
-                                                           20000)
-        ));
+        new ConsumerConfig(createConsumerProperties(zkConnect, "testgroup", "consumer0",
+                                                           20000L))
+    );
     Map<String, Integer> topicCountMap = new HashMap<String, Integer>();
     topicCountMap.put(topicName, 1);
     Map<String, List<KafkaStream<K, V>>> streams =
@@ -305,5 +305,24 @@ public class TestUtils {
       }
       assertEquals(refCountCounts, msgCountCounts);
     }
+  }
+
+  /**
+   * Create a test config for a consumer
+   */
+  public static Properties createConsumerProperties(String zkConnect, String groupId, String consumerId,
+                                              Long consumerTimeout) {
+    Properties props = new Properties();
+    props.put("zookeeper.connect", zkConnect);
+    props.put("group.id", groupId);
+    props.put("consumer.id", consumerId);
+    props.put("consumer.timeout.ms", consumerTimeout.toString());
+    props.put("zookeeper.session.timeout.ms", "6000");
+    props.put("zookeeper.sync.time.ms", "200");
+    props.put("auto.commit.interval.ms", "1000");
+    props.put("rebalance.max.retries", "4");
+    props.put("auto.offset.reset", "smallest");
+    props.put("num.consumer.fetchers", "2");
+    return props;
   }
 }


### PR DESCRIPTION
The build that fails:
https://jenkins.confluent.io/job/test-cp-downstream-builds/4143/console

This is due to the `kafka.utils.TestUtils.createConsumerProperties` method being deleted from AK (https://github.com/apache/kafka/commit/7a9631e6349239b2dff3728d9237e6a17aa5ad81).

I am a bit concerned whether this isn't used in other Confluent projects and if we're not better off moving it in a common location, but there's only one way to find out ¯\_(ツ)_/¯

