### PR TITLE
ST-1704 and ST-1705: Fix usage of variable

### DIFF
--- a/create_spec.sh
+++ b/create_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # create_spec.sh spec.in out.spec
-CONFLUENT_PATCH = "cp"
+CONFLUENT_PATCH="cp"
 set -e
 
 echo "Creating the spec file"


### PR DESCRIPTION
Due to extra spaces, the variable is being interpreted as a command and
the variable is never assigned. This causes later logic to always treat
this as a hotfix version.