### PR TITLE
Fix kafka-rest build to use new schema-registry packages.

### DIFF
--- a/kafka-rest-scala-consumer/pom.xml
+++ b/kafka-rest-scala-consumer/pom.xml
@@ -41,6 +41,11 @@
             <version>5.5.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-serializer</artifactId>
+            <version>5.5.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${log4j.version}</version>
@@ -97,6 +102,7 @@
                             <include>com.101tec:zkclient</include>
                             <include>io.confluent:kafka-avro-serializer</include>
                             <include>io.confluent:kafka-json-serializer</include>
+                            <include>io.confluent:kafka-schema-serializer</include>
                         </includes>
                     </artifactSet>
                     <relocations>


### PR DESCRIPTION
Broken after https://github.com/confluentinc/schema-registry/pull/1295.