### PR TITLE
CPKAFKA-2590: Bump ZK connection timeout to avoid test flakes.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -95,7 +95,7 @@ public abstract class ClusterTestHarness {
   protected String zkConnect;
   protected EmbeddedZookeeper zookeeper;
   protected KafkaZkClient zkClient;
-  protected int zkConnectionTimeout = 6000;
+  protected int zkConnectionTimeout = 10000;
   protected int zkSessionTimeout = 6000;
 
   // Kafka Config


### PR DESCRIPTION
Also addresses CPKAFKA-2591.

This PR just bumps the timeout for connecting to Zookeeper in ClusterTestHarness. There seemed to be multiple tests flaking due to:
```
kafka.zookeeper.ZooKeeperClientTimeoutException: Timed out waiting for connection while in state: CONNECTING
```

I ran the tests 20 times locally and could not reproduce the above error.