### PR TITLE
CPKAFKA-1868: Improve consumer tests

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -420,7 +420,8 @@ public class ConsumerManager {
 
     @Override
     public long getDelay(TimeUnit unit) {
-      return waitExpirationMs - config.getTime().milliseconds();
+      return unit.convert(waitExpirationMs - config.getTime().milliseconds(),
+              TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -345,7 +345,7 @@ public class ConsumerManager {
     return state;
   }
 
-  private ConsumerState getConsumerInstance(String group, String instance) {
+  ConsumerState getConsumerInstance(String group, String instance) {
     return getConsumerInstance(group, instance, false);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -72,7 +72,7 @@ public class ConsumerManager {
   // they're also comparatively rare. These are executed serially in a dedicated thread.
   private final ExecutorService executor;
   private ConsumerFactory consumerFactory;
-  private final DelayQueue<RunnableReadTask> delayedReadTasks = new DelayQueue<>();
+  final DelayQueue<RunnableReadTask> delayedReadTasks = new DelayQueue<>();
   private final ReadTaskSchedulerThread readTaskSchedulerThread;
   private final ExpirationThread expirationThread;
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerState.java
@@ -42,7 +42,7 @@ public abstract class ConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientVa
   private ConsumerInstanceId instanceId;
   private ConsumerConnector consumer;
   private Map<String, ConsumerTopicState<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT>> topics;
-  private volatile long expiration;
+  volatile long expiration;
   // A read/write lock on the ConsumerState allows concurrent readTopic calls, but allows
   // commitOffsets to safely lock the entire state in order to get correct information about all
   // the topic/stream's current offset state. All operations on individual TopicStates must be

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -97,7 +97,7 @@ public class KafkaConsumerManager {
   // are executed separately in dedicated threads via a cached thread pool.
   private final ExecutorService executor;
   private KafkaConsumerFactory consumerFactory;
-  private final DelayQueue<RunnableReadTask> delayedReadTasks = new DelayQueue<>();
+  final DelayQueue<RunnableReadTask> delayedReadTasks = new DelayQueue<>();
   private final ExpirationThread expirationThread;
   private ReadTaskSchedulerThread readTaskSchedulerThread;
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -386,7 +386,7 @@ public class KafkaConsumerManager {
     @Override
     public long getDelay(TimeUnit unit) {
       long delayMs = waitExpirationMs - config.getTime().milliseconds();
-      return TimeUnit.MILLISECONDS.convert(delayMs, unit);
+      return unit.convert(delayMs, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -345,7 +345,6 @@ public class KafkaConsumerManager {
 
       long delay = delayMs + config.getTime().milliseconds();
       waitExpirationMs = Math.min(delay, requestExpiration);
-      log.trace("{} {}", waitExpirationMs, config.getTime().milliseconds());
       // add to delayedReadTasks so the scheduler thread can re-schedule another partial read later
       delayedReadTasks.add(this);
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -578,7 +578,7 @@ public class KafkaConsumerManager {
     return state;
   }
 
-  private KafkaConsumerState getConsumerInstance(String group, String instance) {
+  KafkaConsumerState getConsumerInstance(String group, String instance) {
     return getConsumerInstance(group, instance, false);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -345,6 +345,7 @@ public class KafkaConsumerManager {
 
       long delay = delayMs + config.getTime().milliseconds();
       waitExpirationMs = Math.min(delay, requestExpiration);
+      log.trace("{} {}", waitExpirationMs, config.getTime().milliseconds());
       // add to delayedReadTasks so the scheduler thread can re-schedule another partial read later
       delayedReadTasks.add(this);
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -61,7 +61,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
 
   private Queue<ConsumerRecord<KafkaKeyT, KafkaValueT>> consumerRecords = new ArrayDeque<>();
 
-  private volatile long expiration;
+  volatile long expiration;
   private ReentrantLock lock;
 
   public KafkaConsumerState(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
@@ -1,0 +1,172 @@
+package io.confluent.kafkarest.v2;
+
+import io.confluent.kafkarest.ConsumerReadCallback;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.SystemTime;
+import io.confluent.kafkarest.entities.BinaryConsumerRecord;
+import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
+import io.confluent.kafkarest.entities.ConsumerRecord;
+import io.confluent.kafkarest.entities.ConsumerSubscriptionRecord;
+import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.rest.exceptions.RestException;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.IExpectationSetters;
+import org.easymock.Mock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+@RunWith(EasyMockRunner.class)
+public class LoadTest {
+
+    private KafkaRestConfig config;
+    @Mock
+    private KafkaConsumerManager.KafkaConsumerFactory consumerFactory;
+
+    private KafkaConsumerManager consumerManager;
+
+    private static final String topicName = "testtopic";
+
+    private Capture<Properties> capturedConsumerConfig;
+
+    private long requestTimeoutMs = 1000;
+
+    class ConsumerTestRun {
+        private final MockConsumer consumer;
+        private volatile boolean sawCallback;
+        private ConsumerReadCallback callback;
+        private RestException actualException;
+        private List<? extends ConsumerRecord<byte[], byte[]>> actualRecords = null;
+        private int latestOffset = 0;
+
+        ConsumerTestRun(MockConsumer consumer) {
+            this.consumer = consumer;
+            sawCallback = false;
+            callback = new ConsumerReadCallback<byte[], byte[]>() {
+                @Override
+                public void onCompletion(List<? extends ConsumerRecord<byte[], byte[]>> records, RestException e) {
+                    sawCallback = true;
+                    actualRecords = records;
+                    actualException = e;
+                }
+            };
+        }
+
+        void bootstrap() {
+            bootstrapConsumer(consumer);
+        }
+
+        void read() {
+            assertNull(actualException);
+            assertNull(actualRecords);
+            assertFalse(sawCallback);
+            schedulePoll();
+            consumerManager.readRecords(consumer.groupName, consumer.cid(), BinaryKafkaConsumerState.class,
+                    -1, Long.MAX_VALUE, callback);
+        }
+
+        void verifyRead() {
+            Assert.assertTrue("Callback failed to fire", sawCallback);
+            assertNull("There shouldn't be an exception in callback", actualException);
+            List<ConsumerRecord<byte[], byte[]>> expectedRecords = referenceRecords();
+            assertEquals("Records returned not as expected", expectedRecords, actualRecords);
+
+            sawCallback = false;
+            actualRecords = null;
+            actualException = null;
+        }
+
+        private List<ConsumerRecord<byte[], byte[]>> referenceRecords() {
+            return Arrays.<ConsumerRecord<byte[], byte[]>>asList(
+                    new BinaryConsumerRecord(topicName, "k1".getBytes(), "v1".getBytes(), 0, latestOffset - 3),
+                    new BinaryConsumerRecord(topicName, "k2".getBytes(), "v2".getBytes(), 0, latestOffset - 2),
+                    new BinaryConsumerRecord(topicName, "k3".getBytes(), "v3".getBytes(), 0, latestOffset - 1)
+            );
+        }
+
+        private void schedulePoll() {
+            consumer.schedulePollTask(new Runnable() {
+                @Override
+                public void run() {
+                    consumer.addRecord(new org.apache.kafka.clients.consumer.ConsumerRecord<>(topicName, 0, latestOffset, "k1".getBytes(), "v1".getBytes()));
+                    consumer.addRecord(new org.apache.kafka.clients.consumer.ConsumerRecord<>(topicName, 0, latestOffset + 1, "k2".getBytes(), "v2".getBytes()));
+                    consumer.addRecord(new org.apache.kafka.clients.consumer.ConsumerRecord<>(topicName, 0, latestOffset + 2, "k3".getBytes(), "v3".getBytes()));
+                    latestOffset += 3;
+                }
+            });
+        }
+    }
+
+    /**
+     * Test continuous reads for 60 seconds. 50 consumers, separated in 5 consumer groups.
+     */
+    @Test
+    public void testMultipleConsumerMultipleGroups() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://hostname:9092");
+        props.setProperty(KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG, "-1");
+        props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, Long.toString(requestTimeoutMs));
+        config = new KafkaRestConfig(props, new SystemTime());
+        consumerManager = new KafkaConsumerManager(config, consumerFactory);
+        List<ConsumerTestRun> consumers = new ArrayList<>();
+        for (int group = 0; group < 5; group++) {
+            for (int i = 0; i < 10; i++) {
+                consumers.add(new ConsumerTestRun(
+                        new MockConsumer<>(OffsetResetStrategy.EARLIEST, Integer.toString(group))));
+            }
+        }
+        capturedConsumerConfig = Capture.newInstance();
+        Properties properties = EasyMock.capture(capturedConsumerConfig);
+        IExpectationSetters<Consumer> a = EasyMock.expect(consumerFactory.createConsumer(properties));
+        Method andReturnInstance = a.getClass().getMethod("andReturn", Object.class);
+        for (ConsumerTestRun run: consumers) {
+            andReturnInstance.invoke(a, run.consumer);
+        }
+        EasyMock.replay(consumerFactory);
+
+        for (ConsumerTestRun run: consumers) {
+            run.bootstrap();
+        }
+
+        for (ConsumerTestRun run: consumers) {
+            run.read();
+        }
+        for (int i = 0; i < 60; i++) {
+            awaitRead();
+            for (ConsumerTestRun run: consumers) {
+                run.verifyRead();
+                run.read();
+            }
+        }
+    }
+
+    private void awaitRead() throws InterruptedException {
+        Thread.sleep((long) (requestTimeoutMs * 1.5));
+    }
+
+    private void bootstrapConsumer(final MockConsumer<byte[], byte[]> consumer) {
+        String cid = consumerManager.createConsumer(
+                consumer.groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+
+        consumer.cid(cid);
+        consumerManager.subscribe(consumer.groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+        consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
+        consumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(topicName, 0), 0L));
+    }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/MockConsumer.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/MockConsumer.java
@@ -1,0 +1,21 @@
+package io.confluent.kafkarest.v2;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+
+public class MockConsumer<K, V> extends org.apache.kafka.clients.consumer.MockConsumer<K, V> {
+    private String cid;
+    String groupName;
+
+    MockConsumer(OffsetResetStrategy offsetResetStrategy, String groupName) {
+        super(offsetResetStrategy);
+        this.groupName = groupName;
+    }
+
+    public String cid() {
+        return cid;
+    }
+
+    public void cid(String cid) {
+        this.cid = cid;
+    }
+}


### PR DESCRIPTION
This PR adds:
* tests verifying that the `DelayQueue<RunnableReadTask> delayedReadTasks` is populated
* tests verifying that `RunnableReadTask` delays are updated
* tests verifying that `backoff.ms` affects task re-schedules
* a bigger, integration-like load tests where we spawn 50 consumers and run for 1 minute