### PR TITLE
MINOR: Upgade Avro to 1.9.1

### DIFF
--- a/kafka-rest-common/pom.xml
+++ b/kafka-rest-common/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The rest of the platform was recently upgraded to 1.9.1; this is the equivalent change for kafka-rest.