### PR TITLE
the ThreadPoolExecutor RejectedExecutionHandler was error

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -407,7 +407,7 @@ public class ConsumerManager {
       if (callable instanceof RunnableReadTask) {
         return new ReadFutureTask(callable);
       }
-      return super.newTaskFor((callable);
+      return super.newTaskFor((callable));
     }
 
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -37,11 +37,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.Future;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.BlockingQueue;
 
 import javax.ws.rs.core.Response;
@@ -100,7 +98,7 @@ public class ConsumerManager {
           @Override
           public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
             if (r instanceof ReadFutureTask) {
-             RunnableReadTask readTask = ((ReadFutureTask)r).getReadTask();
+              RunnableReadTask readTask = ((ReadFutureTask)r).getReadTask();
               int delayMs = ThreadLocalRandom.current().nextInt(25, 75 + 1);
               readTask.waitExpirationMs = config.getTime().milliseconds() + delayMs;
               delayedReadTasks.add(readTask);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -360,26 +360,15 @@ public class ConsumerManager {
 
   class ReadFutureTask<V> extends FutureTask<V> {
 
-    private Runnable myTask;
-
-    private Callable callable;
+    private final Runnable readTask;
 
     public ReadFutureTask(Runnable runnable, V result) {
       super(runnable, result);
-      this.myTask = runnable;
-    }
-
-    public ReadFutureTask(Callable callable) {
-      super(callable);
-      this.callable = callable;
+      this.readTask = runnable;
     }
 
     public RunnableReadTask getReadTask() {
-      if (myTask != null) {
-        return (RunnableReadTask)myTask;
-      } else {
-        return (RunnableReadTask)callable;
-      }
+        return (RunnableReadTask)readTask;
     }
   }
 
@@ -400,14 +389,6 @@ public class ConsumerManager {
       }
       return super.newTaskFor(runnable, value);
     }
-
-    protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
-      if (callable instanceof RunnableReadTask) {
-        return new ReadFutureTask(callable);
-      }
-      return super.newTaskFor((callable));
-    }
-
   }
 
   class RunnableReadTask implements Runnable, Delayed {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.BlockingQueue;
@@ -368,7 +367,7 @@ public class ConsumerManager {
     }
 
     public RunnableReadTask getReadTask() {
-        return (RunnableReadTask)readTask;
+      return (RunnableReadTask)readTask;
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -37,6 +37,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.BlockingQueue;
 
 import javax.ws.rs.core.Response;
 
@@ -87,14 +93,14 @@ public class ConsumerManager {
     int maxThreadCount = config.getInt(KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG) < 0
         ? Integer.MAX_VALUE : config.getInt(KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG);
 
-    this.executor = new ThreadPoolExecutor(0, maxThreadCount,
+    this.executor = new KafkaConsumerThreadPoolExecutor(0, maxThreadCount,
         60L, TimeUnit.SECONDS,
         new SynchronousQueue<Runnable>(),
         new RejectedExecutionHandler() {
           @Override
           public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-            if (r instanceof RunnableReadTask) {
-              RunnableReadTask readTask = (RunnableReadTask) r;
+            if (r instanceof ReadFutureTask) {
+             RunnableReadTask readTask = ((ReadFutureTask)r).getReadTask();
               int delayMs = ThreadLocalRandom.current().nextInt(25, 75 + 1);
               readTask.waitExpirationMs = config.getTime().milliseconds() + delayMs;
               delayedReadTasks.add(readTask);
@@ -352,6 +358,58 @@ public class ConsumerManager {
   public interface ConsumerFactory {
 
     ConsumerConnector createConsumer(ConsumerConfig config);
+  }
+
+  class ReadFutureTask<V> extends FutureTask<V> {
+
+    private Runnable myTask;
+
+    private Callable callable;
+
+    public ReadFutureTask(Runnable runnable, V result) {
+      super(runnable, result);
+      this.myTask = runnable;
+    }
+
+    public ReadFutureTask(Callable callable) {
+      super(callable);
+      this.callable = callable;
+    }
+
+    public RunnableReadTask getReadTask() {
+      if (myTask != null) {
+        return (RunnableReadTask)myTask;
+      } else {
+        return (RunnableReadTask)callable;
+      }
+    }
+  }
+
+  class KafkaConsumerThreadPoolExecutor extends ThreadPoolExecutor {
+    public KafkaConsumerThreadPoolExecutor(int corePoolSize,
+                                           int maximumPoolSize,
+                                           long keepAliveTime,
+                                           TimeUnit unit,
+                                           BlockingQueue<Runnable> workQueue,
+                                           RejectedExecutionHandler handler) {
+      super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+      if (runnable instanceof RunnableReadTask) {
+        return new ReadFutureTask(runnable, value);
+      }
+      return super.newTaskFor(runnable, value);
+    }
+
+    protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
+      if (callable instanceof RunnableReadTask) {
+        return new ReadFutureTask(callable);
+      }
+      return super.newTaskFor((callable);
+    }
+
   }
 
   class RunnableReadTask implements Runnable, Delayed {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -48,6 +48,8 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.Callable;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.Response;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -48,7 +48,6 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.Response;
@@ -325,7 +324,7 @@ public class KafkaConsumerManager {
     }
 
     public RunnableReadTask getReadTask() {
-        return (RunnableReadTask)readTask;
+      return (RunnableReadTask)readTask;
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -35,9 +35,23 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.Vector;
-import java.util.concurrent.*;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.ws.rs.core.Response;
+
 import io.confluent.kafkarest.entities.ConsumerAssignmentRequest;
 import io.confluent.kafkarest.entities.ConsumerAssignmentResponse;
 import io.confluent.kafkarest.entities.ConsumerCommittedRequest;
@@ -53,7 +67,6 @@ import io.confluent.kafkarest.entities.TopicPartitionOffsetMetadata;
 import io.confluent.rest.exceptions.RestException;
 import io.confluent.rest.exceptions.RestNotFoundException;
 import io.confluent.rest.exceptions.RestServerErrorException;
-
 import static io.confluent.kafkarest.KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG;
 import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_CONFIG;
 import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_VALUE;
@@ -93,7 +106,7 @@ public class KafkaConsumerManager {
   public KafkaConsumerManager(final KafkaRestConfig config) {
     this.config = config;
     this.time = config.getTime();
-    this.bootstrapServers = config.bootstrapBrokers();RejectedExecutionHandler
+    this.bootstrapServers = config.bootstrapBrokers();
 
     // Cached thread pool
     int maxThreadCount = config.getInt(CONSUMER_MAX_THREADS_CONFIG) < 0 ? Integer.MAX_VALUE

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -362,7 +362,7 @@ public class KafkaConsumerManager {
       if (callable instanceof RunnableReadTask) {
         return new ReadFutureTask(callable);
       }
-      return super.newTaskFor((callable);
+      return super.newTaskFor((callable));
     }
 
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -35,7 +35,25 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.Vector;
-import java.util.concurrent.*;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.FutureTask;
+
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+
+
+
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.Response;
@@ -316,24 +334,22 @@ public class KafkaConsumerManager {
       return myTask;
     }
   }
-
-    class KafkaConsumerThreadPoolExecutor extends ThreadPoolExecutor {
-
-     public KafkaConsumerThreadPoolExecutor(int corePoolSize,
+  class KafkaConsumerThreadPoolExecutor extends ThreadPoolExecutor {
+    public KafkaConsumerThreadPoolExecutor(int corePoolSize,
                                                int maximumPoolSize,
                                                long keepAliveTime,
                                                TimeUnit unit,
                                                BlockingQueue<Runnable> workQueue,
                                                RejectedExecutionHandler handler) {
-       super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
 
-     }
+    }
 
        @Override
-       protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
         return new ReadFutureTask(runnable, value);
-       }
     }
+  }
 
   class RunnableReadTask implements Runnable, Delayed {
     private final ReadTaskState taskState;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -49,7 +49,6 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.Callable;
-
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.Response;
@@ -69,6 +68,7 @@ import io.confluent.kafkarest.entities.TopicPartitionOffsetMetadata;
 import io.confluent.rest.exceptions.RestException;
 import io.confluent.rest.exceptions.RestNotFoundException;
 import io.confluent.rest.exceptions.RestServerErrorException;
+
 import static io.confluent.kafkarest.KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG;
 import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_CONFIG;
 import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_VALUE;
@@ -332,9 +332,9 @@ public class KafkaConsumerManager {
     }
 
     public RunnableReadTask getReadTask() {
-      if(myTask !=null){
+      if (myTask != null) {
         return (RunnableReadTask)myTask;
-      }else{
+      } else {
         return (RunnableReadTask)callable;
       }
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -334,6 +334,7 @@ public class KafkaConsumerManager {
       return myTask;
     }
   }
+
   class KafkaConsumerThreadPoolExecutor extends ThreadPoolExecutor {
     public KafkaConsumerThreadPoolExecutor(int corePoolSize,
                                                int maximumPoolSize,
@@ -345,9 +346,9 @@ public class KafkaConsumerManager {
 
     }
 
-       @Override
+    @Override
     protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
-        return new ReadFutureTask(runnable, value);
+      return new ReadFutureTask(runnable, value);
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -317,26 +317,15 @@ public class KafkaConsumerManager {
 
   class ReadFutureTask<V> extends FutureTask<V> {
 
-    private Runnable myTask;
-
-    private Callable callable;
+    private final Runnable readTask;
 
     public ReadFutureTask(Runnable runnable, V result) {
       super(runnable, result);
-      this.myTask = runnable;
-    }
-
-    public ReadFutureTask(Callable callable) {
-      super(callable);
-      this.callable = callable;
+      this.readTask = runnable;
     }
 
     public RunnableReadTask getReadTask() {
-      if (myTask != null) {
-        return (RunnableReadTask)myTask;
-      } else {
-        return (RunnableReadTask)callable;
-      }
+        return (RunnableReadTask)readTask;
     }
   }
 
@@ -357,14 +346,6 @@ public class KafkaConsumerManager {
       }
       return super.newTaskFor(runnable, value);
     }
-
-    protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
-      if (callable instanceof RunnableReadTask) {
-        return new ReadFutureTask(callable);
-      }
-      return super.newTaskFor((callable));
-    }
-
   }
 
   class RunnableReadTask implements Runnable, Delayed {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -352,11 +352,17 @@ public class KafkaConsumerManager {
 
     @Override
     protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
-      return new ReadFutureTask(runnable, value);
+      if (runnable instanceof RunnableReadTask) {
+        return new ReadFutureTask(runnable, value);
+      }
+      return super.newTaskFor(runnable, value);
     }
 
     protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
-      return new ReadFutureTask<T>(callable);
+      if (callable instanceof RunnableReadTask) {
+        return new ReadFutureTask(callable);
+      }
+      return super.newTaskFor((callable);
     }
 
   }


### PR DESCRIPTION
```  java 
this.executor = new KafkaConsumerThreadPoolExecutor(0, maxThreadCount,
            60L, TimeUnit.SECONDS,
            new SynchronousQueue<Runnable>(),
            new RejectedExecutionHandler() {
            @Override
            public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
              log.debug("The runnable {} was rejected execution. "
                  + "The thread pool must be satured or shutiing down", r);
              if (r instanceof ReadFutureTask) {
                ReadFutureTask readFutureTask = (ReadFutureTask) r;
                RunnableReadTask readTask = (RunnableReadTask)readFutureTask.getReadTask();
                readTask.delayFor(ThreadLocalRandom.current().nextInt(25, 76));
              } else {
                // run commitOffset and consumer close tasks from the caller thread
                if (!executor.isShutdown()) {
                  r.run();
                }
              }
            }
          }
    );
```   
in RejectedExecutionHandler the rejectedExecution method,the runnable is the future task type,so Can't convert directly like  

```  java
 RunnableReadTask readTask = (r)readFutureTask.getReadTask();
``` 
because the runnable is the future task type.
wo can override the 
```  java
  public KafkaConsumerThreadPoolExecutor(int corePoolSize,
                                               int maximumPoolSize,
                                               long keepAliveTime,
                                               TimeUnit unit,
                                               BlockingQueue<Runnable> workQueue,
                                               RejectedExecutionHandler handler) {
       super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);

     }

       @Override
       protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
        return new ReadFutureTask(runnable, value);
       }
    }
``` 
and get the task like this 
```   java
if (r instanceof ReadFutureTask) {
                ReadFutureTask readFutureTask = (ReadFutureTask) r;
                RunnableReadTask readTask = (RunnableReadTask)readFutureTask.getReadTask();
                readTask.delayFor(ThreadLocalRandom.current().nextInt(25, 76));
              }
``` 
