### PR TITLE
CPKAFKA-1681:  Add long polling functionality

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
 
     <suppress
             checks="(CyclomaticComplexity)"
-            files="(AvroConverter|AvroRestProducer|ConsumerInstanceConfig|ConsumerManager|KafkaConsumerManager|PartitionOffset|KafkaRestContextProvider).java"
+            files="(AvroConverter|AvroRestProducer|ConsumerInstanceConfig|ConsumerManager|ConsumerReadTask|KafkaConsumerManager|PartitionOffset|KafkaRestContextProvider).java"
     />
 
     <suppress

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -772,8 +772,10 @@ any consumers before it is terminated.
    :<json string auto.commit.enable: Sets the ``auto.commit.enable`` setting for the consumer
    :<json string fetch.min.bytes: Sets the ``fetch.min.bytes``
                                                     setting for this consumer specifically
-   :<json string fetch.max.wait.ms: Sets the ``fetch.max.wait.ms``
-                                                 setting for this consumer specifically
+   :<json string consumer.request.timeout.ms: Sets the ``consumer.request.timeout.ms`` setting for this consumer specifically.
+                                              This setting controls the maximum total time to wait for messages for a request
+                                              if the maximum request size has not yet been reached.
+                                              It does not affect the underlying consumer->broker connection  
 
    :>json string instance_id: Unique ID for the consumer instance in this group.
    :>json string base_uri: Base URI used to construct URIs for subsequent requests against this consumer instance. This

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -770,6 +770,10 @@ any consumers before it is terminated.
                          defaults to "binary".
    :<json string auto.offset.reset: Sets the ``auto.offset.reset`` setting for the consumer
    :<json string auto.commit.enable: Sets the ``auto.commit.enable`` setting for the consumer
+   :<json string fetch.min.bytes: Sets the ``fetch.min.bytes``
+                                                    setting for this consumer specifically
+   :<json string fetch.max.wait.ms: Sets the ``fetch.max.wait.ms``
+                                                 setting for this consumer specifically
 
    :>json string instance_id: Unique ID for the consumer instance in this group.
    :>json string base_uri: Base URI used to construct URIs for subsequent requests against this consumer instance. This

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -46,6 +46,9 @@ Java Kafka clients.
   * Importance: high
 
 ``consumer.request.max.bytes``
+  DEPRECATED: see ``fetch.max.bytes``
+
+``fetch.max.bytes``
   Maximum number of bytes in unencoded message keys and values returned by a single request. This can be used by administrators to limit the memory used by a single consumer and to control the memory usage required to decode responses on clients that cannot perform a streaming decode. Note that the actual payload will be larger due to overhead from base64 encoding the response data and from JSON encoding the entire response.
 
   * Type: long
@@ -60,6 +63,7 @@ Java Kafka clients.
   * Importance: medium
 
 ``consumer.request.timeout.ms``
+  DEPRECATED: see ``fetch.max.wait.ms``
   The maximum total time to wait for messages for a request if the maximum number of messages has not yet been reached.
 
   * Type: int
@@ -109,6 +113,21 @@ Java Kafka clients.
   * Type: int
   * Default: 50
   * Importance: low
+
+
+``fetch.max.wait.ms``
+  Maximum amount of time the proxy will wait before returning a consumer response. Note that a response will be returned earlier if ``fetch.min.bytes`` is fulfilled.
+
+  * Type: int
+  * Default: 1000
+  * Importance: medium
+
+``fetch.min.bytes``
+  Minimum number of bytes in message keys and values returned by a single request before the timeout of `fetch.max.wait.ms` passes.
+
+  * Type: int
+  * Default: 1000
+  * Importance: medium
 
 ``consumer.iterator.timeout.ms``
   Timeout for blocking consumer iterator operations. This should be set to a small enough value that it is possible to effectively peek() on the iterator.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -46,9 +46,6 @@ Java Kafka clients.
   * Importance: high
 
 ``consumer.request.max.bytes``
-  DEPRECATED: see ``fetch.max.bytes``
-
-``fetch.max.bytes``
   Maximum number of bytes in unencoded message keys and values returned by a single request. This can be used by administrators to limit the memory used by a single consumer and to control the memory usage required to decode responses on clients that cannot perform a streaming decode. Note that the actual payload will be larger due to overhead from base64 encoding the response data and from JSON encoding the entire response.
 
   * Type: long
@@ -63,7 +60,6 @@ Java Kafka clients.
   * Importance: medium
 
 ``consumer.request.timeout.ms``
-  DEPRECATED: see ``fetch.max.wait.ms``
   The maximum total time to wait for messages for a request if the maximum number of messages has not yet been reached.
 
   * Type: int
@@ -114,19 +110,12 @@ Java Kafka clients.
   * Default: 50
   * Importance: low
 
-
-``fetch.max.wait.ms``
-  Maximum amount of time the proxy will wait before returning a consumer response. Note that a response will be returned earlier if ``fetch.min.bytes`` is fulfilled.
-
-  * Type: int
-  * Default: 1000
-  * Importance: medium
-
 ``fetch.min.bytes``
-  Minimum number of bytes in message keys and values returned by a single request before the timeout of `fetch.max.wait.ms` passes.
+  Minimum number of bytes in message keys and values returned by a single request before the timeout of `consumer.request.timeout.ms` passes.
+  The special sentinel value of -1 disables this functionality.
 
   * Type: int
-  * Default: 1000
+  * Default: -1
   * Importance: medium
 
 ``consumer.iterator.timeout.ms``

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -178,7 +178,7 @@ changing these based on your specific use case.
      before the timeout of `consumer.request.timeout.ms` passes.
 
      * Type: int
-     * Default: the value of `consumer.request.max.bytes`
+     * Default: -1
      * Importance: medium
 
    ``consumer.request.timeout.ms``

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -156,9 +156,6 @@ Other settings are important to the health and performance of the proxy. You sho
 changing these based on your specific use case.
 
    ``consumer.request.max.bytes``
-     DEPRECATED: See ``fetch.max.bytes``
-
-   ``fetch.max.bytes``
      Maximum number of bytes in message keys and values returned by a single request.
      Smaller values reduce the maximum memory used by a single consumer and may be helpful to
      clients that cannot perform a streaming decode of responses, limiting the maximum memory
@@ -176,24 +173,15 @@ changing these based on your specific use case.
      * Default: 67108864
      * Importance: medium
 
-   ``fetch.max.wait.ms``
-     The maximum amount of time the proxy will wait before returning a consumer response if
-     there isn't sufficient daa to satisfy the requirement given by ``fetch.min.bytes``.
-
-     * Type: int
-     * Default: 1000
-     * Importance: medium
-
    ``fetch.min.bytes``
      The minimum number of bytes in message keys and values returned by a single request
-     before the timeout of `fetch.max.wait.ms` passes.
+     before the timeout of `consumer.request.timeout.ms` passes.
 
      * Type: int
-     * Default: 1000
+     * Default: the value of `consumer.request.max.bytes`
      * Importance: medium
 
    ``consumer.request.timeout.ms``
-     DEPRECATED: see ``fetch.max.wait.ms``
      The maximum total time to wait for messages for a request if the maximum request size has
      not yet been reached. The consumer uses a timeout to enable batching. A larger value will
      allow the consumer to wait longer, possibly including more messages in the response.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -156,6 +156,9 @@ Other settings are important to the health and performance of the proxy. You sho
 changing these based on your specific use case.
 
    ``consumer.request.max.bytes``
+     DEPRECATED: See ``fetch.max.bytes``
+
+   ``fetch.max.bytes``
      Maximum number of bytes in message keys and values returned by a single request.
      Smaller values reduce the maximum memory used by a single consumer and may be helpful to
      clients that cannot perform a streaming decode of responses, limiting the maximum memory
@@ -173,7 +176,24 @@ changing these based on your specific use case.
      * Default: 67108864
      * Importance: medium
 
+   ``fetch.max.wait.ms``
+     The maximum amount of time the proxy will wait before returning a consumer response if
+     there isn't sufficient daa to satisfy the requirement given by ``fetch.min.bytes``.
+
+     * Type: int
+     * Default: 1000
+     * Importance: medium
+
+   ``fetch.min.bytes``
+     The minimum number of bytes in message keys and values returned by a single request
+     before the timeout of `fetch.max.wait.ms` passes.
+
+     * Type: int
+     * Default: 1000
+     * Importance: medium
+
    ``consumer.request.timeout.ms``
+     DEPRECATED: see ``fetch.max.wait.ms``
      The maximum total time to wait for messages for a request if the maximum request size has
      not yet been reached. The consumer uses a timeout to enable batching. A larger value will
      allow the consumer to wait longer, possibly including more messages in the response.

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -391,7 +391,7 @@ public class ConsumerManager {
       this.started = config.getTime().milliseconds();
       this.consumerConfig = taskState.consumerState.getConfig();
       this.requestExpiration = this.started
-          + consumerConfig.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+          + consumerConfig.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
       this.waitExpirationMs = 0;
     }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerReadTask.java
@@ -77,12 +77,12 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
     this.parent = parent;
     this.maxResponseBytes = Math.min(
         maxBytes,
-        conf.consumerResponseMaxBytes()
+        conf.getLong(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG)
     );
     this.callback = callback;
     this.finished = new CountDownLatch(1);
 
-    this.requestTimeoutMs = conf.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+    this.requestTimeoutMs = conf.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
     int responseMinBytes = conf.getInt(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG);
     this.responseMinBytes = responseMinBytes < 0 ? Integer.MAX_VALUE : responseMinBytes;
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
@@ -18,6 +18,7 @@ package io.confluent.kafkarest;
 
 import org.apache.avro.SchemaParseException;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.RetriableException;
 
 import javax.ws.rs.core.Response;
@@ -156,6 +157,15 @@ public class Errors {
 
   public static RestConstraintViolationException invalidConsumerConfigException(
       InvalidConfigException e
+  ) {
+    return new RestConstraintViolationException(
+        INVALID_CONSUMER_CONFIG_MESSAGE + e.getMessage(),
+        INVALID_CONSUMER_CONFIG_ERROR_CODE
+    );
+  }
+
+  public static RestConstraintViolationException invalidConsumerConfigException(
+          ConfigException e
   ) {
     return new RestConstraintViolationException(
         INVALID_CONSUMER_CONFIG_MESSAGE + e.getMessage(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
@@ -173,6 +173,19 @@ public class Errors {
     );
   }
 
+  public static final String INVALID_CONSUMER_CONFIG_CONSTRAINT_MESSAGE =
+      "Invalid consumer configuration. It does not abide by the constraints: ";
+  public static final int INVALID_CONSUMER_CONFIG_CONSTAINT_ERROR_CODE = 40001;
+
+  public static RestConstraintViolationException invalidConsumerConfigConstraintException(
+      io.confluent.common.config.ConfigException e
+  ) {
+    return new RestConstraintViolationException(
+        INVALID_CONSUMER_CONFIG_CONSTRAINT_MESSAGE + e.getMessage(),
+        INVALID_CONSUMER_CONFIG_CONSTAINT_ERROR_CODE
+    );
+  }
+
   public static final String INVALID_SCHEMA_MESSAGE = "Invalid schema: ";
   public static final int INVALID_SCHEMA_ERROR_CODE = 42205;
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -118,17 +118,6 @@ public class KafkaRestConfig extends RestConfig {
       "The base URL for the schema registry that should be used by the Avro serializer.";
   private static final String SCHEMA_REGISTRY_URL_DEFAULT = "http://localhost:8081";
 
-  public static final String PROXY_FETCH_MAX_WAIT_MS_CONFIG =
-          "fetch.max.wait.ms";
-  private static final String PROXY_FETCH_MAX_WAIT_MS_DOC =
-          "The maximum amount of time the proxy will wait before returning a consumer response if"
-          + " there isn't sufficient data to satisfy the requirement given by"
-          + "fetch.min.bytes";
-  public static final String PROXY_FETCH_MAX_WAIT_MS_DEFAULT = "1000";
-  private static final int PROXY_FETCH_MAX_WAIT_MS_MAX = 60000;
-  public static final ConfigDef.Range PROXY_FETCH_MAX_WAIT_MS_VALIDATOR =
-          ConfigDef.Range.between(1, PROXY_FETCH_MAX_WAIT_MS_MAX);
-
   public static final String PROXY_FETCH_MIN_BYTES_CONFIG =
           "fetch.min.bytes";
   private static final String PROXY_FETCH_MIN_BYTES_DOC =
@@ -137,7 +126,7 @@ public class KafkaRestConfig extends RestConfig {
           + "The special sentinel value of -1 disables this functionality.";
   private static final String PROXY_FETCH_MIN_BYTES_DEFAULT = "-1";
   private static final int PROXY_FETCH_MIN_BYTES_MAX = 10000000; // 10mb
-  public static final ConfigDef.Range PROXY_CONSUMER_RESPONSE_MIN_BYTES_VALIDATOR =
+  public static final ConfigDef.Range PROXY_FETCH_MIN_BYTES_VALIDATOR =
           ConfigDef.Range.between(-1, PROXY_FETCH_MIN_BYTES_MAX);
 
   public static final String PRODUCER_THREADS_CONFIG = "producer.threads";
@@ -168,31 +157,15 @@ public class KafkaRestConfig extends RestConfig {
       + "request if the maximum number of messages has not yet been reached.";
   public static final String CONSUMER_REQUEST_TIMEOUT_MS_DEFAULT = "1000";
 
-  @Deprecated
   public static final String CONSUMER_REQUEST_MAX_BYTES_CONFIG = "consumer.request.max.bytes";
-  @Deprecated
   private static final String CONSUMER_REQUEST_MAX_BYTES_DOC =
-      "DEPRECATED: Maximum number of bytes in unencoded message keys and values returned "
-      + "by a single request. This can be used by administrators to limit the memory used "
-      + "by a single consumer and to control the memory usage required to decode responses"
-      + "on clients that cannot perform a streaming decode. "
-      + "Note that the actual payload will be larger due to overhead from base64 encoding the "
-      + "response data and from JSON encoding the entire response.";
-  @Deprecated
-  public static final long CONSUMER_REQUEST_MAX_BYTES_DEFAULT = 64 * 1024 * 1024;
-
-  public static final String PROXY_FETCH_MAX_BYTES_CONFIG =
-          "fetch.max.bytes";
-  private static final String PROXY_FETCH_MAX_BYTES_CONFIG_DOC =
       "Maximum number of bytes in unencoded message keys and values returned "
       + "by a single request. This can be used by administrators to limit the memory used "
       + "by a single consumer and to control the memory usage required to decode responses"
       + "on clients that cannot perform a streaming decode. "
       + "Note that the actual payload will be larger due to overhead from base64 encoding the "
       + "response data and from JSON encoding the entire response.";
-  public static final long PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT = 64 * 1024 * 1024;
-  // keep placeholder for default value until consumer.request.max.bytes support is removed
-  public static final long PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT_PLACEHOLDER = -1;
+  public static final long CONSUMER_REQUEST_MAX_BYTES_DEFAULT = 64 * 1024 * 1024;
 
   public static final String CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG = "consumer.instance.timeout.ms";
   private static final String CONSUMER_INSTANCE_TIMEOUT_MS_DOC =
@@ -417,18 +390,10 @@ public class KafkaRestConfig extends RestConfig {
             SCHEMA_REGISTRY_URL_DOC
         )
         .define(
-            PROXY_FETCH_MAX_WAIT_MS_CONFIG,
-            Type.INT,
-            PROXY_FETCH_MAX_WAIT_MS_DEFAULT,
-            PROXY_FETCH_MAX_WAIT_MS_VALIDATOR,
-            Importance.MEDIUM,
-            PROXY_FETCH_MAX_WAIT_MS_DOC
-        )
-        .define(
             PROXY_FETCH_MIN_BYTES_CONFIG,
             Type.INT,
             PROXY_FETCH_MIN_BYTES_DEFAULT,
-            PROXY_CONSUMER_RESPONSE_MIN_BYTES_VALIDATOR,
+                PROXY_FETCH_MIN_BYTES_VALIDATOR,
             Importance.LOW,
             PROXY_FETCH_MIN_BYTES_DOC
         )
@@ -466,13 +431,6 @@ public class KafkaRestConfig extends RestConfig {
             CONSUMER_REQUEST_MAX_BYTES_DEFAULT,
             Importance.MEDIUM,
             CONSUMER_REQUEST_MAX_BYTES_DOC
-        )
-        .define(
-            PROXY_FETCH_MAX_BYTES_CONFIG,
-            Type.LONG,
-            PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT_PLACEHOLDER,
-            Importance.MEDIUM,
-            PROXY_FETCH_MAX_BYTES_CONFIG_DOC
         )
         .define(
             CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG,
@@ -819,19 +777,6 @@ public class KafkaRestConfig extends RestConfig {
       }
     }
     return bootstrapBrokers;
-  }
-
-  /**
-   * fetch.max.bytes takes precedence over the deprecated consumer.request.max.bytes
-   */
-  public Long consumerResponseMaxBytes() {
-    long maxBytes = getLong(PROXY_FETCH_MAX_BYTES_CONFIG);
-    if (maxBytes == PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT_PLACEHOLDER) {
-      // new config is undefined, use old config
-      maxBytes = getLong(CONSUMER_REQUEST_MAX_BYTES_CONFIG);
-    }
-
-    return maxBytes;
   }
 
   public static void main(String[] args) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -118,6 +118,28 @@ public class KafkaRestConfig extends RestConfig {
       "The base URL for the schema registry that should be used by the Avro serializer.";
   private static final String SCHEMA_REGISTRY_URL_DEFAULT = "http://localhost:8081";
 
+  public static final String PROXY_FETCH_MAX_WAIT_MS_CONFIG =
+          "fetch.max.wait.ms";
+  private static final String PROXY_FETCH_MAX_WAIT_MS_DOC =
+          "The maximum amount of time the proxy will wait before returning a consumer response if"
+          + " there isn't sufficient data to satisfy the requirement given by"
+          + "fetch.min.bytes";
+  public static final String PROXY_FETCH_MAX_WAIT_MS_DEFAULT = "1000";
+  private static final int PROXY_FETCH_MAX_WAIT_MS_MAX = 10000;
+  public static final ConfigDef.Range PROXY_FETCH_MAX_WAIT_MS_VALIDATOR =
+          ConfigDef.Range.between(1, PROXY_FETCH_MAX_WAIT_MS_MAX);
+
+  public static final String PROXY_FETCH_MIN_BYTES_CONFIG =
+          "fetch.min.bytes";
+  private static final String PROXY_FETCH_MIN_BYTES_DOC =
+          "Minimum bytes of records for the proxy to accumulate before"
+          + "returning a response to a consumer request. "
+          + "The special sentinel value of -1 disables this functionality.";
+  private static final String PROXY_FETCH_MIN_BYTES_DEFAULT = "-1";
+  private static final int PROXY_FETCH_MIN_BYTES_MAX = 10000000; // 10mb
+  public static final ConfigDef.Range PROXY_CONSUMER_RESPONSE_MIN_BYTES_VALIDATOR =
+          ConfigDef.Range.between(-1, PROXY_FETCH_MIN_BYTES_MAX);
+
   public static final String PRODUCER_THREADS_CONFIG = "producer.threads";
   private static final String PRODUCER_THREADS_DOC =
       "Number of threads to run produce requests on.";
@@ -146,15 +168,31 @@ public class KafkaRestConfig extends RestConfig {
       + "request if the maximum number of messages has not yet been reached.";
   public static final String CONSUMER_REQUEST_TIMEOUT_MS_DEFAULT = "1000";
 
+  @Deprecated
   public static final String CONSUMER_REQUEST_MAX_BYTES_CONFIG = "consumer.request.max.bytes";
+  @Deprecated
   private static final String CONSUMER_REQUEST_MAX_BYTES_DOC =
-      "Maximum number of bytes in unencoded message keys and values returned by a single "
-      + "request. This can be used by administrators to limit the memory used by a single "
-      + "consumer and to control the memory usage required to decode responses on clients that "
-      + "cannot perform a streaming decode. Note that the actual payload will be larger due to "
-      + "overhead from base64 encoding the response data and from JSON encoding the entire "
-      + "response.";
+      "DEPRECATED: Maximum number of bytes in unencoded message keys and values returned "
+      + "by a single request. This can be used by administrators to limit the memory used "
+      + "by a single consumer and to control the memory usage required to decode responses"
+      + "on clients that cannot perform a streaming decode. "
+      + "Note that the actual payload will be larger due to overhead from base64 encoding the "
+      + "response data and from JSON encoding the entire response.";
+  @Deprecated
   public static final long CONSUMER_REQUEST_MAX_BYTES_DEFAULT = 64 * 1024 * 1024;
+
+  public static final String PROXY_FETCH_MAX_BYTES_CONFIG =
+          "fetch.max.bytes";
+  private static final String PROXY_FETCH_MAX_BYTES_CONFIG_DOC =
+      "Maximum number of bytes in unencoded message keys and values returned "
+      + "by a single request. This can be used by administrators to limit the memory used "
+      + "by a single consumer and to control the memory usage required to decode responses"
+      + "on clients that cannot perform a streaming decode. "
+      + "Note that the actual payload will be larger due to overhead from base64 encoding the "
+      + "response data and from JSON encoding the entire response.";
+  public static final long PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT = 64 * 1024 * 1024;
+  // keep placeholder for default value until consumer.request.max.bytes support is removed
+  public static final long PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT_PLACEHOLDER = -1;
 
   public static final String CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG = "consumer.instance.timeout.ms";
   private static final String CONSUMER_INSTANCE_TIMEOUT_MS_DOC =
@@ -379,6 +417,22 @@ public class KafkaRestConfig extends RestConfig {
             SCHEMA_REGISTRY_URL_DOC
         )
         .define(
+            PROXY_FETCH_MAX_WAIT_MS_CONFIG,
+            Type.INT,
+            PROXY_FETCH_MAX_WAIT_MS_DEFAULT,
+            PROXY_FETCH_MAX_WAIT_MS_VALIDATOR,
+            Importance.MEDIUM,
+            PROXY_FETCH_MAX_WAIT_MS_DOC
+        )
+        .define(
+            PROXY_FETCH_MIN_BYTES_CONFIG,
+            Type.INT,
+            PROXY_FETCH_MIN_BYTES_DEFAULT,
+            PROXY_CONSUMER_RESPONSE_MIN_BYTES_VALIDATOR,
+            Importance.LOW,
+            PROXY_FETCH_MIN_BYTES_DOC
+        )
+        .define(
             PRODUCER_THREADS_CONFIG,
             Type.INT,
             PRODUCER_THREADS_DEFAULT,
@@ -412,6 +466,13 @@ public class KafkaRestConfig extends RestConfig {
             CONSUMER_REQUEST_MAX_BYTES_DEFAULT,
             Importance.MEDIUM,
             CONSUMER_REQUEST_MAX_BYTES_DOC
+        )
+        .define(
+            PROXY_FETCH_MAX_BYTES_CONFIG,
+            Type.LONG,
+            PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT_PLACEHOLDER,
+            Importance.MEDIUM,
+            PROXY_FETCH_MAX_BYTES_CONFIG_DOC
         )
         .define(
             CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG,
@@ -758,6 +819,19 @@ public class KafkaRestConfig extends RestConfig {
       }
     }
     return bootstrapBrokers;
+  }
+
+  /**
+   * fetch.max.bytes takes precedence over the deprecated consumer.request.max.bytes
+   */
+  public Long consumerResponseMaxBytes() {
+    long maxBytes = getLong(PROXY_FETCH_MAX_BYTES_CONFIG);
+    if (maxBytes == PROXY_FETCH_MAX_BYTES_CONFIG_DEFAULT_PLACEHOLDER) {
+      // new config is undefined, use old config
+      maxBytes = getLong(CONSUMER_REQUEST_MAX_BYTES_CONFIG);
+    }
+
+    return maxBytes;
   }
 
   public static void main(String[] args) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -125,7 +125,7 @@ public class KafkaRestConfig extends RestConfig {
           + " there isn't sufficient data to satisfy the requirement given by"
           + "fetch.min.bytes";
   public static final String PROXY_FETCH_MAX_WAIT_MS_DEFAULT = "1000";
-  private static final int PROXY_FETCH_MAX_WAIT_MS_MAX = 10000;
+  private static final int PROXY_FETCH_MAX_WAIT_MS_MAX = 60000;
   public static final ConfigDef.Range PROXY_FETCH_MAX_WAIT_MS_VALIDATOR =
           ConfigDef.Range.between(1, PROXY_FETCH_MAX_WAIT_MS_MAX);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
@@ -57,7 +57,7 @@ public class ConsumerInstanceConfig {
       @JsonProperty("auto.commit.enable") String autoCommitEnable,
       @JsonProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG)
               Integer responseMinBytes,
-      @JsonProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG) Integer requestWaitMs
+      @JsonProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG) Integer requestWaitMs
   ) {
     this.id = id;
     this.name = name;
@@ -79,7 +79,7 @@ public class ConsumerInstanceConfig {
       }
     }
     this.setResponseMinBytes(responseMinBytes);
-    this.setRequestWaitMs(requestWaitMs);
+    this.requestWaitMs = requestWaitMs;
     this.autoOffsetReset = autoOffsetReset;
     this.autoCommitEnable = autoCommitEnable;
   }
@@ -94,7 +94,7 @@ public class ConsumerInstanceConfig {
               config.getResponseMinBytes().toString());
     }
     if (config.getRequestWaitMs() != null) {
-      props.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG,
+      props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG,
               config.getRequestWaitMs().toString());
     }
 
@@ -130,7 +130,7 @@ public class ConsumerInstanceConfig {
     }
 
     try {
-      KafkaRestConfig.PROXY_CONSUMER_RESPONSE_MIN_BYTES_VALIDATOR.ensureValid(
+      KafkaRestConfig.PROXY_FETCH_MIN_BYTES_VALIDATOR.ensureValid(
               KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG,
               responseMinBytes
       );
@@ -143,24 +143,6 @@ public class ConsumerInstanceConfig {
   @JsonProperty
   public Integer getRequestWaitMs() {
     return this.requestWaitMs;
-  }
-
-  @JsonProperty
-  public void setRequestWaitMs(Integer requestWaitMs) throws RestConstraintViolationException {
-    if (requestWaitMs == null) {
-      this.requestWaitMs = null;
-      return;
-    }
-
-    try {
-      KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_VALIDATOR.ensureValid(
-              KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG,
-              requestWaitMs
-      );
-      this.requestWaitMs = requestWaitMs;
-    } catch (io.confluent.common.config.ConfigException e) {
-      throw Errors.invalidConsumerConfigConstraintException(e);
-    }
   }
 
   @JsonProperty

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.Response;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
 
@@ -56,8 +56,8 @@ public class ConsumerInstanceConfig {
       @JsonProperty("auto.offset.reset") String autoOffsetReset,
       @JsonProperty("auto.commit.enable") String autoCommitEnable,
       @JsonProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG)
-              String responseMinBytes,
-      @JsonProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG) String requestWaitMs
+              Integer responseMinBytes,
+      @JsonProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG) Integer requestWaitMs
   ) {
     this.id = id;
     this.name = name;
@@ -122,28 +122,21 @@ public class ConsumerInstanceConfig {
   }
 
   @JsonProperty
-  public void setResponseMinBytes(String responseMinBytes) throws RestConstraintViolationException {
+  public void setResponseMinBytes(Integer responseMinBytes)
+      throws RestConstraintViolationException {
     if (responseMinBytes == null) {
       this.responseMinBytes = null;
       return;
     }
 
     try {
-      this.responseMinBytes = Integer.parseInt(responseMinBytes);
       KafkaRestConfig.PROXY_CONSUMER_RESPONSE_MIN_BYTES_VALIDATOR.ensureValid(
               KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG,
-              this.responseMinBytes
+              responseMinBytes
       );
+      this.responseMinBytes = responseMinBytes;
     } catch (io.confluent.common.config.ConfigException e) {
-      throw new RestConstraintViolationException(
-              e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()
-      );
-    } catch (NumberFormatException e) {
-      throw new RestConstraintViolationException(
-              String.format("Invalid value for configuration %s: must be an integer",
-                      responseMinBytes,
-                      KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG),
-              Response.Status.BAD_REQUEST.getStatusCode());
+      throw Errors.invalidConsumerConfigConstraintException(e);
     }
   }
 
@@ -153,28 +146,20 @@ public class ConsumerInstanceConfig {
   }
 
   @JsonProperty
-  public void setRequestWaitMs(String requestWaitMs) throws RestConstraintViolationException {
+  public void setRequestWaitMs(Integer requestWaitMs) throws RestConstraintViolationException {
     if (requestWaitMs == null) {
       this.requestWaitMs = null;
       return;
     }
 
     try {
-      this.requestWaitMs = Integer.parseInt(requestWaitMs);
       KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_VALIDATOR.ensureValid(
               KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG,
-              this.requestWaitMs
+              requestWaitMs
       );
+      this.requestWaitMs = requestWaitMs;
     } catch (io.confluent.common.config.ConfigException e) {
-      throw new RestConstraintViolationException(
-              e.getMessage(), Response.Status.BAD_REQUEST.getStatusCode()
-      );
-    } catch (NumberFormatException e) {
-      throw new RestConstraintViolationException(
-              String.format("Invalid value for configuration %s: must be an integer",
-                      responseMinBytes,
-                      KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG),
-              Response.Status.BAD_REQUEST.getStatusCode());
+      throw Errors.invalidConsumerConfigConstraintException(e);
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -334,7 +334,7 @@ public class KafkaConsumerManager {
       this.started = config.getTime().milliseconds();
       this.consumerConfig = taskState.consumerState.getConfig();
       this.requestExpiration = this.started
-              + consumerConfig.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+              + consumerConfig.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
       this.backoffMs = consumerConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG);
       this.waitExpirationMs = 0;
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
@@ -44,12 +44,19 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
 
   private KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> parent;
   private final long requestTimeoutMs;
+  // the minimum bytes the task should accumulate
+  // before returning a response (or hitting the timeout)
+  // responseMinBytes might be bigger than maxResponseBytes
+  // in cases where the functionality is disabled
+  private final int responseMinBytes;
   private final long maxResponseBytes;
   private final ConsumerReadCallback<ClientKeyT, ClientValueT> callback;
   private boolean finished;
 
   private List<ConsumerRecord<ClientKeyT, ClientValueT>> messages;
   private long bytesConsumed = 0;
+  private boolean exceededMinResponseBytes = false;
+  private boolean exceededMaxResponseBytes = false;
   private final long started;
 
 
@@ -63,12 +70,18 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
     this.maxResponseBytes =
         Math.min(
             maxBytes,
-            parent.getConfig().getLong(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG)
+            parent.getConfig().consumerResponseMaxBytes()
         );
     long defaultRequestTimeout =
-        parent.getConfig().getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
+        parent.getConfig().getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
     this.requestTimeoutMs =
-        timeout <= 0 ? defaultRequestTimeout : Math.min(timeout, defaultRequestTimeout);
+            timeout <= 0 ? defaultRequestTimeout : Math.min(timeout, defaultRequestTimeout);
+
+    int responseMinBytes = parent.getConfig().getInt(
+            KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG);
+    this.responseMinBytes = responseMinBytes < 0 ? Integer.MAX_VALUE : responseMinBytes;
+
+
     this.callback = callback;
     this.finished = false;
 
@@ -85,20 +98,7 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
         messages = new Vector<>();
       }
 
-      long roughMsgSize = 0;
-
-      while (parent.hasNext()) {
-        ConsumerRecordAndSize<ClientKeyT, ClientValueT> recordAndSize =
-            parent.createConsumerRecord(parent.peek());
-        roughMsgSize = recordAndSize.getSize();
-        if (bytesConsumed + roughMsgSize >= maxResponseBytes) {
-          break;
-        }
-
-        messages.add(recordAndSize.getRecord());
-        parent.next();
-        bytesConsumed += roughMsgSize;
-      }
+      addRecords();
 
       log.trace(
           "KafkaConsumerReadTask exiting read with id={} messages={} bytes={}, backing off if not"
@@ -114,13 +114,14 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
       // Including the rough message size here ensures processing finishes if the next
       // message exceeds the maxResponseBytes
       boolean requestTimedOut = elapsed >= requestTimeoutMs;
-      boolean exceededMaxResponseBytes = bytesConsumed + roughMsgSize >= maxResponseBytes;
-      if (requestTimedOut || exceededMaxResponseBytes) {
+      if (requestTimedOut || exceededMaxResponseBytes || exceededMinResponseBytes) {
         log.trace(
-            "Finishing KafkaConsumerReadTask id={} requestTimedOut={} exceededMaxResponseBytes={}",
+            "Finishing KafkaConsumerReadTask id={} requestTimedOut={} "
+            + "exceededMaxResponseBytes={} exceededMinResponseBytes={}",
             this,
             requestTimedOut,
-            exceededMaxResponseBytes
+            exceededMaxResponseBytes,
+            exceededMinResponseBytes
         );
         finish();
       }
@@ -132,6 +133,45 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
 
   public boolean isDone() {
     return finished;
+  }
+
+  /**
+   * Polls for and reads records until either the minimum response bytes are filled,
+   *  the maximum response bytes will be reached, or no more records can be read from polling.
+   */
+  private void addRecords() {
+    while (!exceededMinResponseBytes && !exceededMaxResponseBytes && parent.hasNext()) {
+      maybeAddRecord();
+    }
+    while (exceededMinResponseBytes && !exceededMaxResponseBytes && parent.hasNextCached()) {
+      // will not call poll() anymore. Continue draining loaded records
+      maybeAddRecord();
+    }
+  }
+
+  /**
+   * Tries to add the latest record from the iterator
+   * to the read records if it doesn't go over the maximum response bytes.
+   * Keeps track and marks when we are about to exceed the max response bytes, and
+   * have exceeded the min response bytes
+   * @return boolean indicating whether the record was added
+   */
+  private boolean maybeAddRecord() {
+    ConsumerRecordAndSize<ClientKeyT, ClientValueT> recordAndSize =
+            parent.createConsumerRecord(parent.peek());
+    long roughMsgSize = recordAndSize.getSize();
+    if (bytesConsumed + roughMsgSize >= maxResponseBytes) {
+      this.exceededMaxResponseBytes = true;
+      return false;
+    }
+
+    messages.add(recordAndSize.getRecord());
+    parent.next(); // increment iterator
+    bytesConsumed += roughMsgSize;
+    if (!exceededMinResponseBytes && bytesConsumed > responseMinBytes) {
+      this.exceededMinResponseBytes = true;
+    }
+    return true;
   }
 
   void finish() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
@@ -70,10 +70,10 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
     this.maxResponseBytes =
         Math.min(
             maxBytes,
-            parent.getConfig().consumerResponseMaxBytes()
+            parent.getConfig().getLong(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG)
         );
     long defaultRequestTimeout =
-        parent.getConfig().getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+        parent.getConfig().getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
     this.requestTimeoutMs =
             timeout <= 0 ? defaultRequestTimeout : Math.min(timeout, defaultRequestTimeout);
 
@@ -154,7 +154,6 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
    * to the read records if it doesn't go over the maximum response bytes.
    * Keeps track and marks when we are about to exceed the max response bytes, and
    * have exceeded the min response bytes
-   * @return boolean indicating whether the record was added
    */
   private void maybeAddRecord() {
     ConsumerRecordAndSize<ClientKeyT, ClientValueT> recordAndSize =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -378,6 +378,10 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
     }
   }
 
+  boolean hasNextCached() {
+    return !consumerRecords.isEmpty();
+  }
+
   ConsumerRecord<KafkaKeyT, KafkaValueT> next() {
     return consumerRecords.poll();
   }
@@ -395,10 +399,6 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
     for (ConsumerRecord<KafkaKeyT, KafkaValueT> consumerRecord : polledRecords) {
       consumerRecords.add(consumerRecord);
     }
-  }
-
-  private boolean hasNextCached() {
-    return !consumerRecords.isEmpty();
   }
 
   private class NoOpOnRebalance implements ConsumerRebalanceListener {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -289,7 +289,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     // request timeout, the iterator timeout used for "peeking", and the backoff period, as well
     // as some extra slack for general overhead (which apparently mostly comes from running the
     // request and can be quite substantial).
-    final int TIMEOUT = restConfig.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+    final int TIMEOUT = restConfig.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
     final int TIMEOUT_SLACK =
         restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG)
         + restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG) + 500;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -123,7 +123,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     ConsumerInstanceConfig config = null;
     if (id != null || name != null || format != null) {
       config = new ConsumerInstanceConfig(
-          id, name, (format != null ? format.toString() : null), null, null);
+          id, name, (format != null ? format.toString() : null), null, null, null, null);
     }
     return request("/consumers/" + groupName)
         .post(Entity.entity(config, Versions.KAFKA_MOST_SPECIFIC_DEFAULT));
@@ -289,7 +289,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     // request timeout, the iterator timeout used for "peeking", and the backoff period, as well
     // as some extra slack for general overhead (which apparently mostly comes from running the
     // request and can be quite substantial).
-    final int TIMEOUT = restConfig.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
+    final int TIMEOUT = restConfig.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
     final int TIMEOUT_SLACK =
         restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG)
         + restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG) + 500;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
@@ -155,7 +155,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testInvalidKafkaConsumerConfig() {
     ConsumerInstanceConfig config = new ConsumerInstanceConfig("id", "name", "binary",
-                                                               "bad-config", null);
+                                                               "bad-config", null, null, null);
     Response response = request("/consumers/" + groupName)
         .post(Entity.entity(config, Versions.KAFKA_V1_JSON));
     assertErrorResponse(ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY, response,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
@@ -325,7 +325,7 @@ public class ConsumerManagerTest {
 
     ConsumerInstanceConfig config = new ConsumerInstanceConfig(EmbeddedFormat.BINARY);
     // we expect one record to be returned since the setting is overridden
-    config.setResponseMinBytes(Integer.toString(1));
+    config.setResponseMinBytes(1);
     readFromDefault(consumerManager.createConsumer(groupName, config));
 
     assertTrue("Callback failed to fire", sawCallback);
@@ -355,7 +355,7 @@ public class ConsumerManagerTest {
     EasyMock.replay(mdObserver, consumerFactory);
 
     ConsumerInstanceConfig consumerConfig = new ConsumerInstanceConfig(EmbeddedFormat.BINARY);
-    consumerConfig.setRequestWaitMs(overriddenWaitTimeMs.toString());
+    consumerConfig.setRequestWaitMs(overriddenWaitTimeMs);
     String cid = consumerManager.createConsumer(groupName, consumerConfig);
     long startTime = System.currentTimeMillis();
     readFromDefault(cid);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +68,7 @@ import static org.junit.Assert.fail;
  */
 public class ConsumerManagerTest {
 
+  private Properties properties;
   private KafkaRestConfig config;
   private MetadataObserver mdObserver;
   private ConsumerManager.ConsumerFactory consumerFactory;
@@ -87,12 +89,16 @@ public class ConsumerManagerTest {
 
   @Before
   public void setUp() throws RestConfigException {
-    Properties props = new Properties();
-    props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG, "1024");
+    this.properties = new Properties();
+    properties.setProperty(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG, "1024");
     // This setting supports the testConsumerOverrides test. It is otherwise benign and should
     // not affect other tests.
-    props.setProperty("exclude.internal.topics", "false");
-    config = new KafkaRestConfig(props, new SystemTime());
+    properties.setProperty("exclude.internal.topics", "false");
+    setUp(properties);
+  }
+
+  public void setUp(Properties properties) throws RestConfigException {
+    config = new KafkaRestConfig(properties, new SystemTime());
     mdObserver = EasyMock.createMock(MetadataObserver.class);
     consumerFactory = EasyMock.createMock(ConsumerManager.ConsumerFactory.class);
     consumerManager = new ConsumerManager(config, mdObserver, consumerFactory);
@@ -165,14 +171,10 @@ public class ConsumerManagerTest {
   @Test
   public void testConsumerNormalOps() throws Exception {
     // Tests create instance, read, and delete
-    final List<ConsumerRecord<byte[], byte[]>> referenceRecords
-        = Arrays.<ConsumerRecord<byte[], byte[]>>asList(
-        new BinaryConsumerRecord(topicName, "k1".getBytes(), "v1".getBytes(), 0, 0),
-        new BinaryConsumerRecord(topicName, "k2".getBytes(), "v2".getBytes(), 1, 0),
-        new BinaryConsumerRecord(topicName, "k3".getBytes(), "v3".getBytes(), 2, 0));
+    final List<ConsumerRecord<byte[], byte[]>> referenceRecords = referenceRecords(3);
     Map<Integer, List<ConsumerRecord<byte[], byte[]>>>
         referenceSchedule =
-        new HashMap<Integer, List<ConsumerRecord<byte[], byte[]>>>();
+            new HashMap<>();
     referenceSchedule.put(50, referenceRecords);
 
     Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
@@ -184,13 +186,8 @@ public class ConsumerManagerTest {
     EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
 
     EasyMock.replay(mdObserver, consumerFactory);
-
-    String cid = consumerManager.createConsumer(
-        groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
-    sawCallback = false;
-    actualException = null;
-    actualRecords = null;
-    readTopic(cid);
+    String cid = consumerManager.createConsumer(groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+    readFromDefault(cid);
 
     verifyRead(referenceRecords, null);
 
@@ -216,6 +213,158 @@ public class ConsumerManagerTest {
     consumerManager.deleteConsumer(groupName, cid);
 
     EasyMock.verify(mdObserver, consumerFactory);
+  }
+
+  /**
+   * consumer.request.timeout.ms should not modify how long the proxy waits until returning a response
+   * fetch.max.wait.ms should dictate that
+   */
+  @Test
+  public void testConsumerRequestTimeoutDoesNotModifyProxyResponseTime() throws Exception {
+    properties.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "2500");
+    Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
+            schedules =
+            new HashMap<>();
+    Map<Integer, List<ConsumerRecord<byte[], byte[]>>> referenceSchedule = new HashMap<>();
+    schedules.put(topicName, Arrays.asList(referenceSchedule));
+    expectCreate(schedules);
+
+    EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
+    EasyMock.replay(mdObserver, consumerFactory);
+
+    long startTime = System.currentTimeMillis();
+    readFromDefault(consumerManager.createConsumer(groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY)));
+
+    assertTrue(System.currentTimeMillis() - startTime < 2500);
+    assertTrue("Callback failed to fire", sawCallback);
+    assertNull("No exception in callback", actualException);
+    // should wait default wait.ms time
+    assertEquals(Integer.parseInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_DEFAULT),
+            config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG));
+  }
+
+  /**
+   * Response should return no sooner than KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG
+   */
+  @Test
+  public void testConsumerWaitMs() throws Exception {
+    Integer expectedWaitMs = 400;
+    properties.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG, expectedWaitMs.toString());
+    setUp(properties);
+    Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
+            schedules =
+            new HashMap<>();
+    Map<Integer, List<ConsumerRecord<byte[], byte[]>>> referenceSchedule = new HashMap<>();
+    schedules.put(topicName, Arrays.asList(referenceSchedule));
+    expectCreate(schedules);
+
+    EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
+    EasyMock.replay(mdObserver, consumerFactory);
+
+    long startTime = System.currentTimeMillis();
+    readFromDefault(consumerManager.createConsumer(groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY)));
+    assertTrue(System.currentTimeMillis() - startTime > expectedWaitMs);
+    assertTrue("Callback failed to fire", sawCallback);
+    assertNull("No exception in callback", actualException);
+  }
+
+  /**
+   * When min.bytes is fulfilled, we should return immediately
+   */
+  @Test
+  public void testConsumerWaitMsAndMinBytes() throws Exception {
+    properties.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG, "1303");
+    properties.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, "1");
+    setUp(properties);
+
+    final List<ConsumerRecord<byte[], byte[]>> referenceRecords = referenceRecords(3);
+    Map<Integer, List<ConsumerRecord<byte[], byte[]>>>
+            referenceSchedule = new HashMap<>();
+    referenceSchedule.put(50, referenceRecords);
+
+    Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
+            schedules = new HashMap<>();
+    schedules.put(topicName, Arrays.asList(referenceSchedule));
+
+    expectCreate(schedules);
+    EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
+    EasyMock.replay(mdObserver, consumerFactory);
+
+    String cid = consumerManager.createConsumer(groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+    long startTime = System.currentTimeMillis();
+    readFromDefault(cid);
+
+    assertTrue("Callback failed to fire", sawCallback);
+    assertNull("No exception in callback", actualException);
+    // should return first record immediately since min.bytes is fulfilled
+    assertEquals("Records returned not as expected",
+            Arrays.asList(referenceRecords.get(0)), actualRecords);
+    long estimatedTime = System.currentTimeMillis() - startTime;
+    int waitMs = config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+    assertTrue(estimatedTime < waitMs); // should have returned earlier than min.wait.ms
+  }
+
+  @Test
+  public void testConsumeMinBytesIsOverridablePerConsumer() throws Exception {
+    properties.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, "10");
+    // global settings should return more than one record immediately
+    setUp(properties);
+
+    final List<ConsumerRecord<byte[], byte[]>> referenceRecords = referenceRecords(3);
+    Map<Integer, List<ConsumerRecord<byte[], byte[]>>>
+            referenceSchedule = new HashMap<>();
+    referenceSchedule.put(50, referenceRecords);
+
+    Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
+            schedules = new HashMap<>();
+    schedules.put(topicName, Arrays.asList(referenceSchedule));
+
+    expectCreate(schedules);
+    EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
+    EasyMock.replay(mdObserver, consumerFactory);
+
+    ConsumerInstanceConfig config = new ConsumerInstanceConfig(EmbeddedFormat.BINARY);
+    // we expect one record to be returned since the setting is overridden
+    config.setResponseMinBytes(Integer.toString(1));
+    readFromDefault(consumerManager.createConsumer(groupName, config));
+
+    assertTrue("Callback failed to fire", sawCallback);
+    assertNull("No exception in callback", actualException);
+    // should return first record immediately since min.bytes is fulfilled
+    assertEquals("Records returned not as expected",
+            Arrays.asList(referenceRecords.get(0)), actualRecords);
+  }
+
+  /**
+   * Response should return no sooner than the overridden PROXY_FETCH_MAX_WAIT_MS_CONFIG
+   */
+  @Test
+  public void testConsumerWaitMsIsOverriddablePerConsumer() throws Exception {
+    Integer overriddenWaitTimeMs = 111;
+    Integer globalWaitTimeMs = 1201;
+    properties.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG, globalWaitTimeMs.toString());
+    setUp(properties);
+    Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
+            schedules =
+            new HashMap<>();
+    Map<Integer, List<ConsumerRecord<byte[], byte[]>>> referenceSchedule = new HashMap<>();
+    schedules.put(topicName, Arrays.asList(referenceSchedule));
+    expectCreate(schedules);
+
+    EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true);
+    EasyMock.replay(mdObserver, consumerFactory);
+
+    ConsumerInstanceConfig consumerConfig = new ConsumerInstanceConfig(EmbeddedFormat.BINARY);
+    consumerConfig.setRequestWaitMs(overriddenWaitTimeMs.toString());
+    String cid = consumerManager.createConsumer(groupName, consumerConfig);
+    long startTime = System.currentTimeMillis();
+    readFromDefault(cid);
+    long elapsedTime = System.currentTimeMillis() - startTime;
+    assertTrue(elapsedTime < globalWaitTimeMs);
+    assertTrue(elapsedTime > overriddenWaitTimeMs);
+
+    assertTrue("Callback failed to fire", sawCallback);
+    assertNull("No exception in callback", actualException);
   }
 
   @Test
@@ -299,7 +448,7 @@ public class ConsumerManagerTest {
 
     String cid = consumerManager.createConsumer(
         groupName,
-        new ConsumerInstanceConfig("id", "name", EmbeddedFormat.BINARY.toString(), null, null)
+        new ConsumerInstanceConfig("id", "name", EmbeddedFormat.BINARY.toString(), null, null, null, null)
     );
     assertEquals("id", cid);
     assertEquals("id", capturedConsumerConfig.getValue().consumerId().getOrElse(null));
@@ -313,13 +462,13 @@ public class ConsumerManagerTest {
 
     consumerManager.createConsumer(
         groupName,
-        new ConsumerInstanceConfig(null, "name", EmbeddedFormat.BINARY.toString(), null, null)
+        new ConsumerInstanceConfig(null, "name", EmbeddedFormat.BINARY.toString(), null, null, null, null)
     );
 
     try {
       consumerManager.createConsumer(
           groupName,
-          new ConsumerInstanceConfig(null, "name", EmbeddedFormat.BINARY.toString(), null, null)
+          new ConsumerInstanceConfig(null, "name", EmbeddedFormat.BINARY.toString(), null, null, null, null)
       );
       fail("Expected to see exception because consumer already exists");
     } catch (RestException e) {
@@ -505,6 +654,55 @@ public class ConsumerManagerTest {
     consumerManager.deleteConsumer(groupName, "invalidinstance");
   }
 
+  @Test
+  public void testConsumerExceptions() throws Exception {
+    // We should be able to handle an exception thrown by the consumer, then issue another
+    // request that succeeds and still see all the data
+    final List<ConsumerRecord<byte[], byte[]>> referenceRecords = referenceRecords(3);
+    referenceRecords.add(null); // trigger exception
+    Map<Integer, List<ConsumerRecord<byte[], byte[]>>>
+        referenceSchedule =
+        new HashMap<Integer, List<ConsumerRecord<byte[], byte[]>>>();
+    referenceSchedule.put(50, referenceRecords);
+
+    Map<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>
+        schedules =
+        new HashMap<String, List<Map<Integer, List<ConsumerRecord<byte[], byte[]>>>>>();
+    schedules.put(topicName, Arrays.asList(referenceSchedule));
+
+    expectCreate(schedules);
+    EasyMock.expect(mdObserver.topicExists(topicName)).andReturn(true).times(2);
+
+    EasyMock.replay(mdObserver, consumerFactory);
+
+    String cid = consumerManager.createConsumer(
+        groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+
+    // First read should result in exception.
+    sawCallback = false;
+    actualException = null;
+    actualRecords = null;
+    readTopic(cid);
+    assertTrue("Callback not called", sawCallback);
+    assertNotNull("Callback exception should be populated", actualException);
+    assertNull("Callback with exception should not have any records", actualRecords);
+
+    // Second read should recover and return all the data.
+    sawCallback = false;
+    readTopic(cid, new ConsumerReadCallback<byte[], byte[]>() {
+      @Override
+      public void onCompletion(List<? extends ConsumerRecord<byte[], byte[]>> records,
+                               RestException e) {
+        sawCallback = true;
+        assertNull(e);
+        assertEquals(referenceRecords, records);
+      }
+    });
+    assertTrue(sawCallback);
+
+    EasyMock.verify(mdObserver, consumerFactory);
+  }
+
   /**
    * We need to wait for topic reads to finish. We can't rely on the returned Future
    * because one whole read task is spanned throughout multiple Runnables.
@@ -543,6 +741,39 @@ public class ConsumerManagerTest {
 
   private Future readTopicFuture(String cid, String topic, long maxBytes, final ConsumerReadCallback callback) {
     return consumerManager.readTopic(groupName, cid, topic, BinaryConsumerState.class, maxBytes, callback);
+  }
+
+  /**
+   * Returns a list of one record per partition, up to {@code count} partitions
+   */
+  private List<ConsumerRecord<byte[], byte[]>> referenceRecords(int count) {
+    List<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      records.add(
+          new BinaryConsumerRecord(
+              topicName,
+              ("k" + (i + 1)).getBytes(),
+              ("v" + (i + 1)).getBytes(), i, 0)
+      );
+    }
+    return records;
+  }
+
+  private void readFromDefault(String cid) throws InterruptedException, ExecutionException {
+    sawCallback = false;
+    actualException = null;
+    actualRecords = null;
+    consumerManager.readTopic(
+            groupName, cid, topicName, BinaryConsumerState.class, Long.MAX_VALUE,
+        new ConsumerReadCallback<byte[], byte[]>() {
+          @Override
+          public void onCompletion(List<? extends ConsumerRecord<byte[], byte[]>> records,
+                                   RestException e) {
+            actualException = e;
+            actualRecords = records;
+            sawCallback = true;
+          }
+        }).get();
   }
 
   private void readAndExpectImmediateNotFound(String cid, String topic) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -54,6 +53,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 /**
@@ -86,7 +86,11 @@ public class KafkaConsumerManagerTest {
 
     @Before
     public void setUp() throws RestConfigException {
-        config = new KafkaRestConfig(setUpProperties(), new SystemTime());
+        setUpConsumer(setUpProperties());
+    }
+
+    private void setUpConsumer(Properties properties) throws RestConfigException {
+        config = new KafkaRestConfig(properties, new SystemTime());
         consumerManager = new KafkaConsumerManager(config, consumerFactory);
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST, groupName);
     }
@@ -139,11 +143,178 @@ public class KafkaConsumerManagerTest {
     }
 
     /**
-     * Tests create instance, read, and delete
+     * consumer.request.timeout.ms should not modify how long the proxy waits until returning a response.
+     * fetch.max.wait.ms should dictate that
      */
     @Test
-    public void testConsumerNormalOps() throws InterruptedException, ExecutionException, RestConfigException {
-        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = bootstrapConsumer(consumer);
+    public void testConsumerRequestTimeoutDoesNotModifyProxyResponseTime() throws Exception {
+        Properties props = setUpProperties(new Properties());
+        props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "2500");
+        setUpConsumer(props);
+
+        expectCreate(consumer);
+        String cid = consumerManager.createConsumer(
+            groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+        consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+
+        readFromDefault(cid);
+        assertEquals(config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG),
+            Integer.parseInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_DEFAULT));
+        Thread.sleep(config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG));
+        assertTrue("Callback failed to fire", sawCallback);
+        assertNull("No exception in callback", actualException);
+    }
+
+
+    /**
+     * Response should return no sooner than KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG
+     */
+    @Test
+    public void testConsumerWaitMs() throws Exception {
+        Properties props = setUpProperties(new Properties());
+        Integer expectedWaitMs = 400;
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG, expectedWaitMs.toString());
+        setUpConsumer(props);
+
+        expectCreate(consumer);
+        schedulePoll();
+
+        String cid = consumerManager.createConsumer(
+                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+        consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+        consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
+        consumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(topicName, 0), 0L));
+
+        readFromDefault(cid);
+        long startTime = System.currentTimeMillis();
+        while ((System.currentTimeMillis() - startTime) < expectedWaitMs) {
+            assertFalse(sawCallback);
+            Thread.sleep(40);
+        }
+        assertTrue("Callback failed to fire", sawCallback);
+        assertNull("No exception in callback", actualException);
+    }
+
+    /**
+     * When min.bytes is not fulfilled, we should return after wait.ms
+     * When min.bytes is fulfilled, we should return immediately
+     */
+    @Test
+    public void testConsumerWaitMsAndMinBytes() throws Exception {
+        Properties props = setUpProperties(new Properties());
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG, "1303");
+        props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "3000");
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, "5");
+        setUpConsumer(props);
+
+        expectCreate(consumer);
+
+        String cid = consumerManager.createConsumer(
+                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+        consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+        consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
+        consumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(topicName, 0), 0L));
+
+        long startTime = System.currentTimeMillis();
+        readFromDefault(cid);
+        int expectedWaitMs = config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG);
+        while ((System.currentTimeMillis() - startTime) < expectedWaitMs) {
+            assertFalse(sawCallback);
+            Thread.sleep(100);
+        }
+        assertTrue("Callback failed to fire", sawCallback);
+        assertNull("No exception in callback", actualException);
+        assertTrue("Records returned not empty", actualRecords.isEmpty());
+
+
+        sawCallback = false;
+        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = schedulePoll();
+        readFromDefault(cid);
+        Thread.sleep(expectedWaitMs / 2); // should return in less time
+
+        assertEquals("Records returned not as expected", referenceRecords, actualRecords);
+        assertTrue("Callback not called", sawCallback);
+        assertNull("Callback exception", actualException);
+    }
+
+    /**
+     * Should return more than min bytes of records and less than max bytes.
+     * Should not poll() twice after min bytes have been reached
+     */
+    @Test
+    public void testConsumerMinAndMaxBytes() throws Exception {
+        BinaryConsumerRecord sampleRecord = binaryConsumerRecord(0);
+        int sampleRecordSize = sampleRecord.getKey().length + sampleRecord.getValue().length;
+        // we expect all the records from the first poll to be returned
+        Properties props = setUpProperties(new Properties());
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, Integer.toString(sampleRecordSize));
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_BYTES_CONFIG, Integer.toString(sampleRecordSize * 10));
+        setUpConsumer(props);
+
+        final List<ConsumerRecord<byte[], byte[]>> scheduledRecords = schedulePoll();
+        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = Arrays.asList(scheduledRecords.get(0), scheduledRecords.get(1), scheduledRecords.get(2));
+        schedulePoll(3);
+
+        expectCreate(consumer);
+        String cid = consumerManager.createConsumer(
+                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+        consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+        consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
+        consumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(topicName, 0), 0L));
+
+        readFromDefault(cid);
+        Thread.sleep((long) (Integer.parseInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_DEFAULT) * 0.5)); // should return sooner since min bytes hit
+
+        assertTrue("Callback failed to fire", sawCallback);
+        assertNull("No exception in callback", actualException);
+        assertEquals("Records returned not as expected", referenceRecords, actualRecords);
+    }
+
+    @Test
+    public void testConsumeMinBytesIsOverridablePerConsumer() throws Exception {
+        BinaryConsumerRecord sampleRecord = binaryConsumerRecord(0);
+        int sampleRecordSize = sampleRecord.getKey().length + sampleRecord.getValue().length;
+        Properties props = setUpProperties(new Properties());
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, Integer.toString(sampleRecordSize * 5));
+        props.setProperty(KafkaRestConfig.PROXY_FETCH_MAX_BYTES_CONFIG, Integer.toString(sampleRecordSize * 6));
+        setUpConsumer(props);
+
+        final List<ConsumerRecord<byte[], byte[]>> scheduledRecords = schedulePoll();
+        // global settings would make the consumer call poll twice and get more than 3 records,
+        // overridden settings should make him poll once since the min bytes will be reached
+        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = Arrays.asList(scheduledRecords.get(0),
+                scheduledRecords.get(1),
+                scheduledRecords.get(2));
+        schedulePoll(3);
+
+        expectCreate(consumer);
+        ConsumerInstanceConfig config = new ConsumerInstanceConfig(EmbeddedFormat.BINARY);
+        // we expect three records to be returned since the setting is overridden and poll() wont be called a second time
+        config.setResponseMinBytes(Integer.toString(sampleRecordSize * 2));
+        String cid = consumerManager.createConsumer(
+                groupName, config);
+        consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+        consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
+        consumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(topicName, 0), 0L));
+
+        readFromDefault(cid);
+        Thread.sleep((long) (Integer.parseInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_DEFAULT) * 0.5)); // should return sooner since min bytes hit
+
+        assertTrue("Callback failed to fire", sawCallback);
+        assertNull("No exception in callback", actualException);
+        assertEquals("Records returned not as expected", referenceRecords, actualRecords);
+    }
+
+    @Test
+    public void testConsumerNormalOps() throws InterruptedException, ExecutionException {
+        expectCreate(consumer);
+        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = schedulePoll();
+
+        String cid = consumerManager.createConsumer(
+                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+        consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+        consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
+        consumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(topicName, 0), 0L));
 
         sawCallback = false;
         actualException = null;
@@ -158,6 +329,9 @@ public class KafkaConsumerManagerTest {
             }
         });
         awaitRead();
+
+        readFromDefault(cid);
+        Thread.sleep((long) (Integer.parseInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_DEFAULT) * 1.10));
 
         assertTrue("Callback failed to fire", sawCallback);
         assertNull("No exception in callback", actualException);
@@ -355,4 +529,54 @@ public class KafkaConsumerManagerTest {
         return referenceRecords;
     }
 
+    private void readFromDefault(String cid) throws InterruptedException, ExecutionException {
+        consumerManager.readRecords(groupName, cid, BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
+            new ConsumerReadCallback<byte[], byte[]>() {
+              @Override
+              public void onCompletion(List<? extends ConsumerRecord<byte[], byte[]>> records, RestException e) {
+                actualException = e;
+                actualRecords = records;
+                sawCallback = true;
+              }
+            });
+    }
+
+    private List<ConsumerRecord<byte[], byte[]>> schedulePoll() {
+        return schedulePoll(0);
+    }
+
+    private List<ConsumerRecord<byte[], byte[]>> schedulePoll(final int fromOffset) {
+        consumer.schedulePollTask(new Runnable() {
+          @Override
+          public void run() {
+            consumer.addRecord(KafkaConsumerManagerTest.this.record(fromOffset));
+            consumer.addRecord(KafkaConsumerManagerTest.this.record(fromOffset + 1));
+            consumer.addRecord(KafkaConsumerManagerTest.this.record(fromOffset + 2));
+          }
+        });
+        return Arrays.asList(
+            (ConsumerRecord<byte[], byte[]>) binaryConsumerRecord(fromOffset),
+            binaryConsumerRecord(fromOffset + 1),
+            binaryConsumerRecord(fromOffset + 2)
+        );
+    }
+
+    private BinaryConsumerRecord binaryConsumerRecord(int offset) {
+        return new BinaryConsumerRecord(
+                topicName,
+                String.format("k%d", offset).getBytes(),
+                String.format("v%d", offset).getBytes(),
+                0,
+                offset
+        );
+    }
+
+    private org.apache.kafka.clients.consumer.ConsumerRecord<byte[], byte[]> record(int offset) {
+        return new org.apache.kafka.clients.consumer.ConsumerRecord<>(
+                topicName,
+                0,
+                offset,
+                String.format("k%d", offset).getBytes(),
+                String.format("v%d", offset).getBytes());
+    }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -292,7 +292,7 @@ public class KafkaConsumerManagerTest {
         expectCreate(consumer);
         ConsumerInstanceConfig config = new ConsumerInstanceConfig(EmbeddedFormat.BINARY);
         // we expect three records to be returned since the setting is overridden and poll() wont be called a second time
-        config.setResponseMinBytes(Integer.toString(sampleRecordSize * 2));
+        config.setResponseMinBytes(sampleRecordSize * 2);
         String cid = consumerManager.createConsumer(
                 groupName, config);
         consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -160,7 +160,7 @@ public class KafkaConsumerManagerTest {
         readFromDefault(cid);
         assertEquals(config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG),
             Integer.parseInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_DEFAULT));
-        Thread.sleep(config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG));
+        Thread.sleep((long) (config.getInt(KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG) * 1.10));
         assertTrue("Callback failed to fire", sawCallback);
         assertNull("No exception in callback", actualException);
     }
@@ -191,6 +191,7 @@ public class KafkaConsumerManagerTest {
             assertFalse(sawCallback);
             Thread.sleep(40);
         }
+        Thread.sleep(200);
         assertTrue("Callback failed to fire", sawCallback);
         assertNull("No exception in callback", actualException);
     }
@@ -222,6 +223,7 @@ public class KafkaConsumerManagerTest {
             assertFalse(sawCallback);
             Thread.sleep(100);
         }
+        Thread.sleep(200);
         assertTrue("Callback failed to fire", sawCallback);
         assertNull("No exception in callback", actualException);
         assertTrue("Records returned not empty", actualRecords.isEmpty());


### PR DESCRIPTION
This commit enables long-polling functionality in the V1 and V2 consumer APIs.

Previously, consumer.request.timeout.ms would control when the proxy sent back a response to the user. The default value was 1000ms, but setting it explicitly to 1000 (or 2000) would cause it to be passed to the underlying consumer connection. This caused a NullPointerException because configuration exceptions were ignored in the V2 API.
This PR stops the behavior of passing the consumer.request.timeout.ms to the underlying consumer.
The proxy now also raises exceptions and returns proper 4xx responses when the given V2 Consumer settings are invalid.

Adds a new config setting:
* fetch.min.bytes - the amount of bytes of records the proxy will collect before immediately returning a response. It is configurable per consumer.
This new setting controls how the user->proxy connection works, not the underlying consumer->broker.


### Future Work
In a future PR aimed at `master`, where we can be more lenient with backwards-compatibility, we should consider renaming some configs and deprecating old ones
* fetch.max.wait.ms - time before a consumer response is sent back when neither min or max bytes are fulfilled
* deprecate consumer.request.max.bytes and introduce proxy.fetch.max.bytes - same config but renamed. If proxy.fetch.max.bytes is explicitly defined it will override the set consumer.request.max.bytes
* proxy.fetch.max.wait.ms and proxy.fetch.min.bytes are configurable per consumer as well as globally
* consumer.request.timeout.ms is totally unused now
