### PR TITLE
CPKAFKA-2810: Update file descriptor limit to 1 million

### DIFF
--- a/debian/confluent-kafka-rest.service
+++ b/debian/confluent-kafka-rest.service
@@ -9,7 +9,7 @@ User=cp-kafka-rest
 Group=confluent
 Environment="LOG_DIR=/var/log/confluent/kafka-rest"
 ExecStart=/usr/bin/kafka-rest-start /etc/kafka-rest/kafka-rest.properties
-LimitNOFILE=1000000
+LimitNOFILE=100000
 TimeoutStopSec=180
 Restart=no
 

--- a/debian/confluent-kafka-rest.service
+++ b/debian/confluent-kafka-rest.service
@@ -9,6 +9,7 @@ User=cp-kafka-rest
 Group=confluent
 Environment="LOG_DIR=/var/log/confluent/kafka-rest"
 ExecStart=/usr/bin/kafka-rest-start /etc/kafka-rest/kafka-rest.properties
+LimitNOFILE=1000000
 TimeoutStopSec=180
 Restart=no
 


### PR DESCRIPTION
Kafka rest proxy opens a lot of files while running. And systemd ignores the
open file limit in /etc/security/limits.conf.

So this change updates kafka-rest.service systemd service file that we
ship to increase open file descriptor limit by adding this line in
[Service] section:

LimitNOFILE=1000000

This sets both hard and soft limit for "the maximum number of open file
descriptors" the program will use. NOTE: If we want to set different
value for hard and soft limits, the syntax is "soft:hard".