### PR TITLE
Explain `fetch.min.bytes`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -767,11 +767,10 @@ any consumers before it is terminated.
                          defaults to "binary".
    :<json string auto.offset.reset: Sets the ``auto.offset.reset`` setting for the consumer
    :<json string auto.commit.enable: Sets the ``auto.commit.enable`` setting for the consumer
-   :<json string fetch.min.bytes: Sets the ``fetch.min.bytes``
-                                                    setting for this consumer specifically
+   :<json string fetch.min.bytes: Minimal amount of bytes to return before timeout has been reached. This setting allows consumer to return before timeout is reached. Default is `-1`
    :<json string consumer.request.timeout.ms: Sets the ``consumer.request.timeout.ms`` setting for this consumer specifically.
                                               This setting controls the maximum total time to wait for messages for a request
-                                              if the maximum request size has not yet been reached.
+                                              if the maximum request size has not yet been reached. If you want to return earlier than that if a given byte threshold is reached, configure `fetch.min.bytes`.
                                               It does not affect the underlying consumer->broker connection. Default value is taken from the REST proxy config file  
 
    :>json string instance_id: Unique ID for the consumer instance in this group.


### PR DESCRIPTION
Another follow up from #481 , this time trying to explain minimal amount of bytes to fetch from consumer