### PR TITLE
CPKAFKA-1865:  Performance degrades drastically after running for extended periods

### DIFF
--- a/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -259,7 +259,7 @@ public class ConsumerManager {
           public void onCompletion(
               List<? extends ConsumerRecord<ClientKeyT, ClientValueT>> records, Exception e
           ) {
-            updateExpiration(state);
+            state.updateExpiration();
             if (e != null) {
               // Ensure caught exceptions are converted to RestExceptions so the user gets a
               // nice error message. Currently we don't define any more specific errors because
@@ -307,7 +307,7 @@ public class ConsumerManager {
           }
           callback.onCompletion(null, responseException);
         } finally {
-          updateExpiration(state);
+          state.updateExpiration();
         }
       }
     });
@@ -360,10 +360,6 @@ public class ConsumerManager {
 
   private ConsumerState getConsumerInstance(String group, String instance) {
     return getConsumerInstance(group, instance, false);
-  }
-
-  private synchronized void updateExpiration(ConsumerState state) {
-    state.updateExpiration();
   }
 
   public interface ConsumerFactory {

--- a/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -372,6 +372,10 @@ public class ConsumerManager {
   }
 
   private synchronized void updateExpiration(ConsumerState state) {
+    if (!consumers.containsKey(state.getId())) {
+      return;
+    }
+
     state.updateExpiration();
     consumersByExpiration.remove(state);
     consumersByExpiration.add(state);

--- a/src/main/java/io/confluent/kafkarest/ConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerState.java
@@ -145,10 +145,6 @@ public abstract class ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientVa
                       + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
   }
 
-  public long untilExpiration(long nowMs) {
-    return this.expiration - nowMs;
-  }
-
   public KafkaRestConfig getConfig() {
     return config;
   }

--- a/src/main/java/io/confluent/kafkarest/ConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerState.java
@@ -43,7 +43,7 @@ public abstract class ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientVa
   private ConsumerInstanceId instanceId;
   private ConsumerConnector consumer;
   private Map<String, ConsumerTopicState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>> topics;
-  private long expiration;
+  private volatile long expiration;
   // A read/write lock on the ConsumerState allows concurrent readTopic calls, but allows
   // commitOffsets to safely lock the entire state in order to get correct information about all
   // the topic/stream's current offset state. All operations on individual TopicStates must be

--- a/src/main/java/io/confluent/kafkarest/ConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/ConsumerState.java
@@ -37,8 +37,7 @@ import kafka.serializer.Decoder;
  * {@code KafkaMessageAndMetadata<K,V>} values to ConsumerRecords that can be returned to the client
  * (including translation if the decoded Kafka consumer type and ConsumerRecord types differ).
  */
-public abstract class ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
-    implements Comparable<ConsumerState> {
+public abstract class ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
 
   private KafkaRestConfig config;
   private ConsumerInstanceId instanceId;
@@ -151,17 +150,6 @@ public abstract class ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientVa
 
   public void setConfig(KafkaRestConfig config) {
     this.config = config;
-  }
-
-  @Override
-  public int compareTo(ConsumerState o) {
-    if (this.expiration < o.expiration) {
-      return -1;
-    } else if (this.expiration == o.expiration) {
-      return 0;
-    } else {
-      return 1;
-    }
   }
 
   public ConsumerTopicState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> getOrCreateTopicState(

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -475,6 +475,7 @@ public class KafkaConsumerManager {
     if (state == null) {
       throw Errors.consumerInstanceNotFoundException();
     }
+    state.updateExpiration();
     return state;
   }
 
@@ -499,9 +500,9 @@ public class KafkaConsumerManager {
 
     @Override
     public void run() {
-      synchronized (KafkaConsumerManager.this) {
-        try {
-          while (isRunning.get()) {
+      try {
+        while (isRunning.get()) {
+          synchronized (KafkaConsumerManager.this) {
             long now = time.milliseconds();
             Iterator itr = consumers.values().iterator();
             while (itr.hasNext()) {
@@ -517,12 +518,12 @@ public class KafkaConsumerManager {
                 });
               }
             }
-
-            KafkaConsumerManager.this.wait(1000);
           }
-        } catch (InterruptedException e) {
-          // Interrupted by other thread, do nothing to allow this thread to exit
+
+          Thread.sleep(1000);
         }
+      } catch (InterruptedException e) {
+        // Interrupted by other thread, do nothing to allow this thread to exit
       }
       shutdownLatch.countDown();
     }

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -278,7 +278,7 @@ public class KafkaConsumerManager {
           public void onCompletion(
               List<? extends ConsumerRecord<ClientKeyT, ClientValueT>> records, Exception e
           ) {
-            updateExpiration(state);
+            state.updateExpiration();
             if (e != null) {
               // Ensure caught exceptions are converted to RestExceptions so the user gets a
               // nice error message. Currently we don't define any more specific errors because
@@ -329,7 +329,7 @@ public class KafkaConsumerManager {
           }
           callback.onCompletion(null, responseException);
         } finally {
-          updateExpiration(state);
+          state.updateExpiration();
         }
       }
     });
@@ -480,15 +480,6 @@ public class KafkaConsumerManager {
   private KafkaConsumerState getConsumerInstance(String group, String instance) {
     return getConsumerInstance(group, instance, false);
   }
-
-  /*
-    Update the expiration of a KafkaConsumerState.
-    Synchronized to avoid race conditions with the ExpirationThread
-   */
-  private synchronized void updateExpiration(KafkaConsumerState state) {
-    state.updateExpiration();
-  }
-
 
   public interface KafkaConsumerFactory {
 

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -494,6 +494,10 @@ public class KafkaConsumerManager {
   }
 
   private synchronized void updateExpiration(KafkaConsumerState state) {
+    if (!consumers.containsKey(state.getId())) {
+      return;
+    }
+
     state.updateExpiration();
     consumersByExpiration.remove(state);
     consumersByExpiration.add(state);

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -64,7 +64,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
   private int index = 0;
 
 
-  private long expiration;
+  private volatile long expiration;
   // A read/write lock on the KafkaConsumerState allows concurrent readRecord calls, but allows
   // commitOffsets to safely lock the entire state in order to get correct information about all
   // the topic/stream's current offset state. All operations on individual TopicStates must be

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -371,10 +371,6 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
                       + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
   }
 
-  public long untilExpiration(long nowMs) {
-    return this.expiration - nowMs;
-  }
-
   public KafkaRestConfig getConfig() {
     return config;
   }

--- a/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -53,8 +53,7 @@ import kafka.serializer.Decoder;
  * {@code KafkaMessageAndMetadata<K,V>} values to ConsumerRecords that can be returned to the client
  * (including translation if the decoded Kafka consumer type and ConsumerRecord types differ).
  */
-public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>
-    implements Comparable<KafkaConsumerState> {
+public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
 
   private KafkaRestConfig config;
   private ConsumerInstanceId instanceId;
@@ -377,17 +376,6 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
 
   public void setConfig(KafkaRestConfig config) {
     this.config = config;
-  }
-
-  @Override
-  public int compareTo(KafkaConsumerState o) {
-    if (this.expiration < o.expiration) {
-      return -1;
-    } else if (this.expiration == o.expiration) {
-      return 0;
-    } else {
-      return 1;
-    }
   }
 
   /**

--- a/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -38,7 +38,7 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
   // This is pretty large since there is sometimes significant overhead to doing a read (e.g.
   // checking topic existence in ZK)
   private static final Integer instanceTimeout = 1000;
-  private static final Integer slackTime = 5;
+  private static final Integer slackTime = 1100;
 
   @Before
   @Override


### PR DESCRIPTION
### Problem
The REST Proxy has a memory leak in maintaining one data structure.

Its `consumersByExpiration` priority queue is supposed to track the consumer that is closest to expiry. There is a separate `ExpirationThread` that monitors this structure and deletes a consume if it has expired.

We update a consumer's expiration and add it back to the queue (so it can re-order itself) on every `poll()` call. The root problem is that we do not remove the old consumer instance from the queue. This results in a `consumersByExpiration` structure with huge sizes, since `poll()` is called very often, especially when consuming high volumes of records. (max.poll.records is set to 30 by default) Even worse, the proxy is currently configured to `poll()` repeatedly with a timeout of 50ms until the default consume ('/records` endpoint) request timeout of 1000ms is reached.

Testing locally 4 clients consuming and producing every second, the `consumersByExpiration` structure would reach 5.5 million elements in under five minutes.

This explains the CPU usage and the consumer creation requests blocking for a long time in the escalation ticket.

This problem has always been present in both the v1 and v2 consumer implementation. The reason it popped up now in the v2 implementation is that the recent changes in https://github.com/confluentinc/kafka-rest/pull/476 made more frequent calls to `updateExpiration`

### Solution
Remove the consumer from `consumersByExpiration` prior to adding it when updating its expiry.
The overall state machine should now ensure that `consumersByExpiration` contains 1 entry per consumer in the proxy.

1. Create consumer -> add to `consumersByExpiration`
2. Delete consumer - remove from `consumersByExpiration`
3. Update expiry - remove and add to `consumersByExpiration`

There also existed a race condition where a concurrent read/offset-commit might re-add the consumer to `consumersByExpiration` because of the expiration update. Adding a check to see if the consumer is present from the `consumers` data structure (the source of truth for active consumer instances) should prevent this from happening.