### PR TITLE
Fix SimpleConsumerManager properly return requested offsets for compressed topic

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/SimpleConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/SimpleConsumerManager.java
@@ -164,6 +164,12 @@ public class SimpleConsumerManager {
         }
 
         for (final MessageAndOffset messageAndOffset : messageAndOffsets) {
+
+          // while the offset is less than the requested offset continue
+          if (messageAndOffset.offset() < offset) {
+            continue;
+          }
+
           records.add(createConsumerRecord(
               messageAndOffset,
               topicName,


### PR DESCRIPTION
Fixed bug where the API would return the incorrect offset when specific offset was requested and the topic was compressed. The SimpleConsumerManager assumed the first offset in the returned MessageSet was the requested offset, this is not necessarily the case with compressed formats.

See bug #475 