### PR TITLE
Add API to get beginning offset, end offset and offset for time.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -15,18 +15,8 @@
 
 package io.confluent.kafkarest;
 
-import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
-import io.confluent.rest.exceptions.KafkaExceptionMapper;
-import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
-import org.eclipse.jetty.util.StringUtil;
-
-import java.lang.reflect.Proxy;
-import java.util.List;
-import java.util.Properties;
-
-import javax.ws.rs.core.Configurable;
-
 import io.confluent.kafkarest.extension.ContextInvocationHandler;
+import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.extension.KafkaRestCleanupFilter;
 import io.confluent.kafkarest.extension.KafkaRestContextProvider;
 import io.confluent.kafkarest.extension.RestResourceExtension;
@@ -38,6 +28,14 @@ import io.confluent.kafkarest.resources.TopicsResource;
 import io.confluent.kafkarest.v2.KafkaConsumerManager;
 import io.confluent.rest.Application;
 import io.confluent.rest.RestConfigException;
+import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
+import io.confluent.rest.exceptions.KafkaExceptionMapper;
+import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Properties;
+import javax.ws.rs.core.Configurable;
+import org.eclipse.jetty.util.StringUtil;
 
 
 /**
@@ -107,6 +105,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     config.register(new io.confluent.kafkarest.resources.v2.ConsumersResource(context));
     config.register(new io.confluent.kafkarest.resources.v2.PartitionsResource(context));
     config.register(KafkaRestCleanupFilter.class);
+    config.register(InstantConverterProvider.class);
 
     for (RestResourceExtension restResourceExtension : restResourceExtensions) {
       restResourceExtension.register(config, appConfig);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicPartitionOffsetResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicPartitionOffsetResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
+/**
+ * Response for GET /topics/(topic)/partitions/(partition)/offsets requests.
+ *
+ * @see io.confluent.kafkarest.resources.v2.PartitionsResource#getOffsets(String, int)
+ */
+public final class TopicPartitionOffsetResponse {
+
+  private final long beginningOffset;
+  private final long endOffset;
+
+  public TopicPartitionOffsetResponse(long beginningOffset, long endOffset) {
+    this.beginningOffset = beginningOffset;
+    this.endOffset = endOffset;
+  }
+
+  /**
+   * The earliest offset in the topic partition.
+   */
+  @JsonProperty(value = "beginning_offset", access = Access.READ_ONLY)
+  public long getBeginningOffset() {
+    return beginningOffset;
+  }
+
+  /**
+   * The latest offset in the topic partition.
+   */
+  @JsonProperty(value = "end_offset", access = Access.READ_ONLY)
+  public long getEndOffset() {
+    return endOffset;
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/extension/InstantConverterProvider.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/extension/InstantConverterProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.extension;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import javax.annotation.Nullable;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * A {@link ParamConverterProvider} for {@link InstantConverter}.
+ *
+ * <p>By default it uses {@link DateTimeFormatter#ISO_INSTANT} format.</p>
+ *
+ * <p>TODO: If more formats are needed, create an annotation, e.g. DateTimeParam, and an
+ * enum, e.g. DateTimeFormat, and map from enum value to DateTimeFormatter. The annotation will be
+ * passed in {@link #getConverter(Class, Type, Annotation[])}.</p>
+ */
+@Provider
+public final class InstantConverterProvider implements ParamConverterProvider {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ParamConverter<T> getConverter(
+      Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (!rawType.equals(Instant.class)) {
+      return null;
+    }
+    return (ParamConverter<T>) new InstantConverter(DateTimeFormatter.ISO_INSTANT);
+  }
+
+  /**
+   * A {@link ParamConverter} for {@link Instant}.
+   */
+  private static final class InstantConverter implements ParamConverter<Instant> {
+
+    private final DateTimeFormatter formatter;
+
+    private InstantConverter(DateTimeFormatter formatter) {
+      this.formatter = requireNonNull(formatter, "formatter");
+    }
+
+    @Override
+    @Nullable
+    public Instant fromString(@Nullable String value) {
+      // Contrary to JAX-RS specification, if the parameter is not present in the requested URI
+      // Jersey will try to convert `null' instead of bypassing conversion and injecting `null'
+      // directly. Return `null' here so that it can be passed to the injection point as expected.
+      if (value == null) {
+        return null;
+      }
+      return formatter.parse(value, Instant::from);
+    }
+
+    @Override
+    public String toString(Instant value) {
+      return formatter.format(value);
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAbstractConsumeTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAbstractConsumeTest.java
@@ -15,19 +15,24 @@
 
 package io.confluent.kafkarest.unit;
 
-import io.confluent.kafkarest.*;
+import io.confluent.kafkarest.ConsumerReadCallback;
+import io.confluent.kafkarest.DefaultKafkaRestContext;
+import io.confluent.kafkarest.KafkaRestApplication;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.ScalaConsumersContext;
+import io.confluent.kafkarest.SimpleConsumerManager;
 import io.confluent.kafkarest.entities.ConsumerRecord;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.resources.PartitionsResource;
 import io.confluent.rest.EmbeddedServerTestHarness;
 import io.confluent.rest.RestConfigException;
+import java.util.List;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Response;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
-
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.core.Response;
-import java.util.List;
 
 public class PartitionsResourceAbstractConsumeTest extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
 
@@ -45,6 +50,7 @@ public class PartitionsResourceAbstractConsumeTest extends EmbeddedServerTestHar
     final DefaultKafkaRestContext ctx = new DefaultKafkaRestContext(config, null, null, null,
         scalaConsumersContext);
     addResource(new PartitionsResource(ctx));
+    addResource(InstantConverterProvider.class);
   }
 
   protected void expectConsume(final EmbeddedFormat embeddedFormat,  final List<? extends ConsumerRecord> records) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceAvroProduceTest.java
@@ -15,20 +15,9 @@
 
 package io.confluent.kafkarest.unit;
 
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.IAnswer;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
+import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
+import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static org.junit.Assert.assertEquals;
 
 import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
@@ -45,15 +34,24 @@ import io.confluent.kafkarest.entities.PartitionProduceRequest;
 import io.confluent.kafkarest.entities.ProduceRecord;
 import io.confluent.kafkarest.entities.ProduceResponse;
 import io.confluent.kafkarest.entities.SchemaHolder;
+import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.resources.PartitionsResource;
 import io.confluent.kafkarest.resources.TopicsResource;
 import io.confluent.rest.EmbeddedServerTestHarness;
 import io.confluent.rest.RestConfigException;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
-
-import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
-import static io.confluent.kafkarest.TestUtils.assertOKResponse;
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.Before;
+import org.junit.Test;
 
 // This test is much lighter than the Binary one since they would otherwise be mostly duplicated
 // -- this just sanity checks the Jersey processing of these requests.
@@ -91,6 +89,7 @@ public class PartitionsResourceAvroProduceTest
     );
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
+    addResource(InstantConverterProvider.class);
 
     produceRecordsWithKeys = Arrays.asList(
         new AvroProduceRecord(TestUtils.jsonTree("1"), TestUtils.jsonTree("{\"field\":42}")),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceBinaryProduceTest.java
@@ -15,26 +15,13 @@
 
 package io.confluent.kafkarest.unit;
 
-import io.confluent.kafkarest.Errors;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.TopicAuthorizationException;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.IAnswer;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
+import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
+import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static org.junit.Assert.assertEquals;
 
 import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestApplication;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.ProducerPool;
@@ -49,15 +36,26 @@ import io.confluent.kafkarest.entities.ProduceRecord;
 import io.confluent.kafkarest.entities.ProduceResponse;
 import io.confluent.kafkarest.entities.SchemaHolder;
 import io.confluent.kafkarest.entities.TopicProduceRequest;
+import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.resources.PartitionsResource;
 import io.confluent.kafkarest.resources.TopicsResource;
 import io.confluent.rest.EmbeddedServerTestHarness;
 import io.confluent.rest.RestConfigException;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
-
-import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
-import static io.confluent.kafkarest.TestUtils.assertOKResponse;
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.Before;
+import org.junit.Test;
 
 public class PartitionsResourceBinaryProduceTest
     extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
@@ -87,6 +85,7 @@ public class PartitionsResourceBinaryProduceTest
 
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
+    addResource(InstantConverterProvider.class);
 
     produceRecordsOnlyValues = Arrays.asList(
         new BinaryProduceRecord("value".getBytes()),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceConsumeTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceConsumeTest.java
@@ -1,0 +1,165 @@
+package io.confluent.kafkarest.unit;
+
+import static io.confluent.kafkarest.entities.EntityUtils.encodeBase64Binary;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafkarest.ConsumerReadCallback;
+import io.confluent.kafkarest.DefaultKafkaRestContext;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.KafkaRestContext;
+import io.confluent.kafkarest.ScalaConsumersContext;
+import io.confluent.kafkarest.SimpleConsumerManager;
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.BinaryConsumerRecord;
+import io.confluent.kafkarest.entities.ConsumerRecord;
+import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.kafkarest.extension.InstantConverterProvider;
+import io.confluent.kafkarest.resources.PartitionsResource;
+import io.confluent.kafkarest.v2.KafkaConsumerManager;
+import io.confluent.rest.RestConfigException;
+import io.confluent.rest.validation.JacksonMessageBodyProvider;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import javax.ws.rs.core.Application;
+import org.easymock.Capture;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PartitionsResourceConsumeTest extends JerseyTest {
+
+  private static final String TOPIC = "topic";
+  private static final int PARTITION = 1;
+  private static final long OFFSET = 30L;
+  private static final Instant TIMESTAMP = Instant.ofEpochMilli(1000L);
+  private static final long COUNT = 10L;
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+  private static final byte[] KEY = "key".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] VALUE = "value".getBytes(StandardCharsets.UTF_8);
+
+  private static final List<BinaryConsumerRecord> RECORDS =
+      unmodifiableList(
+          singletonList(new BinaryConsumerRecord(TOPIC, KEY, VALUE, PARTITION, OFFSET)));
+
+
+  private KafkaConsumerManager kafkaConsumerManager;
+  private SimpleConsumerManager simpleConsumerManager;
+
+  @Override
+  protected Application configure() {
+    ResourceConfig application = new ResourceConfig();
+    application.register(new PartitionsResource(createKafkaRestContext()));
+    application.register(InstantConverterProvider.class);
+    application.register(new JacksonMessageBodyProvider());
+    return application;
+  }
+
+  private KafkaRestContext createKafkaRestContext() {
+    kafkaConsumerManager = createMock(KafkaConsumerManager.class);
+    simpleConsumerManager = createMock(SimpleConsumerManager.class);
+
+    try {
+      return new DefaultKafkaRestContext(
+          new KafkaRestConfig(),
+          /* producerPool= */ null,
+          kafkaConsumerManager,
+          /* adminClientWrapper= */ null,
+          new ScalaConsumersContext(
+              /* metadataObserver= */ null,
+              /* consumerManager= */ null,
+              simpleConsumerManager));
+    } catch (RestConfigException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private <K, V> void expectConsume(
+      String topicName,
+      int partitionId,
+      long offset,
+      long count,
+      EmbeddedFormat embeddedFormat,
+      List<? extends ConsumerRecord<K, V>> records) {
+    Capture<ConsumerReadCallback<K, V>> callback = Capture.newInstance();
+    simpleConsumerManager.consume(
+        eq(topicName),
+        eq(partitionId),
+        eq(offset),
+        eq(count),
+        eq(embeddedFormat),
+        capture(callback));
+    expectLastCall().andAnswer(
+        () -> {
+          callback.getValue().onCompletion(records, /* e= */ null);
+          return null;
+        });
+  }
+
+  @Before
+  public void setUpMocks() {
+    reset(kafkaConsumerManager, simpleConsumerManager);
+  }
+
+  @Test
+  public void getMessages_withTimestamp_returnsMessagesAtTimestamp() {
+    expect(kafkaConsumerManager.getOffsetForTime(TOPIC, PARTITION, TIMESTAMP))
+        .andReturn(Optional.of(OFFSET));
+    expectConsume(TOPIC, PARTITION, OFFSET, COUNT, EmbeddedFormat.BINARY, RECORDS);
+    replay(kafkaConsumerManager, simpleConsumerManager);
+
+    String response =
+        target("/topics/{topic}/partitions/{partition}/messages")
+            .resolveTemplate("topic", TOPIC)
+            .resolveTemplate("partition", PARTITION)
+            .queryParam("timestamp", DATE_TIME_FORMATTER.format(TIMESTAMP))
+            .queryParam("count", COUNT)
+            .request(Versions.KAFKA_V1_JSON_BINARY)
+            .get(String.class);
+
+    assertEquals("[{"
+            + "\"topic\":\"" + TOPIC + "\","
+            + "\"key\":\"" + encodeBase64Binary(KEY) + "\","
+            + "\"value\":\"" + encodeBase64Binary(VALUE) + "\","
+            + "\"partition\":" + PARTITION + ","
+            + "\"offset\":" + OFFSET
+            + "}]",
+        response);
+
+    verify(kafkaConsumerManager, simpleConsumerManager);
+  }
+
+  @Test
+  public void getMessages_withTimestamp_noSuchOffset_returnsEmpty() {
+    expect(kafkaConsumerManager.getOffsetForTime(TOPIC, PARTITION, TIMESTAMP))
+        .andReturn(Optional.empty());
+    replay(kafkaConsumerManager, simpleConsumerManager);
+
+    String response =
+        target("/topics/{topic}/partitions/{partition}/messages")
+            .resolveTemplate("topic", TOPIC)
+            .resolveTemplate("partition", PARTITION)
+            .queryParam("timestamp", DATE_TIME_FORMATTER.format(TIMESTAMP))
+            .request(Versions.KAFKA_V1_JSON_BINARY)
+            .get(String.class);
+
+    assertEquals("[]", response);
+
+    verify(kafkaConsumerManager, simpleConsumerManager);
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/PartitionsResourceTest.java
@@ -14,15 +14,9 @@
  */
 package io.confluent.kafkarest.unit;
 
-import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
+import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static org.junit.Assert.assertEquals;
 
 import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
@@ -33,14 +27,18 @@ import io.confluent.kafkarest.ProducerPool;
 import io.confluent.kafkarest.TestUtils;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
+import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.resources.PartitionsResource;
 import io.confluent.kafkarest.resources.TopicsResource;
 import io.confluent.rest.EmbeddedServerTestHarness;
 import io.confluent.rest.RestConfigException;
-
-import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
-import static io.confluent.kafkarest.TestUtils.assertOKResponse;
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.List;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 
 public class PartitionsResourceTest
     extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
@@ -73,6 +71,7 @@ public class PartitionsResourceTest
 
     addResource(new TopicsResource(ctx));
     addResource(new PartitionsResource(ctx));
+    addResource(InstantConverterProvider.class);
   }
 
   @Before

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.v2;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafkarest.AdminClientWrapper;
+import io.confluent.kafkarest.DefaultKafkaRestContext;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.KafkaRestContext;
+import io.confluent.kafkarest.resources.v2.PartitionsResource;
+import io.confluent.rest.RestConfigException;
+import io.confluent.rest.validation.JacksonMessageBodyProvider;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PartitionsResourceTest extends JerseyTest {
+
+  private static final String TOPIC = "topic";
+  private static final int PARTITION = 1;
+  private static final long BEGINNING_OFFSET = 10L;
+  private static final long END_OFFSET = 20L;
+
+  private AdminClientWrapper adminClientWrapper;
+  private KafkaConsumerManager consumerManager;
+
+  @Override
+  protected Application configure() {
+    ResourceConfig application = new ResourceConfig();
+    application.register(new PartitionsResource(createKafkaRestContext()));
+    application.register(new JacksonMessageBodyProvider());
+    return application;
+  }
+
+  private KafkaRestContext createKafkaRestContext() {
+    adminClientWrapper = createMock(AdminClientWrapper.class);
+    consumerManager = createMock(KafkaConsumerManager.class);
+
+    try {
+      return new DefaultKafkaRestContext(
+          new KafkaRestConfig(),
+          /* producerPool= */ null,
+          consumerManager,
+          adminClientWrapper,
+          /* scalaConsumersContext= */ null);
+    } catch (RestConfigException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Before
+  public void setUpMocks() {
+    reset(adminClientWrapper, consumerManager);
+  }
+
+  @Test
+  public void getOffsets_returnsBeginningAndEnd() throws Exception {
+    expect(adminClientWrapper.topicExists(TOPIC)).andReturn(true);
+    expect(adminClientWrapper.partitionExists(TOPIC, PARTITION)).andReturn(true);
+    expect(consumerManager.getBeginningOffset(TOPIC, PARTITION)).andReturn(BEGINNING_OFFSET);
+    expect(consumerManager.getEndOffset(TOPIC, PARTITION)).andReturn(END_OFFSET);
+    replay(adminClientWrapper, consumerManager);
+
+    String response =
+        target("/topics/{topic}/partitions/{partition}/offsets")
+            .resolveTemplate("topic", TOPIC)
+            .resolveTemplate("partition", PARTITION)
+            .request()
+            .get(String.class);
+
+    assertEquals(
+        String.format("{\"beginning_offset\":%d,\"end_offset\":%d}", BEGINNING_OFFSET, END_OFFSET),
+        response);
+
+    verify(adminClientWrapper, consumerManager);
+  }
+
+  @Test
+  public void getOffsets_topicDoesNotExist_returns404() throws Exception {
+    expect(adminClientWrapper.topicExists(TOPIC)).andReturn(false);
+    replay(adminClientWrapper);
+
+    Response response =
+        target("/topics/{topic}/partitions/{partition}/offsets")
+            .resolveTemplate("topic", TOPIC)
+            .resolveTemplate("partition", PARTITION)
+            .request()
+            .get();
+
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+
+    verify(adminClientWrapper);
+  }
+
+  @Test
+  public void getOffsets_partitionDoesNotExist_returns404() throws Exception {
+    expect(adminClientWrapper.topicExists(TOPIC)).andReturn(true);
+    expect(adminClientWrapper.partitionExists(TOPIC, PARTITION)).andReturn(false);
+    replay(adminClientWrapper);
+
+    Response response =
+        target("/topics/{topic}/partitions/{partition}/offsets")
+            .resolveTemplate("topic", TOPIC)
+            .resolveTemplate("partition", PARTITION)
+            .request()
+            .get();
+
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+
+    verify(adminClientWrapper);
+  }
+}


### PR DESCRIPTION
CPKAFKA-1526: Extend the topic partition resource to support getting
offset information. The equivalent Java APIs are KafkaConsumer
beginningOffsets, endOffsets and offsetForTimes.

The kafka-rest server will create a randomly generated consumer-group
and consumer to use to query the offsets information. It is possible for
an adversarial user to kill this consumer manually. There are some
measures in place for self-healing if that happens.