### PR TITLE
MINOR: Include `zkclient` dependency to kafka-rest-scala-consumer shaded jar

### DIFF
--- a/kafka-rest-scala-consumer/pom.xml
+++ b/kafka-rest-scala-consumer/pom.xml
@@ -94,6 +94,7 @@
                         <includes>
                             <include>org.apache.kafka:kafka_${kafka.scala.version}</include>
                             <include>org.apache.kafka:kafka-clients</include>
+                            <include>com.101tec:zkclient</include>
                             <include>io.confluent:kafka-avro-serializer</include>
                             <include>io.confluent:kafka-json-serializer</include>
                         </includes>


### PR DESCRIPTION
We have removed `zkclient` dependency from Kafka.  kafka-rest-scala-consumer depends on zk-client. This PR includes `zkclient` dependency to kafka-rest-scala-consumer shade jar.