### PR TITLE
CPKAFKA-1681: Add long-polling functionality

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -771,6 +771,10 @@ any consumers before it is terminated.
                          defaults to "binary".
    :<json string auto.offset.reset: Sets the ``auto.offset.reset`` setting for the consumer
    :<json string auto.commit.enable: Sets the ``auto.commit.enable`` setting for the consumer
+   :<json string proxy.fetch.min.bytes: Sets the ``proxy.fetch.min.bytes``
+                                                    setting for this consumer specifically
+   :<json string proxy.fetch.max.wait.ms: Sets the ``proxy.fetch.max.wait.ms``
+                                                 setting for this consumer specifically
 
    :>json string instance_id: Unique ID for the consumer instance in this group.
    :>json string base_uri: Base URI used to construct URIs for subsequent requests against this consumer instance. This

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -52,6 +52,9 @@ General
   * Importance: high
 
 ``consumer.request.max.bytes``
+  DEPRECATED: see ``proxy.fetch.max.bytes``
+
+``proxy.fetch.max.bytes``
   Maximum number of bytes in unencoded message keys and values returned by a single request. This can be used by administrators to limit the memory used by a single consumer and to control the memory usage required to decode responses on clients that cannot perform a streaming decode. Note that the actual payload will be larger due to overhead from base64 encoding the response data and from JSON encoding the entire response.
 
   * Type: long
@@ -115,6 +118,21 @@ General
   * Type: int
   * Default: 50
   * Importance: low
+
+
+``proxy.fetch.max.wait.ms``
+  Maximum amount of time the proxy will wait before returning a consumer response. Note that a response will be returned earlier if ``proxy.fetch.min.bytes`` is fulfilled.
+
+  * Type: int
+  * Default: 1000
+  * Importance: medium
+
+``proxy.fetch.min.bytes``
+  Minimum number of bytes in message keys and values returned by a single request before the timeout of `proxy.fetch.max.wait.ms` passes.
+
+  * Type: int
+  * Default: 1000
+  * Importance: medium
 
 ``consumer.iterator.timeout.ms``
   Timeout for blocking consumer iterator operations. This should be set to a small enough value that it is possible to effectively peek() on the iterator.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -156,6 +156,9 @@ Other settings are important to the health and performance of the proxy. You sho
 changing these based on your specific use case.
 
    ``consumer.request.max.bytes``
+     DEPRECATED: See ``proxy.fetch.max.bytes``
+
+   ``proxy.fetch.max.bytes``
      Maximum number of bytes in message keys and values returned by a single request.
      Smaller values reduce the maximum memory used by a single consumer and may be helpful to
      clients that cannot perform a streaming decode of responses, limiting the maximum memory
@@ -171,6 +174,22 @@ changing these based on your specific use case.
 
      * Type: long
      * Default: 67108864
+     * Importance: medium
+
+   ``proxy.fetch.max.wait.ms``
+     The maximum amount of time the proxy will wait before returning a consumer response if
+     there isn't sufficient daa to satisfy the requirement given by ``proxy.fetch.min.bytes``.
+
+     * Type: int
+     * Default: 1000
+     * Importance: medium
+
+   ``proxy.fetch.min.bytes``
+     The minimum number of bytes in message keys and values returned by a single request
+     before the timeout of `proxy.fetch.max.wait.ms` passes.
+
+     * Type: int
+     * Default: 1000
      * Importance: medium
 
    ``consumer.request.timeout.ms``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -178,6 +178,7 @@ dependencies as well.
    quickstart
    api
    config
+   ../../cloud/connect/connect-kafka-rest-config
    operations
    security
    changelog

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerReadTask.java
@@ -50,6 +50,12 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
 
   private ConsumerState parent;
   private final long maxResponseBytes;
+  private final int requestTimeoutMs;
+  // the minimum bytes the task should accumulate
+  // before returning a response (or hitting the timeout)
+  // responseMinBytes might be bigger than maxResponseBytes
+  // in cases where the functionality is disabled
+  private final int responseMinBytes;
   private final ConsumerWorkerReadCallback<ClientKeyT, ClientValueT> callback;
   private CountDownLatch finished;
 
@@ -57,6 +63,8 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
   private ConsumerIterator<KafkaKeyT, KafkaValueT> iter;
   private List<ConsumerRecord<ClientKeyT, ClientValueT>> messages;
   private long bytesConsumed = 0;
+  private boolean exceededMinResponseBytes = false;
+  private boolean willExceedMaxResponseBytes = false;
   private final long started;
 
   // Expiration if this task is waiting, considering both the expiration of the whole task and
@@ -69,15 +77,20 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
       long maxBytes,
       ConsumerWorkerReadCallback<ClientKeyT, ClientValueT> callback
   ) {
+    KafkaRestConfig conf = parent.getConfig();
     this.parent = parent;
     this.maxResponseBytes = Math.min(
         maxBytes,
-        parent.getConfig().getLong(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG)
+        conf.consumerResponseMaxBytes()
     );
     this.callback = callback;
     this.finished = new CountDownLatch(1);
 
-    started = parent.getConfig().getTime().milliseconds();
+    this.requestTimeoutMs = conf.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+    int responseMinBytes = conf.getInt(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG);
+    this.responseMinBytes = responseMinBytes < 0 ? Integer.MAX_VALUE : responseMinBytes;
+
+    started = conf.getTime().milliseconds();
     try {
       topicState = parent.getOrCreateTopicState(topic);
 
@@ -85,6 +98,8 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
       ConsumerReadTask previousTask = topicState.clearFailedTask();
       if (previousTask != null) {
         this.messages = previousTask.messages;
+        this.exceededMinResponseBytes = previousTask.exceededMinResponseBytes;
+        this.willExceedMaxResponseBytes = previousTask.willExceedMaxResponseBytes;
         this.bytesConsumed = previousTask.bytesConsumed;
       }
     } catch (RestException e) {
@@ -112,8 +127,7 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
       long roughMsgSize = 0;
 
       long startedIteration = parent.getConfig().getTime().milliseconds();
-      final int requestTimeoutMs = parent.getConfig().getInt(
-          KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
+
       try {
         // Read off as many messages as we can without triggering a timeout exception. The
         // consumer timeout should be set very small, so the expectation is that even in the
@@ -124,13 +138,18 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
           ConsumerRecordAndSize<ClientKeyT, ClientValueT> recordAndSize =
               parent.createConsumerRecord(msg);
           roughMsgSize = recordAndSize.getSize();
-          if (bytesConsumed + roughMsgSize >= maxResponseBytes) {
+          this.willExceedMaxResponseBytes = bytesConsumed + roughMsgSize >= maxResponseBytes;
+          if (this.willExceedMaxResponseBytes) {
             break;
           }
 
           iter.next();
           messages.add(recordAndSize.getRecord());
           bytesConsumed += roughMsgSize;
+          this.exceededMinResponseBytes = bytesConsumed > responseMinBytes;
+          if (this.exceededMinResponseBytes) {
+            break;
+          }
           // Updating the consumed offsets isn't done until we're actually going to return the
           // data since we may encounter an error during a subsequent read, in which case we'll
           // have to defer returning the data so we can return an HTTP error instead
@@ -154,17 +173,16 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
       int itbackoff
           = parent.getConfig().getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG);
       long backoffExpiration = startedIteration + itbackoff;
-      long requestExpiration =
-          started + parent.getConfig().getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
+      long requestExpiration = started + requestTimeoutMs;
       waitExpiration = Math.min(backoffExpiration, requestExpiration);
 
       // Including the rough message size here ensures processing finishes if the next
       // message exceeds the maxResponseBytes
       boolean requestTimedOut = elapsed >= requestTimeoutMs;
-      boolean exceededMaxResponseBytes = bytesConsumed + roughMsgSize >= maxResponseBytes;
-      if (requestTimedOut || exceededMaxResponseBytes) {
-        log.trace("Finishing ConsumerReadTask id={} requestTimedOut={} exceededMaxResponseBytes={}",
-                  this, requestTimedOut, exceededMaxResponseBytes
+      if (requestTimedOut || willExceedMaxResponseBytes || exceededMinResponseBytes) {
+        log.trace("Finishing ConsumerReadTask id={} requestTimedOut={} "
+                  + "willExceedMaxResponseBytes={} exceededMinResponseBytes={}",
+                  this, requestTimedOut, willExceedMaxResponseBytes, this.exceededMinResponseBytes
         );
         finish();
       }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
@@ -18,6 +18,7 @@ package io.confluent.kafkarest;
 
 import org.apache.avro.SchemaParseException;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.RetriableException;
 
 import javax.ws.rs.core.Response;
@@ -156,6 +157,15 @@ public class Errors {
 
   public static RestConstraintViolationException invalidConsumerConfigException(
       InvalidConfigException e
+  ) {
+    return new RestConstraintViolationException(
+        INVALID_CONSUMER_CONFIG_MESSAGE + e.getMessage(),
+        INVALID_CONSUMER_CONFIG_ERROR_CODE
+    );
+  }
+
+  public static RestConstraintViolationException invalidConsumerConfigException(
+          ConfigException e
   ) {
     return new RestConstraintViolationException(
         INVALID_CONSUMER_CONFIG_MESSAGE + e.getMessage(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -19,6 +19,7 @@ package io.confluent.kafkarest.v2;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,34 +200,18 @@ public class KafkaConsumerManager {
           );
       }
 
-      Consumer consumer = null;
+      Consumer consumer;
       try {
         if (consumerFactory == null) {
           consumer = new KafkaConsumer(props);
         } else {
           consumer = consumerFactory.createConsumer(props);
         }
-      } catch (Exception e) {
-        log.debug("ignoring this", e);
+      } catch (ConfigException e) {
+        throw Errors.invalidConsumerConfigException(e);
       }
 
-      KafkaConsumerState state = null;
-      switch (instanceConfig.getFormat()) {
-        case BINARY:
-          state = new BinaryKafkaConsumerState(this.config, cid, consumer);
-          break;
-        case AVRO:
-          state = new AvroKafkaConsumerState(this.config, cid, consumer);
-          break;
-        case JSON:
-          state = new JsonKafkaConsumerState(this.config, cid, consumer);
-          break;
-        default:
-          throw new RestServerErrorException(
-              "Invalid embedded format for new consumer.",
-              Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()
-          );
-      }
+      KafkaConsumerState state = createConsumerState(instanceConfig, cid, consumer);
       synchronized (this) {
         consumers.put(cid, state);
         consumersByExpiration.add(state);
@@ -241,6 +226,44 @@ public class KafkaConsumerManager {
         }
       }
     }
+  }
+
+  private KafkaConsumerState createConsumerState(
+          ConsumerInstanceConfig instanceConfig,
+          ConsumerInstanceId cid, Consumer consumer
+  ) throws RestServerErrorException {
+    Properties newProps = ConsumerInstanceConfig.attachProxySpecificProperties(
+            (Properties) this.config.getOriginalProperties().clone(), instanceConfig);
+
+    KafkaRestConfig newConfig;
+    try {
+      newConfig = new KafkaRestConfig(newProps, this.config.getTime());
+    } catch (io.confluent.rest.RestConfigException e) {
+      throw new RestServerErrorException(
+              "Invalid configuration for new consumer.",
+              Response.Status.BAD_REQUEST.getStatusCode()
+      );
+    }
+
+    KafkaConsumerState state;
+    switch (instanceConfig.getFormat()) {
+      case BINARY:
+        state = new BinaryKafkaConsumerState(newConfig, cid, consumer);
+        break;
+      case AVRO:
+        state = new AvroKafkaConsumerState(newConfig, cid, consumer);
+        break;
+      case JSON:
+        state = new JsonKafkaConsumerState(newConfig, cid, consumer);
+        break;
+      default:
+        throw new RestServerErrorException(
+                "Invalid embedded format for new consumer.",
+                Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()
+        );
+    }
+
+    return state;
   }
 
   public interface ReadCallback<K, V> {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -410,23 +410,27 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
   }
 
   public ConsumerRecord<KafkaKeyT, KafkaValueT> peek() {
-    if (hasNext()) {
+    if (hasNextWithPoll()) {
       return consumerRecordList.get(this.index);
     }
     return null;
   }
 
-  public boolean hasNext() {
-    if (consumerRecordList != null && this.index < consumerRecordList.size()) {
+  public boolean hasNextWithPoll() {
+    if (hasNext()) {
       return true;
     }
     // If none are available, try checking for any records already fetched by the consumer.
     getOrCreateConsumerRecords();
+    return hasNext();
+  }
+
+  public boolean hasNext() {
     return consumerRecordList != null && this.index < consumerRecordList.size();
   }
 
   public ConsumerRecord<KafkaKeyT, KafkaValueT> next() {
-    if (hasNext()) {
+    if (hasNextWithPoll()) {
       ConsumerRecord<KafkaKeyT, KafkaValueT> record = consumerRecordList.get(index);
       this.index = this.index + 1;
       return record;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -123,7 +123,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     ConsumerInstanceConfig config = null;
     if (id != null || name != null || format != null) {
       config = new ConsumerInstanceConfig(
-          id, name, (format != null ? format.toString() : null), null, null);
+          id, name, (format != null ? format.toString() : null), null, null, null, null);
     }
     return request("/consumers/" + groupName)
         .post(Entity.entity(config, Versions.KAFKA_MOST_SPECIFIC_DEFAULT));
@@ -289,7 +289,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     // request timeout, the iterator timeout used for "peeking", and the backoff period, as well
     // as some extra slack for general overhead (which apparently mostly comes from running the
     // request and can be quite substantial).
-    final int TIMEOUT = restConfig.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
+    final int TIMEOUT = restConfig.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
     final int TIMEOUT_SLACK =
         restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG)
         + restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG) + 500;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
@@ -155,7 +155,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testInvalidKafkaConsumerConfig() {
     ConsumerInstanceConfig config = new ConsumerInstanceConfig("id", "name", "binary",
-                                                               "bad-config", null);
+                                                               "bad-config", null, null, null);
     Response response = request("/consumers/" + groupName)
         .post(Entity.entity(config, Versions.KAFKA_V1_JSON));
     assertErrorResponse(ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY, response,


### PR DESCRIPTION
This PR enables long-polling in V1 and V2 APIs of the REST proxy.

Previously, consumer.request.timeout.ms would control when the proxy sent back a response to the user. The default value was 1000ms, but setting it explicitly to 1000 (or 2000) would cause it to be passed to the underlying consumer connection. This caused a NullPointerException, most likely because configuration exceptions were ignored in the V2 API. This PR removes the consumer.request.timeout.ms functionality of controlling when the proxy returns a response.

Adds new config settings:
* proxy.fetch.max.wait.ms - time before a consumer response is sent back when neither min or max bytes are fulfilled
* proxy.fetch.min.bytes - amount of bytes of records the proxy will collect before immediately returning a response. In the V2 API, the proxy will exhaust all already-loaded records when it hits that threshold.
* deprecate consumer.request.max.bytes and introduce proxy.fetch.max.bytes - same config but renamed. If proxy.fetch.max.bytes is explicitly defined it will override the set consumer.request.max.bytes
* proxy.fetch.max.wait.ms and proxy.fetch.min.bytes are configurable per consumer as well as globally
These new settings control how the user->proxy connection, not the underlying consumer->broker.

Now also raises exceptions and returns proper 4xx response when V2 Consumer settings are invalid.