### PR TITLE
CLIENTS-1454: Propagate Schema Registry properties to KafkaAvroDecoder.

### DIFF
--- a/kafka-rest-common/pom.xml
+++ b/kafka-rest-common/pom.xml
@@ -23,6 +23,11 @@
             <version>1.9.1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kafka-rest-common/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest-common/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -656,7 +656,7 @@ public class KafkaRestConfig extends RestConfig {
 
       if (name.startsWith("ssl.") || name.startsWith("sasl.")
           || name.startsWith("client.") || name.startsWith("producer.")
-          || name.startsWith("consumer.")) {
+          || name.startsWith("consumer.") || name.startsWith("schema.registry")) {
         continue;
       }
 
@@ -687,6 +687,9 @@ public class KafkaRestConfig extends RestConfig {
     addPropertiesWithPrefix("client.", producerProps);
     addPropertiesWithPrefix("producer.", producerProps);
 
+    // Propagate Schema Registry properties.
+    producerProps.putAll(originalsWithPrefix("schema.registry", /* strip= */ false));
+
     return producerProps;
   }
 
@@ -695,6 +698,10 @@ public class KafkaRestConfig extends RestConfig {
     //copy cover the properties with prefixes "client." and  "consumer."
     addPropertiesWithPrefix("client.", consumerProps);
     addPropertiesWithPrefix("consumer.", consumerProps);
+
+    // Propagate Schema Registry properties.
+    consumerProps.putAll(originalsWithPrefix("schema.registry", /* strip= */ false));
+
     return consumerProps;
   }
 

--- a/kafka-rest-common/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest-common/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -1,0 +1,32 @@
+package io.confluent.kafkarest;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.rest.RestConfigException;
+import java.util.Properties;
+import org.junit.Test;
+
+public class KafkaRestConfigTest {
+
+  @Test
+  public void getProducerProperties_propagatesSchemaRegistryProperties()
+      throws RestConfigException {
+    Properties properties = new Properties();
+    properties.put("schema.registry.url", "https://schemaregistry:8085");
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    Properties producerProperties = config.getProducerProperties();
+    assertEquals("https://schemaregistry:8085", producerProperties.get("schema.registry.url"));
+  }
+
+  @Test
+  public void getConsumerProperties_propagatesSchemaRegistryProperties()
+      throws RestConfigException{
+    Properties properties = new Properties();
+    properties.put("schema.registry.url", "https://schemaregistry:8085");
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    Properties consumerProperties = config.getConsumerProperties();
+    assertEquals("https://schemaregistry:8085", consumerProperties.get("schema.registry.url"));
+  }
+}

--- a/kafka-rest-scala-consumer/src/main/java/io/confluent/kafkarest/AvroConsumerState.java
+++ b/kafka-rest-scala-consumer/src/main/java/io/confluent/kafkarest/AvroConsumerState.java
@@ -43,6 +43,7 @@ public class AvroConsumerState extends ConsumerState<Object, Object, JsonNode, J
     Properties props = new Properties();
     props.setProperty("schema.registry.url",
                       config.getString(KafkaRestConfig.SCHEMA_REGISTRY_URL_CONFIG));
+    props.putAll(config.originalsWithPrefix("schema.registry", /* strip= */ false));
     decoder = new KafkaAvroDecoder(new VerifiableProperties(props));
   }
 

--- a/kafka-rest-scala-consumer/src/main/java/io/confluent/kafkarest/SimpleConsumerManager.java
+++ b/kafka-rest-scala-consumer/src/main/java/io/confluent/kafkarest/SimpleConsumerManager.java
@@ -96,6 +96,7 @@ public class SimpleConsumerManager {
         "schema.registry.url",
         config.getString(KafkaRestConfig.SCHEMA_REGISTRY_URL_CONFIG)
     );
+    props.putAll(config.originalsWithPrefix("schema.registry", /* strip= */ false));
     avroDecoder = new KafkaAvroDecoder(new VerifiableProperties(props));
 
     binaryDecoder = new DefaultDecoder(new VerifiableProperties());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/AvroKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/AvroKafkaConsumerState.java
@@ -24,8 +24,6 @@ import io.confluent.kafkarest.entities.AvroConsumerRecord;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import java.util.Properties;
-
 /**
  * Avro implementation of KafkaConsumerState, which decodes into GenericRecords or primitive types.
  */
@@ -35,9 +33,6 @@ public class AvroKafkaConsumerState extends KafkaConsumerState<Object, Object, J
       ConsumerInstanceId instanceId,
       Consumer consumer) {
     super(config, instanceId, consumer);
-    Properties props = new Properties();
-    props.setProperty("schema.registry.url",
-        config.getString(KafkaRestConfig.SCHEMA_REGISTRY_URL_CONFIG));
   }
 
   @Override


### PR DESCRIPTION
Properties for the Avro Producer were being propagated by accident. Unfortunately (or fortunately, depending on your philosophical stance), this accident didn't happen for the Avro Consumer. This fix explicitly propagate the properties for both.