### PR TITLE
remove usage of deprecated easymock methods

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AbstractConsumerResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AbstractConsumerResourceTest.java
@@ -105,7 +105,7 @@ public class AbstractConsumerResourceTest
       final Exception readException) {
     final Capture<ConsumerReadCallback>
         readCallback =
-        new Capture<ConsumerReadCallback>();
+        Capture.newInstance();
     consumerManager
         .readTopic(EasyMock.eq(groupName), EasyMock.eq(instanceId), EasyMock.eq(topicName),
                    EasyMock.eq(stateClass), EasyMock.eq(maxBytes), EasyMock.capture(readCallback));
@@ -130,7 +130,7 @@ public class AbstractConsumerResourceTest
                               final Exception commitException) {
     final Capture<ConsumerManager.CommitCallback>
         commitCallback =
-        new Capture<ConsumerManager.CommitCallback>();
+        Capture.newInstance();
     consumerManager.commitOffsets(EasyMock.eq(groupName), EasyMock.eq(instanceId),
                                   EasyMock.capture(commitCallback));
     EasyMock.expectLastCall().andAnswer(new IAnswer<Object>() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/ConsumerManagerTest.java
@@ -115,7 +115,7 @@ public class ConsumerManagerTest {
             config.getTime(), "testclient", schedules,
             Integer.parseInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_DEFAULT),
             allowMissingSchedule);
-    capturedConsumerConfig = new Capture<ConsumerConfig>();
+    capturedConsumerConfig = Capture.newInstance();
     EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(capturedConsumerConfig)))
                         .andReturn(consumer);
     return consumer;
@@ -144,7 +144,7 @@ public class ConsumerManagerTest {
             config.getTime(), "testclient", null,
             Integer.parseInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_DEFAULT),
             true);
-    final Capture<ConsumerConfig> consumerConfig = new Capture<ConsumerConfig>();
+    final Capture<ConsumerConfig> consumerConfig = Capture.newInstance();
     EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
         .andReturn(consumer);
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAbstractConsumeTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAbstractConsumeTest.java
@@ -49,7 +49,7 @@ public class PartitionsResourceAbstractConsumeTest extends EmbeddedServerTestHar
   }
 
   protected void expectConsume(final EmbeddedFormat embeddedFormat,  final List<? extends ConsumerRecord> records) {
-    final Capture<ConsumerReadCallback> readCallback = new Capture<ConsumerReadCallback>();
+    final Capture<ConsumerReadCallback> readCallback = Capture.newInstance();
     simpleConsumerManager.consume(
         EasyMock.eq(topicName),
         EasyMock.eq(partitionId),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
@@ -126,7 +126,7 @@ public class PartitionsResourceAvroProduceTest
                                              final List<RecordMetadataOrException> results) {
     final Capture<ProducerPool.ProduceRequestCallback>
         produceCallback =
-        new Capture<ProducerPool.ProduceRequestCallback>();
+        Capture.newInstance();
     EasyMock.expect(adminClientWrapper.topicExists(topic)).andReturn(true);
     EasyMock.expect(adminClientWrapper.partitionExists(topic, partition)).andReturn(true);
     producerPool.produce(EasyMock.eq(topic),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
@@ -121,7 +121,7 @@ public class PartitionsResourceBinaryProduceTest
     request.setRecords(records);
     final Capture<ProducerPool.ProduceRequestCallback>
         produceCallback =
-        new Capture<ProducerPool.ProduceRequestCallback>();
+        Capture.newInstance();
     EasyMock.expect(adminClientWrapper.topicExists(topic)).andReturn(true);
     EasyMock.expect(adminClientWrapper.partitionExists(topic, partition)).andReturn(true);
     producerPool.produce(EasyMock.eq(topic),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceAvroProduceTest.java
@@ -129,7 +129,7 @@ public class TopicsResourceAvroProduceTest
                                          final List<RecordMetadataOrException> results) {
     final Capture<ProducerPool.ProduceRequestCallback>
         produceCallback =
-        new Capture<ProducerPool.ProduceRequestCallback>();
+        Capture.newInstance();
     producerPool.produce(EasyMock.eq(topic),
         EasyMock.eq((Integer) null),
         EasyMock.eq(recordFormat),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/TopicsResourceBinaryProduceTest.java
@@ -164,7 +164,7 @@ public class TopicsResourceBinaryProduceTest
     request.setRecords(records);
     final Capture<ProducerPool.ProduceRequestCallback>
         produceCallback =
-        new Capture<ProducerPool.ProduceRequestCallback>();
+        Capture.newInstance();
     producerPool.produce(EasyMock.eq(topic),
                          EasyMock.eq((Integer) null),
                          EasyMock.eq(recordFormat),


### PR DESCRIPTION
methods have been removed in easymock 4.x