### PR TITLE
Fix call to TestUtil.createBrokerConfig

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -88,7 +88,7 @@ import static org.junit.Assert.assertTrue;
         0, "", false, false, kafka.utils.TestUtils.RandomPort(), securityProtocolOption,
         Option.empty(), saslProperties, true, true, kafka.utils.TestUtils.RandomPort(),
         false, kafka.utils.TestUtils.RandomPort(), false, kafka.utils.TestUtils.RandomPort(), Option.empty(), 1,
-        false);
+        false, 1, (short) 1);
     brokerProps.put(KafkaConfig.BrokerIdProp(), Integer.toString(i));
     brokerProps.put(KafkaConfig.ZkConnectProp(), zkConnect);
     brokerProps.setProperty("authorizer.class.name", SimpleAclAuthorizer.class.getName());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -235,7 +235,8 @@ public abstract class ClusterTestHarness {
     Properties props = TestUtils.createBrokerConfig(
         i, zkConnect, false, false, TestUtils.RandomPort(), noInterBrokerSecurityProtocol,
         noFile, Option.<Properties>empty(), true, false, TestUtils.RandomPort(), false,
-        TestUtils.RandomPort(), false, TestUtils.RandomPort(), Option.<String>empty(), 1, false);
+        TestUtils.RandomPort(), false, TestUtils.RandomPort(), Option.<String>empty(), 1, false,
+        1, (short) 1);
     props.setProperty("auto.create.topics.enable", "false");
     // We *must* override this to use the port we allocated (Kafka currently allocates one port
     // that it always uses for ZK


### PR DESCRIPTION
https://github.com/apache/kafka/pull/6728/commits/5c54538b7dbecec781cf0418cc1dc44923003753 changed the signature of `TestUtils.createBrokerConfig`, this change fixes calls to that method.