### PR TITLE
DOCS-630 - Add CCloud link to nav

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,6 +180,7 @@ dependencies as well.
    quickstart
    api
    config
+   ../../cloud/connect/connect-kafka-rest-config
    operations
    security
    changelog


### PR DESCRIPTION
Add connecting to ccloud to nav.

![image](https://user-images.githubusercontent.com/11722533/45187135-8e213180-b1e4-11e8-9e98-b7b2350200be.png)
