### PR TITLE
MINOR: Increase CI job timeout.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@
 common {
   slackChannel = '#kafka-core-eng '
   upstreamProjects = 'confluentinc/schema-registry'
+  timeoutHours = 2
 }


### PR DESCRIPTION
 I chose 4.0.x, based on Jenkins history. Looks like the failure is intermittently present in jobs for this version and higher.

The default for main job stage is 1 hour, per the common jobConfig.