### PR TITLE
Pin org.apache.kafka version to 1.1 in tests

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -26,11 +26,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${kafka.scala.version}</artifactId>
-            <version>1.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>1.1.0</version>
         </dependency>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -26,6 +26,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>1.1.0</version>
         </dependency>
@@ -65,6 +70,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>1.1.0</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This PR fixes an error we started getting with the new 2.2 AK version - 
```
java.lang.NoSuchMethodError: kafka.server.KafkaServer.dataPlaneRequestProcessor()Lkafka/server/KafkaApis;
	at io.confluent.kafkarest.integration.AvroProducerTest.setUp(AvroProducerTest.java:127)
```

For some reason, the tests' `TestUtils` would receive a 1.1 version of the `KafkaServer` (without `KafkaServer#dataPlaneRequestProcessor`) whereas it used the 2.2 API - `KafkaServer#dataPlaneRequestProcessor()`

I am not exactly sure how this is possible and how that even works, considering they use the same namespace. Do we construct one version of `KafkaServer` in bytecode and expect another?
This change seems to fix the issue, though

https://confluent.slack.com/archives/C3226NBLJ/p1548554920773700
https://jenkins.confluent.io/job/confluentinc/job/kafka-rest/job/master/1462/