### PR TITLE
Fix compile error due to KIP-515 (ZK TLS)

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/RestConfigUtils.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/RestConfigUtils.java
@@ -49,7 +49,7 @@ public class RestConfigUtils {
           new ZooKeeperClient(config.getString(ZOOKEEPER_CONNECT_CONFIG), zkSessionTimeoutMs,
               zkSessionTimeoutMs, Integer.MAX_VALUE, time,
               "testMetricGroup", "testMetricGroupType"),
-          JaasUtils.isZkSecurityEnabled(),
+          JaasUtils.isZkSaslEnabled(),
           time);
       return getBootstrapBrokers(zkClient);
     } finally {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -163,7 +163,7 @@ public abstract class ClusterTestHarness {
     zkClient = new KafkaZkClient(
         new ZooKeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, Integer.MAX_VALUE, time,
                 "testMetricGroup", "testMetricGroupType"),
-        JaasUtils.isZkSecurityEnabled(),
+        JaasUtils.isZkSaslEnabled(),
         time);
 
     configs = new Vector<>();


### PR DESCRIPTION
Cherry-pick of #617 .

This fixes a compile error that was created when KIP-515 Enable ZK client to use the new TLS supported authentication changed the name of a method that was not part of the public Kafka clients API.

This PR does not address the fact that REST Proxy will be unable to connect to a TLS-enabled ZooKeeper instance -- that will have to be fixed separately.