### PR TITLE
CPKAFKA-1871: Fix problem where ReadTaskSchedulerThread would loop too often

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -420,7 +420,8 @@ public class ConsumerManager {
 
     @Override
     public long getDelay(TimeUnit unit) {
-      return waitExpirationMs - config.getTime().milliseconds();
+      return unit.convert(waitExpirationMs - config.getTime().milliseconds(),
+              TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -386,7 +386,7 @@ public class KafkaConsumerManager {
     @Override
     public long getDelay(TimeUnit unit) {
       long delayMs = waitExpirationMs - config.getTime().milliseconds();
-      return TimeUnit.MILLISECONDS.convert(delayMs, unit);
+      return unit.convert(delayMs, TimeUnit.MILLISECONDS);
     }
 
     @Override


### PR DESCRIPTION
The problem originates from the `getDelay` implementation here:
https://github.com/confluentinc/kafka-rest/blob/2928ac85ae77d2350c774271c5c6d4ae0d34c317/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L389

We want each read task to be delayed for at least 50 milliseconds but the conversion done there takes the 50 milliseconds leftover as nanoseconds and converts them to milliseconds (returning 0). This causes the ReadTaskSchedulerThread to use more CPU than needed by looping read tasks and calling `poll()` too often