### PR TITLE
Updating slack channel for Jenkins build alerts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
 common {
-  slackChannel = '#kafka-core-eng '
+  slackChannel = '#kafka-warn'
   upstreamProjects = 'confluentinc/schema-registry'
 }


### PR DESCRIPTION
As per the new Slack changes we want all the notifications from bots
which are not immediately actionable to go to a different channel. Moving
the jenkins build alerts to #kafka-warn.