### PR TITLE
Revert Consumer Threading 5.0

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -58,18 +58,18 @@ General
   * Default: 67108864
   * Importance: medium
 
-``consumer.threads``
-  The maximum number of threads to run consumer requests on. Note that this must be greater than the maximum number of consumers in a single consumer group.
-  The sentinel value of -1 allows the number of threads to grow as needed to fulfill active consumer requests. Inactive threads will ultimately be stopped and cleaned up.
-  * Type: int
-  * Default: 200
-  * Importance: medium
-
 ``consumer.request.timeout.ms``
   The maximum total time to wait for messages for a request if the maximum number of messages has not yet been reached.
 
   * Type: int
   * Default: 1000
+  * Importance: medium
+
+``consumer.threads``
+  Number of threads to run consumer requests on.
+
+  * Type: int
+  * Default: 1
   * Importance: medium
 
 ``host.name``

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -184,16 +184,6 @@ changing these based on your specific use case.
      * Default: 1000
      * Importance: medium
 
-   ``consumer.threads``
-     The maximum number of threads to run consumer requests on. Consumers requests are
-     ran one per thread in a synchronous manner. It is a must to have this value
-     be set higher than the maximum number of consumers in a single consumer group,
-     otherwise rebalances will deadlock.
-
-     * Type: int
-     * Default: 200
-     * Importance: medium
-
    ``host.name``
      The host name used to generate absolute URLs for consumers. If empty, the default canonical
      hostname is used. You may need to set this value if the FQDN of your host cannot be

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -25,13 +25,13 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.ws.rs.core.Response;
 
@@ -45,10 +45,6 @@ import kafka.common.InvalidConfigException;
 import kafka.consumer.Consumer;
 import kafka.consumer.ConsumerConfig;
 import kafka.javaapi.consumer.ConsumerConnector;
-
-import static io.confluent.kafkarest.KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_VALUE;
 
 /**
  * Manages consumer instances by mapping instance IDs to consumer objects, processing read requests,
@@ -68,8 +64,13 @@ public class ConsumerManager {
   // work without having to know the types for the consumer, only requiring type information
   // during read operations.
   private final Map<ConsumerInstanceId, ConsumerState> consumers = new HashMap<>();
-  // All kind of operations, like reading records, committing offsets and closing a consumer
-  // are executed separately in dedicated threads via a cached thread pool.
+  // Read operations are common and there may be many concurrently, so they are farmed out to
+  // worker threads that can efficiently interleave the operations. Currently we're just using a
+  // simple round-robin scheduler.
+  private final List<ConsumerWorker> workers;
+  private final AtomicInteger nextWorker;
+  // A few other operations, like commit offsets and closing a consumer can't be interleaved, but
+  // they're also comparatively rare. These are executed serially in a dedicated thread.
   private final ExecutorService executor;
   private ConsumerFactory consumerFactory;
   private final PriorityQueue<ConsumerState> consumersByExpiration = new PriorityQueue<>();
@@ -81,12 +82,14 @@ public class ConsumerManager {
     this.zookeeperConnect = config.getString(KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG);
     this.mdObserver = mdObserver;
     this.iteratorTimeoutMs = config.getInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG);
-    // Cached thread pool
-    int maxThreadCount = config.getInt(CONSUMER_MAX_THREADS_CONFIG) < 0 ? Integer.MAX_VALUE
-            : config.getInt(CONSUMER_MAX_THREADS_CONFIG);
-    this.executor = new ThreadPoolExecutor(0, maxThreadCount,
-            60L, TimeUnit.SECONDS,
-            new SynchronousQueue<>());
+    this.workers = new Vector<ConsumerWorker>();
+    for (int i = 0; i < config.getInt(KafkaRestConfig.CONSUMER_THREADS_CONFIG); i++) {
+      ConsumerWorker worker = new ConsumerWorker(config);
+      workers.add(worker);
+      worker.start();
+    }
+    nextWorker = new AtomicInteger(0);
+    this.executor = Executors.newFixedThreadPool(1);
     this.consumerFactory = null;
     this.expirationThread = new ExpirationThread();
     this.expirationThread.start();
@@ -151,7 +154,6 @@ public class ConsumerManager {
       Properties props = (Properties) config.getOriginalProperties().clone();
       props.setProperty("zookeeper.connect", zookeeperConnect);
       props.setProperty("group.id", group);
-      props.setProperty(MAX_POLL_RECORDS_CONFIG, MAX_POLL_RECORDS_VALUE);
       // This ID we pass here has to be unique, only pass a value along if the deprecated ID field
       // was passed in. This generally shouldn't be used, but is maintained for compatibility.
       if (instanceConfig.getId() != null) {
@@ -250,42 +252,33 @@ public class ConsumerManager {
       return null;
     }
 
-    return executor.submit(() -> {
-      try {
-        ConsumerReadTask task = new ConsumerReadTask<>(
-                state,
-                topic,
-                maxBytes,
-                config,
-                (ConsumerWorkerReadCallback<ClientKeyT, ClientValueT>) (records, e) -> {
-                  updateExpiration(state);
-                  if (e != null) {
-                    // Ensure caught exceptions are converted to RestExceptions so the user gets a
-                    // nice error message. Currently we don't define any
-                    // more specific errors because the old consumer interface doesn't classify
-                    // the errors well like the new consumer does.
-                    // When the new consumer is available we may be able to update this
-                    // to provide better feedback to the user.
-                    Exception responseException = e;
-                    if (!(e instanceof RestException)) {
-                      responseException = Errors.kafkaErrorException(e);
-                    }
-                    callback.onCompletion(null, responseException);
-                  } else {
-                    callback.onCompletion(records, null);
-                  }
-                }
-        );
-        task.doFullRead();
-      } catch (Exception e) {
-        log.error("Failed to read records consumer " + state.getId().toString(), e);
-        Exception responseException = e;
-        if (!(e instanceof RestException)) {
-          responseException = Errors.kafkaErrorException(e);
+    int workerId = nextWorker.getAndIncrement() % workers.size();
+    ConsumerWorker worker = workers.get(workerId);
+    return worker.readTopic(
+        state, topic, maxBytes,
+        new ConsumerWorkerReadCallback<ClientKeyT, ClientValueT>() {
+          @Override
+          public void onCompletion(
+              List<? extends ConsumerRecord<ClientKeyT, ClientValueT>> records, Exception e
+          ) {
+            updateExpiration(state);
+            if (e != null) {
+              // Ensure caught exceptions are converted to RestExceptions so the user gets a
+              // nice error message. Currently we don't define any more specific errors because
+              // the old consumer interface doesn't classify the errors well like the new
+              // consumer does. When the new consumer is available we may be able to update this
+              // to provide better feedback to the user.
+              Exception responseException = e;
+              if (!(e instanceof RestException)) {
+                responseException = Errors.kafkaErrorException(e);
+              }
+              callback.onCompletion(null, responseException);
+            } else {
+              callback.onCompletion(records, null);
+            }
+          }
         }
-        callback.onCompletion(null, responseException);
-      }
-    });
+    );
   }
 
   public interface CommitCallback {
@@ -330,7 +323,13 @@ public class ConsumerManager {
 
   public void shutdown() {
     log.debug("Shutting down consumers");
-    executor.shutdown();
+    synchronized (this) {
+      for (ConsumerWorker worker : workers) {
+        log.trace("Shutting down worker " + worker.toString());
+        worker.shutdown();
+      }
+      workers.clear();
+    }
     // Expiration thread needs to be able to acquire a lock on the ConsumerManager to make sure
     // the shutdown will be able to complete.
     log.trace("Shutting down consumer expiration thread");
@@ -341,6 +340,7 @@ public class ConsumerManager {
       }
       consumers.clear();
       consumersByExpiration.clear();
+      executor.shutdown();
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerReadTask.java
@@ -22,6 +22,11 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import io.confluent.kafkarest.entities.ConsumerRecord;
 import io.confluent.rest.exceptions.RestException;
@@ -38,18 +43,19 @@ import kafka.message.MessageAndMetadata;
  * returned by the Kafka consumer's decoder/deserializer, ClientK/ClientV is the format
  * returned to the client in the HTTP response. In some cases these may be identical.
  */
-class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
+class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
+    implements Future<List<ConsumerRecord<ClientKeyT, ClientValueT>>> {
+
   private static final Logger log = LoggerFactory.getLogger(ConsumerReadTask.class);
 
   private ConsumerState parent;
   private final long maxResponseBytes;
   private final ConsumerWorkerReadCallback<ClientKeyT, ClientValueT> callback;
-  private boolean finished;
+  private CountDownLatch finished;
 
   private ConsumerTopicState topicState;
   private ConsumerIterator<KafkaKeyT, KafkaValueT> iter;
   private List<ConsumerRecord<ClientKeyT, ClientValueT>> messages;
-  private KafkaRestConfig config;
   private long bytesConsumed = 0;
   private final long started;
 
@@ -61,7 +67,6 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
       ConsumerState parent,
       String topic,
       long maxBytes,
-      KafkaRestConfig config,
       ConsumerWorkerReadCallback<ClientKeyT, ClientValueT> callback
   ) {
     this.parent = parent;
@@ -70,8 +75,7 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
         parent.getConfig().getLong(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG)
     );
     this.callback = callback;
-    this.finished = false;
-    this.config = config;
+    this.finished = new CountDownLatch(1);
 
     started = parent.getConfig().getTime().milliseconds();
     try {
@@ -88,19 +92,6 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
     }
   }
 
-  public void doFullRead() {
-    log.trace("Executing consumer read task ({})", this);
-    while (!isDone()) {
-      doPartialRead();
-      long now = config.getTime().milliseconds();
-      long waitTime = waitExpiration - now;
-      if (waitTime > 0) {
-        config.getTime().sleep(waitTime);
-      }
-    }
-    log.trace("Finished executing consumer read task ({})", this);
-  }
-
   /**
    * Performs one iteration of reading from a consumer iterator.
    *
@@ -113,7 +104,7 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
         parent.startRead(topicState);
         iter = topicState.getIterator();
 
-        messages = new Vector<>();
+        messages = new Vector<ConsumerRecord<ClientKeyT, ClientValueT>>();
         waitExpiration = 0;
       }
 
@@ -186,15 +177,11 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
     }
   }
 
-  boolean isDone() {
-    return finished;
-  }
-
-  private void finish() {
+  public void finish() {
     finish(null);
   }
 
-  private void finish(Exception e) {
+  public void finish(Exception e) {
     log.trace("Finishing ConsumerReadTask id={} exception={}", this, e);
     if (e == null) {
       // Now it's safe to mark these messages as consumed by updating offsets since we're actually
@@ -222,7 +209,38 @@ class ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
       // done here but log it since it indicates a bug in the calling code.
       log.error("Consumer read callback threw an unhandled exception id={}", this, e);
     }
-    finished = true;
+    finished.countDown();
   }
 
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    return (finished.getCount() == 0);
+  }
+
+  @Override
+  public List<ConsumerRecord<ClientKeyT, ClientValueT>> get()
+      throws InterruptedException, ExecutionException {
+    finished.await();
+    return messages;
+  }
+
+  @Override
+  public List<ConsumerRecord<ClientKeyT, ClientValueT>> get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    finished.await(timeout, unit);
+    if (finished.getCount() > 0) {
+      throw new TimeoutException();
+    }
+    return messages;
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerWorker.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerWorker.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Worker thread for consumers that multiplexes multiple consumer operations onto a single thread.
+ */
+public class ConsumerWorker extends Thread {
+
+  private static final Logger log = LoggerFactory.getLogger(ConsumerWorker.class);
+
+  KafkaRestConfig config;
+
+  AtomicBoolean isRunning = new AtomicBoolean(true);
+  CountDownLatch shutdownLatch = new CountDownLatch(1);
+
+  Queue<ConsumerReadTask> tasks = new LinkedList<ConsumerReadTask>();
+  Queue<ConsumerReadTask> waitingTasks =
+      new PriorityQueue<ConsumerReadTask>(1, new ReadTaskExpirationComparator());
+
+  public ConsumerWorker(KafkaRestConfig config) {
+    this.config = config;
+  }
+
+  public synchronized <KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> Future readTopic(
+      ConsumerState state,
+      String topic,
+      long maxBytes,
+      ConsumerWorkerReadCallback<ClientKeyT, ClientValueT> callback
+  ) {
+    ConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> task =
+        new ConsumerReadTask<>(
+            state,
+            topic,
+            maxBytes,
+            callback
+        );
+    log.trace(
+        "Scheduling consumer worker read worker={} task={} topic={} consumer={}",
+        this,
+        task,
+        topic,
+        state.getId()
+    );
+    if (!task.isDone()) {
+      tasks.add(task);
+      this.notifyAll();
+    }
+    return task;
+  }
+
+  @Override
+  public void run() {
+    while (isRunning.get()) {
+      synchronized (this) {
+        if (tasks.isEmpty()) {
+          try {
+            long now = config.getTime().milliseconds();
+            long nextExpiration = nextWaitingExpiration();
+            if (nextExpiration > now) {
+              long timeout = (nextExpiration == Long.MAX_VALUE ? 0 : nextExpiration - now);
+              assert (timeout >= 0);
+              log.trace(
+                  "Consumer worker waiting for next task worker={} timeout={}",
+                  this,
+                  timeout
+              );
+              config.getTime().waitOn(this, timeout);
+            }
+          } catch (InterruptedException e) {
+            // Indication of shutdown
+          }
+        }
+
+        long now = config.getTime().milliseconds();
+        while (nextWaitingExpiration() <= now) {
+          final ConsumerReadTask waitingTask = waitingTasks.remove();
+          log.trace("Promoting waiting task to scheduled worker={} task={}", this, waitingTask);
+          tasks.add(waitingTask);
+        }
+
+        final ConsumerReadTask task = tasks.poll();
+        if (task != null) {
+          log.trace("Executing consumer read task worker={} task={}", this, task);
+          boolean backoff = task.doPartialRead();
+          if (!task.isDone()) {
+            if (backoff) {
+              log.trace(
+                  "Rescheduling consumer read task with backoff worker={} task={}",
+                  this,
+                  task
+              );
+              waitingTasks.add(task);
+            } else {
+              log.trace(
+                  "Rescheduling consumer read task with immediately worker={} task={}",
+                  this,
+                  task
+              );
+              tasks.add(task);
+            }
+          }
+        }
+      }
+    }
+    shutdownLatch.countDown();
+  }
+
+  private long nextWaitingExpiration() {
+    if (waitingTasks.isEmpty()) {
+      return Long.MAX_VALUE;
+    } else {
+      return waitingTasks.peek().waitExpiration;
+    }
+  }
+
+  public void shutdown() {
+    try {
+      isRunning.set(false);
+      this.interrupt();
+      shutdownLatch.await();
+    } catch (InterruptedException e) {
+      log.error("Interrupted while consumer worker thread.");
+      throw new Error("Interrupted when shutting down consumer worker thread.");
+    }
+  }
+
+  private static class ReadTaskExpirationComparator implements Comparator<ConsumerReadTask> {
+
+    @Override
+    public int compare(ConsumerReadTask t1, ConsumerReadTask t2) {
+      if (t1.waitExpiration == t2.waitExpiration) {
+        return 0;
+      } else if (t1.waitExpiration < t2.waitExpiration) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -60,23 +60,11 @@ public class KafkaRestConfig extends RestConfig {
       + "are used.";
   public static final String ID_DEFAULT = "";
 
-  public static final String MAX_POLL_RECORDS_CONFIG = "max.poll.records";
-  private static final String MAX_POLL_RECORDS_DOC =
-          "The maximum number of records returned in a single call to poll().";
-  // ensures poll is frequently needed and called
-  public static final String MAX_POLL_RECORDS_VALUE = "30";
-
   public static final String HOST_NAME_CONFIG = "host.name";
   private static final String HOST_NAME_DOC =
       "The host name used to generate absolute URLs in responses. If empty, the default canonical"
       + " hostname is used";
   public static final String HOST_NAME_DEFAULT = "";
-
-  public static final String CONSUMER_MAX_THREADS_CONFIG = "consumer.threads";
-  private static final String CONSUMER_MAX_THREADS_DOC =
-      "The maximum number of threads to run consumer requests on."
-      + " The value of -1 denotes unbounded thread creation";
-  public static final String CONSUMER_MAX_THREADS_DEFAULT = "200";
 
   public static final String ZOOKEEPER_CONNECT_CONFIG = "zookeeper.connect";
   private static final String ZOOKEEPER_CONNECT_DOC =
@@ -155,6 +143,11 @@ public class KafkaRestConfig extends RestConfig {
       + "overhead from base64 encoding the response data and from JSON encoding the entire "
       + "response.";
   public static final long CONSUMER_REQUEST_MAX_BYTES_DEFAULT = 64 * 1024 * 1024;
+
+  public static final String CONSUMER_THREADS_CONFIG = "consumer.threads";
+  private static final String CONSUMER_THREADS_DOC =
+      "Number of threads to run consumer requests on.";
+  public static final String CONSUMER_THREADS_DEFAULT = "1";
 
   public static final String CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG = "consumer.instance.timeout.ms";
   private static final String CONSUMER_INSTANCE_TIMEOUT_MS_DOC =
@@ -355,8 +348,6 @@ public class KafkaRestConfig extends RestConfig {
         )
         .define(ID_CONFIG, Type.STRING, ID_DEFAULT, Importance.HIGH, ID_CONFIG_DOC)
         .define(HOST_NAME_CONFIG, Type.STRING, HOST_NAME_DEFAULT, Importance.MEDIUM, HOST_NAME_DOC)
-        .define(CONSUMER_MAX_THREADS_CONFIG, Type.INT, CONSUMER_MAX_THREADS_DEFAULT,
-                Importance.MEDIUM, CONSUMER_MAX_THREADS_DOC)
         .define(
             ZOOKEEPER_CONNECT_CONFIG,
             Type.STRING,
@@ -412,6 +403,13 @@ public class KafkaRestConfig extends RestConfig {
             CONSUMER_REQUEST_MAX_BYTES_DEFAULT,
             Importance.MEDIUM,
             CONSUMER_REQUEST_MAX_BYTES_DOC
+        )
+        .define(
+            CONSUMER_THREADS_CONFIG,
+            Type.INT,
+            CONSUMER_THREADS_DEFAULT,
+            Importance.MEDIUM,
+            CONSUMER_THREADS_DOC
         )
         .define(
             CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -32,15 +32,15 @@ import java.util.UUID;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.ws.rs.core.Response;
 
 import io.confluent.kafkarest.ConsumerInstanceId;
+import io.confluent.kafkarest.ConsumerWorkerReadCallback;
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.Time;
@@ -61,10 +61,6 @@ import io.confluent.rest.exceptions.RestException;
 import io.confluent.rest.exceptions.RestNotFoundException;
 import io.confluent.rest.exceptions.RestServerErrorException;
 
-import static io.confluent.kafkarest.KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_VALUE;
-
 /**
  * Manages consumer instances by mapping instance IDs to consumer objects, processing read requests,
  * and cleaning up when consumers disappear.
@@ -82,8 +78,13 @@ public class KafkaConsumerManager {
   // during read operations.
   private final Map<ConsumerInstanceId, KafkaConsumerState> consumers =
       new HashMap<ConsumerInstanceId, KafkaConsumerState>();
-  // All kind of operations, like reading records, committing offsets and closing a consumer
-  // are executed separately in dedicated threads via a cached thread pool.
+  // Read operations are common and there may be many concurrently, so they are farmed out to
+  // worker threads that can efficiently interleave the operations. Currently we're just using a
+  // simple round-robin scheduler.
+  private final List<KafkaConsumerWorker> workers;
+  private final AtomicInteger nextWorker;
+  // A few other operations, like commit offsets and closing a consumer can't be interleaved, but
+  // they're also comparatively rare. These are executed serially in a dedicated thread.
   private final ExecutorService executor;
   private KafkaConsumerFactory consumerFactory;
   private final PriorityQueue<KafkaConsumerState> consumersByExpiration =
@@ -94,13 +95,14 @@ public class KafkaConsumerManager {
     this.config = config;
     this.time = config.getTime();
     this.bootstrapServers = config.bootstrapBrokers();
-
-    // Cached thread pool
-    int maxThreadCount = config.getInt(CONSUMER_MAX_THREADS_CONFIG) < 0 ? Integer.MAX_VALUE
-            : config.getInt(CONSUMER_MAX_THREADS_CONFIG);
-    this.executor = new ThreadPoolExecutor(0, maxThreadCount,
-            60L, TimeUnit.SECONDS,
-            new SynchronousQueue<>());
+    this.workers = new Vector<KafkaConsumerWorker>();
+    for (int i = 0; i < config.getInt(KafkaRestConfig.CONSUMER_THREADS_CONFIG); i++) {
+      KafkaConsumerWorker worker = new KafkaConsumerWorker(config);
+      workers.add(worker);
+      worker.start();
+    }
+    nextWorker = new AtomicInteger(0);
+    this.executor = Executors.newFixedThreadPool(1);
     this.consumerFactory = null;
     this.expirationThread = new ExpirationThread();
     this.expirationThread.start();
@@ -161,7 +163,6 @@ public class KafkaConsumerManager {
       //Properties props = (Properties) config.getOriginalProperties().clone();
       Properties props = config.getConsumerProperties();
       props.setProperty(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
-      props.setProperty(MAX_POLL_RECORDS_CONFIG, MAX_POLL_RECORDS_VALUE);
       props.setProperty("group.id", group);
       // This ID we pass here has to be unique, only pass a value along if the deprecated ID field
       // was passed in. This generally shouldn't be used, but is maintained for compatibility.
@@ -273,42 +274,30 @@ public class KafkaConsumerManager {
       return null;
     }
 
-    return executor.submit(() -> {
-      try {
-        KafkaConsumerReadTask task = new KafkaConsumerReadTask<KafkaKeyT, KafkaValueT,
-                ClientKeyT, ClientValueT>(
-            state,
-            timeout,
-            maxBytes,
-            config,
-            (records, e) -> {
-              updateExpiration(state);
-              if (e != null) {
-                // Ensure caught exceptions are converted to RestExceptions so the user gets a
-                // nice error message. Currently we don't define any more specific errors because
-                // the old consumer interface doesn't classify the errors well like the new
-                // consumer does. When the new consumer is available we may be able to update this
-                // to provide better feedback to the user.
-                Exception responseException = e;
-                if (!(e instanceof RestException)) {
-                  responseException = Errors.kafkaErrorException(e);
-                }
-                callback.onCompletion(null, responseException);
-              } else {
-                callback.onCompletion(records, null);
+    int workerId = nextWorker.getAndIncrement() % workers.size();
+    KafkaConsumerWorker worker = workers.get(workerId);
+    return worker.readRecords(
+        state, timeout, maxBytes,
+        new ConsumerWorkerReadCallback<ClientKeyT, ClientValueT>() {
+          @Override
+          public void onCompletion(
+              List<? extends ConsumerRecord<ClientKeyT, ClientValueT>> records, Exception e
+          ) {
+            updateExpiration(state);
+            if (e != null) {
+              // Ensure caught exceptions are converted to RestExceptions so the user gets a
+              // nice error message. Currently we don't define any more specific errors because
+              // the old consumer interface doesn't classify the errors well like the new
+              // consumer does. When the new consumer is available we may be able to update this
+              // to provide better feedback to the user.
+              Exception responseException = e;
+              if (!(e instanceof RestException)) {
+                responseException = Errors.kafkaErrorException(e);
               }
             }
-        );
-        task.doFullRead();
-      } catch (Exception e) {
-        log.error("Failed to read records consumer " + state.getId().toString(), e);
-        Exception responseException = e;
-        if (!(e instanceof RestException)) {
-          responseException = Errors.kafkaErrorException(e);
+          }
         }
-        callback.onCompletion(null, responseException);
-      }
-    });
+    );
   }
 
   public interface CommitCallback {
@@ -453,7 +442,13 @@ public class KafkaConsumerManager {
 
   public void shutdown() {
     log.debug("Shutting down consumers");
-    executor.shutdown();
+    synchronized (this) {
+      for (KafkaConsumerWorker worker : workers) {
+        log.trace("Shutting down worker " + worker.toString());
+        worker.shutdown();
+      }
+      workers.clear();
+    }
     // Expiration thread needs to be able to acquire a lock on the KafkaConsumerManager to make sure
     // the shutdown will be able to complete.
     log.trace("Shutting down consumer expiration thread");
@@ -464,6 +459,7 @@ public class KafkaConsumerManager {
       }
       consumers.clear();
       consumersByExpiration.clear();
+      executor.shutdown();
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerWorker.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerWorker.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafkarest.v2;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.confluent.kafkarest.ConsumerWorkerReadCallback;
+import io.confluent.kafkarest.KafkaRestConfig;
+
+/**
+ * Worker thread for consumers that multiplexes multiple consumer operations onto a single thread.
+ */
+public class KafkaConsumerWorker extends Thread {
+
+  private static final Logger log = LoggerFactory.getLogger(KafkaConsumerWorker.class);
+
+  KafkaRestConfig config;
+
+  AtomicBoolean isRunning = new AtomicBoolean(true);
+  CountDownLatch shutdownLatch = new CountDownLatch(1);
+
+  Queue<KafkaConsumerReadTask> tasks = new LinkedList<KafkaConsumerReadTask>();
+  Queue<KafkaConsumerReadTask> waitingTasks =
+      new PriorityQueue<KafkaConsumerReadTask>(1, new ReadTaskExpirationComparator());
+
+  public KafkaConsumerWorker(KafkaRestConfig config) {
+    this.config = config;
+  }
+
+  public synchronized <KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> Future readRecords(
+      KafkaConsumerState state,
+      long timeout,
+      long maxBytes,
+      ConsumerWorkerReadCallback<ClientKeyT, ClientValueT> callback
+  ) {
+    KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> task
+        = new KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>(
+            state,
+            timeout,
+            maxBytes,
+            callback
+    );
+    log.trace(
+        "Scheduling consumer worker read worker={} task={} consumer={}",
+        this,
+        task,
+        state.getId()
+    );
+    if (!task.isDone()) {
+      tasks.add(task);
+      this.notifyAll();
+    }
+    return task;
+  }
+
+  @Override
+  public void run() {
+    while (isRunning.get()) {
+      synchronized (this) {
+        if (tasks.isEmpty()) {
+          try {
+            long now = config.getTime().milliseconds();
+            long nextExpiration = nextWaitingExpiration();
+            if (nextExpiration > now) {
+              long timeout = (nextExpiration == Long.MAX_VALUE ? 0 : nextExpiration - now);
+              assert (timeout >= 0);
+              log.trace(
+                  "Consumer worker waiting for next task worker={} timeout={}",
+                  this,
+                  timeout
+              );
+              config.getTime().waitOn(this, timeout);
+            }
+          } catch (InterruptedException e) {
+            // Indication of shutdown
+          }
+        }
+
+        long now = config.getTime().milliseconds();
+        while (nextWaitingExpiration() <= now) {
+          final KafkaConsumerReadTask waitingTask = waitingTasks.remove();
+          log.trace("Promoting waiting task to scheduled worker={} task={}", this, waitingTask);
+          tasks.add(waitingTask);
+        }
+
+        final KafkaConsumerReadTask task = tasks.poll();
+        if (task != null) {
+          log.trace("Executing consumer read task worker={} task={}", this, task);
+          boolean backoff = task.doPartialRead();
+          if (!task.isDone()) {
+            if (backoff) {
+              log.trace(
+                  "Rescheduling consumer read task with backoff worker={} task={}",
+                  this,
+                  task
+              );
+              waitingTasks.add(task);
+            } else {
+              log.trace(
+                  "Rescheduling consumer read task with immediately worker={} task={}",
+                  this,
+                  task
+              );
+              tasks.add(task);
+            }
+          }
+        }
+      }
+    }
+    shutdownLatch.countDown();
+  }
+
+  private long nextWaitingExpiration() {
+    if (waitingTasks.isEmpty()) {
+      return Long.MAX_VALUE;
+    } else {
+      return waitingTasks.peek().waitExpiration;
+    }
+  }
+
+  public void shutdown() {
+    try {
+      isRunning.set(false);
+      this.interrupt();
+      shutdownLatch.await();
+    } catch (InterruptedException e) {
+      log.error("Interrupted while consumer worker thread.");
+      throw new Error("Interrupted when shutting down consumer worker thread.");
+    }
+  }
+
+  private static class ReadTaskExpirationComparator implements Comparator<KafkaConsumerReadTask> {
+
+    @Override
+    public int compare(KafkaConsumerReadTask t1, KafkaConsumerReadTask t2) {
+      if (t1.waitExpiration == t2.waitExpiration) {
+        return 0;
+      } else if (t1.waitExpiration < t2.waitExpiration) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -285,7 +285,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     assertEquals(0, consumed.size());
 
     // Note that this is only approximate and really only works if you assume the read call has
-    // a dedicated thread. Also note that we have to include the consumer
+    // a dedicated ConsumerWorker thread. Also note that we have to include the consumer
     // request timeout, the iterator timeout used for "peeking", and the backoff period, as well
     // as some extra slack for general overhead (which apparently mostly comes from running the
     // request and can be quite substantial).

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Since we went with a slightly different model for consumer threading in 4.0 (https://github.com/confluentinc/kafka-rest/pull/476), we are going to be merging that upstream to 5.0.x and trunk. The merge would be cleaner if we first reverted the previous changes
