### PR TITLE
Set consumer setting max.poll.interval.ms to rest proxy setting of co…

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ConsumerManager.java
@@ -185,6 +185,12 @@ public class ConsumerManager {
       // functionality, we always use a timeout. This can't perfectly guarantee a total request
       // timeout, but can get as close as this timeout's value
       props.setProperty("consumer.timeout.ms", Integer.toString(iteratorTimeoutMs));
+      // If the consumer.timeout.ms value is set higher than the default value
+      // for max.poll.interval.ms then it is possible the consumer will be
+      // considered failed by the brokers while it has yet to hit the timeout
+      // for the rest proxy.
+      props.setProperty("max.poll.interval.ms", ((Integer) iteratorTimeoutMs).toString());
+
       if (instanceConfig.getAutoCommitEnable() != null) {
         props.setProperty("auto.commit.enable", instanceConfig.getAutoCommitEnable());
       } else {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -216,6 +216,12 @@ public class KafkaConsumerManager {
       // and should not be propagated to the consumer
       props.setProperty("request.timeout.ms", "30000");
 
+      // If the consumer.timeout.ms value is set higher than the default value
+      // for max.poll.interval.ms then it is possible the consumer will be
+      // considered failed by the brokers while it has yet to hit the timeout
+      // for the rest proxy.
+      props.setProperty("max.poll.interval.ms", props.getProperty("consumer.timeout.ms", ""));
+
       props.setProperty(
           "schema.registry.url",
           config.getString(KafkaRestConfig.SCHEMA_REGISTRY_URL_CONFIG)


### PR DESCRIPTION
…nsumer.timeout.ms

If `consumer.timeout.ms` has been set to a value greater than the default value of `max.poll.interval.ms` and a consumer has set `auto.commit.enable=false` then it is possible the kafka brokers will consider a consumer as failed and release its partition assignments, while the rest proxy maintains a consumer instance handle. This then leads to an exception on the next call to poll, commitSync, or similar.

This commit sets max.poll.interval.ms equal to consumer.timeout.ms to ensure that kafka will not consider the consumer failed until the rest proxy does as well.

Steps to reproduce the issue : 
- Kafka version 0.10.1.0 or higher (where `max.poll.interval.ms` is introduced)
- Set `consumer.timeout.ms` to a value greater than the `max.poll.interval.ms` default of 5 minutes
- Create a consumer via the rest proxy
- Sleep for a time greater than `max.poll.interval.ms` but less than `consumer.timeout.ms`
- Have consumer attempt to read a record or post an offset