### PR TITLE
CPKAFKA-1794: Assign leader ID -1 on offline partitions in the topic describe API

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
@@ -148,7 +148,9 @@ public class AdminClientWrapper {
 
       Partition p = new Partition();
       p.setPartition(topicPartitionInfo.partition());
-      p.setLeader(topicPartitionInfo.leader().id());
+      Node partitionLeader = topicPartitionInfo.leader();
+      int leaderId = partitionLeader != null ? partitionLeader.id() : -1;
+      p.setLeader(leaderId);
       List<PartitionReplica> partitionReplicas = new Vector<>();
 
       for (Node replicaNode : topicPartitionInfo.replicas()) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
@@ -47,12 +47,16 @@ public class AdminClientWrapper {
   private AdminClient adminClient;
   private int initTimeOut;
 
-  public AdminClientWrapper(KafkaRestConfig kafkaRestConfig) {
+  public AdminClientWrapper(KafkaRestConfig kafkaRestConfig, AdminClient adminClient) {
+    this.adminClient = adminClient;
+    this.initTimeOut = kafkaRestConfig.getInt(KafkaRestConfig.KAFKACLIENT_INIT_TIMEOUT_CONFIG);
+  }
+
+  public static Properties adminProperties(KafkaRestConfig kafkaRestConfig) {
     Properties properties = new Properties();
     properties.putAll(kafkaRestConfig.getAdminProperties());
     properties.put(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaRestConfig.bootstrapBrokers());
-    adminClient = AdminClient.create(properties);
-    this.initTimeOut = kafkaRestConfig.getInt(KafkaRestConfig.KAFKACLIENT_INIT_TIMEOUT_CONFIG);
+    return properties;
   }
 
   public List<Integer> getBrokerIds() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
@@ -17,6 +17,7 @@
 package io.confluent.kafkarest;
 
 import io.confluent.kafkarest.v2.KafkaConsumerManager;
+import org.apache.kafka.clients.admin.AdminClient;
 
 /**
  * Shared, global state for the REST proxy server, including configuration and connection pools.
@@ -93,7 +94,8 @@ public class DefaultKafkaRestContext implements KafkaRestContext {
   @Override
   public AdminClientWrapper getAdminClientWrapper() {
     if (adminClientWrapper == null) {
-      adminClientWrapper = new AdminClientWrapper(config);
+      adminClientWrapper = new AdminClientWrapper(config,
+          AdminClient.create(AdminClientWrapper.adminProperties(config)));
     }
     return adminClientWrapper;
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AdminClientWrapperTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AdminClientWrapperTest.java
@@ -1,0 +1,35 @@
+package io.confluent.kafkarest.unit;
+
+import io.confluent.kafkarest.AdminClientWrapper;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.entities.Topic;
+import io.confluent.rest.RestConfigException;
+import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.junit.Test;
+
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class AdminClientWrapperTest {
+  @Test
+  public void testGetTopicOnNullLeaderDoesntThrowNPE() throws RestConfigException {
+    Properties props = new Properties();
+    props.put(KafkaRestConfig.KAFKACLIENT_INIT_TIMEOUT_CONFIG, "100");
+    KafkaRestConfig config = new KafkaRestConfig(props);
+    Node controller = new Node(1, "a", 1);
+
+    MockAdminClient adminClient = new MockAdminClient(Arrays.asList(controller, null), controller);
+    TopicPartitionInfo partition = new TopicPartitionInfo(1, null, Collections.singletonList(controller), Collections.singletonList(controller));
+    adminClient.addTopic(false, "topic", Collections.singletonList(partition), new HashMap<String, String>());
+
+    Topic topic = new AdminClientWrapper(config, adminClient).getTopic("topic");
+    assertEquals(topic.getName(), "topic");
+  }
+}


### PR DESCRIPTION
Originally reported in https://github.com/confluentinc/kafka-rest/issues/410

No unit tests exist to test the `AdminClientWrapper`. It is currently not easy to test it since it instantiated its own `AdminClient` and does not have it passed it.

Do comment if you think it is worth it to rework the code to support some mock tests