### PR TITLE
CPKAFKA-4617: Change Admin binding to be request-scoped.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestStartUpIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestStartUpIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.confluent.kafkarest.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Test;
+
+public class KafkaRestStartUpIntegrationTest extends ClusterTestHarness {
+
+  public KafkaRestStartUpIntegrationTest() {
+    super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
+  }
+
+  @Override
+  protected void overrideKafkaRestConfigs(Properties restProperties) {
+    restProperties.put("client.security.protocol", "SASL_PLAINTEXT");
+    restProperties.put("client.sasl.mechanism", "OAUTHBEARER");
+    restProperties.put("client.sasl.kerberos.service.name", "kafka");
+  }
+
+  @Test
+  public void kafkaRest_withInvalidAdminConfigs_startsUp() {
+    // Make sure that Admin is not created on startup. If it were, the server would fail to startup,
+    // since the above security configuration is incomplete. See
+    // https://github.com/confluentinc/kafka-rest/pull/632 for context.
+
+    // The server started up successfully. Now make sure doing a request that require Admin fails.
+    Response response = request("/v3/clusters").accept("application/vnd.api+json").get();
+    assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+}


### PR DESCRIPTION
The request-scope is needed because the Admin creation logic uses request-scoped auth information. KafkaRestContext itself is a proxied instance, so the result will be cached there appropriately, after it is created.