### PR TITLE
CLIENTS-1499: Add LIST/GET Partitions V3 endpoints.

### DIFF
--- a/kafka-rest-common/src/main/java/io/confluent/kafkarest/entities/Partition.java
+++ b/kafka-rest-common/src/main/java/io/confluent/kafkarest/entities/Partition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2020 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -17,35 +17,48 @@ package io.confluent.kafkarest.entities;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.StringJoiner;
-import javax.annotation.Nullable;
 
 public final class Partition {
 
-  private final int partition;
+  private final String clusterId;
 
-  private final int leader;
+  private final String topicName;
 
-  @Nullable
-  private List<PartitionReplica> replicas;
+  private final int partitionId;
 
-  public Partition(int partition, int leader, @Nullable List<PartitionReplica> replicas) {
-    this.partition = partition;
-    this.leader = leader;
-    this.replicas = replicas;
+  private final List<PartitionReplica> replicas;
+
+  public Partition(
+      String clusterId,
+      String topicName,
+      int partitionId,
+      List<PartitionReplica> replicas) {
+    this.clusterId = Objects.requireNonNull(clusterId);
+    this.topicName = Objects.requireNonNull(topicName);
+    this.partitionId = partitionId;
+    this.replicas = Objects.requireNonNull(replicas);
   }
 
-  public int getPartition() {
-    return partition;
+  public String getClusterId() {
+    return clusterId;
   }
 
-  public int getLeader() {
-    return leader;
+  public String getTopicName() {
+    return topicName;
   }
 
-  @Nullable
+  public int getPartitionId() {
+    return partitionId;
+  }
+
   public List<PartitionReplica> getReplicas() {
     return replicas;
+  }
+
+  public Optional<PartitionReplica> getLeader() {
+    return replicas.stream().filter(PartitionReplica::isLeader).findAny();
   }
 
   @Override
@@ -56,22 +69,24 @@ public final class Partition {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Partition partition1 = (Partition) o;
-    return partition == partition1.partition
-        && leader == partition1.leader
-        && Objects.equals(replicas, partition1.replicas);
+    Partition partition = (Partition) o;
+    return partitionId == partition.partitionId
+        && Objects.equals(clusterId, partition.clusterId)
+        && Objects.equals(topicName, partition.topicName)
+        && Objects.equals(replicas, partition.replicas);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(partition, leader, replicas);
+    return Objects.hash(clusterId, topicName, partitionId, replicas);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", Partition.class.getSimpleName() + "[", "]")
-        .add("partition=" + partition)
-        .add("leader=" + leader)
+        .add("clusterId='" + clusterId + "'")
+        .add("topicName='" + topicName + "'")
+        .add("partitionId=" + partitionId)
         .add("replicas=" + replicas)
         .toString();
   }

--- a/kafka-rest-scala-consumer/src/main/java/io/confluent/kafkarest/MetadataObserver.java
+++ b/kafka-rest-scala-consumer/src/main/java/io/confluent/kafkarest/MetadataObserver.java
@@ -74,8 +74,8 @@ public class MetadataObserver {
     }
 
     for (final Partition partition : partitions) {
-      if (partition.getPartition() == partitionId) {
-        return partition.getLeader();
+      if (partition.getPartitionId() == partitionId) {
+        return partition.getLeader().map(PartitionReplica::getBroker).orElse(-1);
       }
     }
 
@@ -130,7 +130,7 @@ public class MetadataObserver {
               new PartitionReplica(broker, (leaderAndIsr.leader() == broker), isr.contains(broker));
           partReplicas.add(r);
         }
-        Partition p = new Partition(partId, leaderAndIsr.leader(), partReplicas);
+        Partition p = new Partition(/* clusterId= */ "", topic, partId, partReplicas);
         partitions.add(p);
       }
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/AdminClientWrapper.java
@@ -90,13 +90,14 @@ public class AdminClientWrapper {
 
   public List<Partition> getTopicPartitions(String topicName) throws Exception {
     TopicDescription topicDescription = getTopicDescription(topicName);
-    List<Partition> partitions = buildPartitonsData(topicDescription.partitions(), null);
+    List<Partition> partitions = buildPartitonsData(topicName, topicDescription.partitions(), null);
     return partitions;
   }
 
   public Partition getTopicPartition(String topicName, int partition) throws Exception {
     TopicDescription topicDescription = getTopicDescription(topicName);
-    List<Partition> partitions = buildPartitonsData(topicDescription.partitions(), partition);
+    List<Partition> partitions =
+        buildPartitonsData(topicName, topicDescription.partitions(), partition);
     if (partitions.isEmpty()) {
       return null;
     }
@@ -109,7 +110,7 @@ public class AdminClientWrapper {
   }
 
   private Topic buildTopic(String topicName, TopicDescription topicDescription) throws Exception {
-    List<Partition> partitions = buildPartitonsData(topicDescription.partitions(), null);
+    List<Partition> partitions = buildPartitonsData(topicName, topicDescription.partitions(), null);
 
     ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
     Config config = adminClient.describeConfigs(
@@ -124,6 +125,7 @@ public class AdminClientWrapper {
   }
 
   private List<Partition> buildPartitonsData(
+      String topicName,
       List<TopicPartitionInfo> partitions,
       Integer partitionsFilter
   ) {
@@ -142,7 +144,12 @@ public class AdminClientWrapper {
             replicaNode.id() == leaderId, topicPartitionInfo.isr().contains(replicaNode)
         ));
       }
-      Partition p = new Partition(topicPartitionInfo.partition(), leaderId, partitionReplicas);
+      Partition p =
+          new Partition(
+              /* clusterId= */ "",
+              topicName,
+              topicPartitionInfo.partition(),
+              partitionReplicas);
       partitionList.add(p);
     }
     return partitionList;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -25,6 +25,7 @@ public final class ControllersModule extends AbstractBinder {
   protected void configure() {
     bind(BrokerManagerImpl.class).to(BrokerManager.class);
     bind(ClusterManagerImpl.class).to(ClusterManager.class);
+    bind(PartitionManagerImpl.class).to(PartitionManager.class);
     bind(TopicManagerImpl.class).to(TopicManager.class);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import io.confluent.kafkarest.entities.Partition;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A service to manage Kafka {@link Partition Partitions}.
+ */
+public interface PartitionManager {
+
+  /**
+   * Returns the list of Kafka {@link Partition Partitions} belonging to the {@link
+   * io.confluent.kafkarest.entities.Topic} with the given {@code topicName}.
+   */
+  CompletableFuture<List<Partition>> listPartitions(String clusterId, String topicName);
+
+  /**
+   * Returns the Kafka {@link Partition} with the given {@code partitionId}.
+   */
+  CompletableFuture<Optional<Partition>> getPartition(
+      String clusterId, String topicName, int partitionId);
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -24,9 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
-import javax.ws.rs.NotFoundException;
 
 class PartitionManagerImpl implements PartitionManager {
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import io.confluent.kafkarest.entities.Partition;
+import io.confluent.kafkarest.entities.Topic;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+
+class PartitionManagerImpl implements PartitionManager {
+
+  private final TopicManager topicManager;
+
+  @Inject
+  PartitionManagerImpl(TopicManager topicManager) {
+    this.topicManager = Objects.requireNonNull(topicManager);
+  }
+
+  @Override
+  public CompletableFuture<List<Partition>> listPartitions(String clusterId, String topicName) {
+    return topicManager.getTopic(clusterId, topicName)
+        .thenApply(
+            topic ->
+                topic.orElseThrow(
+                    () -> new NotFoundException(
+                        String.format("Topic %s cannot be found.", topicName))))
+        .thenApply(Topic::getPartitions);
+  }
+
+  @Override
+  public CompletableFuture<Optional<Partition>> getPartition(
+      String clusterId, String topicName, int partitionId) {
+    return listPartitions(clusterId, topicName)
+        .thenApply(
+            partitions ->
+                partitions.stream()
+                    .filter(partition -> partition.getPartitionId() == partitionId)
+                    .collect(Collectors.toList()))
+        .thenApply(partitions -> partitions.stream().findAny());
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -104,13 +104,14 @@ final class TopicManagerImpl implements TopicManager {
         topicDescription.name(),
         new Properties(),
         topicDescription.partitions().stream()
-            .map(TopicManagerImpl::toPartition)
+            .map(partition -> toPartition(clusterId, topicDescription.name(), partition))
             .collect(Collectors.toList()),
         topicDescription.partitions().get(0).replicas().size(),
         topicDescription.isInternal());
   }
 
-  private static Partition toPartition(TopicPartitionInfo partitionInfo) {
+  private static Partition toPartition(
+      String clusterId, String topicName, TopicPartitionInfo partitionInfo) {
     Set<Node> inSyncReplicas = new HashSet<>(partitionInfo.isr());
     List<PartitionReplica> replicas = new ArrayList<>();
     for (Node replica : partitionInfo.replicas()) {
@@ -120,6 +121,6 @@ final class TopicManagerImpl implements TopicManager {
               partitionInfo.leader().equals(replica),
               inSyncReplicas.contains(replica)));
     }
-    return new Partition(partitionInfo.partition(), partitionInfo.leader().id(), replicas);
+    return new Partition(clusterId, topicName, partitionInfo.partition(), replicas);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v1/GetPartitionResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v1/GetPartitionResponse.java
@@ -73,8 +73,8 @@ public final class GetPartitionResponse {
     List<PartitionReplica> replicas =
         partition.getReplicas() != null ? partition.getReplicas() : Collections.emptyList();
     return new GetPartitionResponse(
-        partition.getPartition(),
-        partition.getLeader(),
+        partition.getPartitionId(),
+        partition.getLeader().map(PartitionReplica::getBroker).orElse(-1),
         replicas.stream().map(Replica::fromPartitionReplica).collect(Collectors.toList()));
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/GetPartitionResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/GetPartitionResponse.java
@@ -73,8 +73,8 @@ public final class GetPartitionResponse {
     List<PartitionReplica> replicas =
         partition.getReplicas() != null ? partition.getReplicas() : Collections.emptyList();
     return new GetPartitionResponse(
-        partition.getPartition(),
-        partition.getLeader(),
+        partition.getPartitionId(),
+        partition.getLeader().map(PartitionReplica::getBroker).orElse(-1),
         replicas.stream().map(Replica::fromPartitionReplica).collect(Collectors.toList()));
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetPartitionResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetPartitionResponse.java
@@ -20,18 +20,19 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
- * Response body for {@code GET /v3/clusters/<clusterId>/topics/<topicName>} requests.
+ * Response body for {@code GET /v3/clusters/<clusterId>/topics/<topicName>/partitions/<partitionId}
+ * requests.
  */
-public final class GetTopicResponse {
+public final class GetPartitionResponse {
 
-  private final TopicData data;
+  private final PartitionData data;
 
-  public GetTopicResponse(TopicData data) {
+  public GetPartitionResponse(PartitionData data) {
     this.data = Objects.requireNonNull(data);
   }
 
   @JsonProperty("data")
-  public TopicData getData() {
+  public PartitionData getData() {
     return data;
   }
 
@@ -43,7 +44,7 @@ public final class GetTopicResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    GetTopicResponse that = (GetTopicResponse) o;
+    GetPartitionResponse that = (GetPartitionResponse) o;
     return Objects.equals(data, that.data);
   }
 
@@ -54,7 +55,7 @@ public final class GetTopicResponse {
 
   @Override
   public String toString() {
-    return new StringJoiner(", ", GetTopicResponse.class.getSimpleName() + "[", "]")
+    return new StringJoiner(", ", GetPartitionResponse.class.getSimpleName() + "[", "]")
         .add("data=" + data)
         .toString();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListPartitionsResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListPartitionsResponse.java
@@ -16,22 +16,31 @@
 package io.confluent.kafkarest.entities.v3;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
- * Response body for {@code GET /v3/clusters/<clusterId>/topics/<topicName>} requests.
+ * Response body for {@code GET /v3/clusters/<clusterId>/topics/<topicName>/partitions} requests.
  */
-public final class GetTopicResponse {
+public final class ListPartitionsResponse {
 
-  private final TopicData data;
+  private final CollectionLink links;
 
-  public GetTopicResponse(TopicData data) {
+  private final List<PartitionData> data;
+
+  public ListPartitionsResponse(CollectionLink links, List<PartitionData> data) {
+    this.links = Objects.requireNonNull(links);
     this.data = Objects.requireNonNull(data);
   }
 
+  @JsonProperty("links")
+  public CollectionLink getLinks() {
+    return links;
+  }
+
   @JsonProperty("data")
-  public TopicData getData() {
+  public List<PartitionData> getData() {
     return data;
   }
 
@@ -43,18 +52,19 @@ public final class GetTopicResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    GetTopicResponse that = (GetTopicResponse) o;
-    return Objects.equals(data, that.data);
+    ListPartitionsResponse that = (ListPartitionsResponse) o;
+    return Objects.equals(links, that.links) && Objects.equals(data, that.data);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(data);
+    return Objects.hash(links, data);
   }
 
   @Override
   public String toString() {
-    return new StringJoiner(", ", GetTopicResponse.class.getSimpleName() + "[", "]")
+    return new StringJoiner(", ", ListPartitionsResponse.class.getSimpleName() + "[", "]")
+        .add("links=" + links)
         .add("data=" + data)
         .toString();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListTopicsResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListTopicsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2020 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.controllers.PartitionManager;
+import io.confluent.kafkarest.entities.Partition;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.GetPartitionResponse;
+import io.confluent.kafkarest.entities.v3.ListPartitionsResponse;
+import io.confluent.kafkarest.entities.v3.PartitionData;
+import io.confluent.kafkarest.entities.v3.Relationship;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.UrlFactory;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+
+@Path("/v3/clusters/{clusterId}/topics/{topicName}/partitions")
+public final class PartitionsResource {
+
+  private final PartitionManager partitionManager;
+  private final UrlFactory urlFactory;
+
+  @Inject
+  public PartitionsResource(PartitionManager partitionManager, UrlFactory urlFactory) {
+    this.partitionManager = Objects.requireNonNull(partitionManager);
+    this.urlFactory = Objects.requireNonNull(urlFactory);
+  }
+
+  @GET
+  @Produces(Versions.JSON_API)
+  public void listPartitions(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName) {
+    CompletableFuture<ListPartitionsResponse> response =
+        partitionManager.listPartitions(clusterId, topicName)
+            .thenApply(
+                partitions ->
+                    new ListPartitionsResponse(
+                        new CollectionLink(
+                            urlFactory.create(
+                                "v3", "clusters", clusterId, "topics", topicName, "partitions"),
+                            /* next= */ null),
+                        partitions.stream()
+                            .map(this::toPartitionData)
+                            .collect(Collectors.toList())));
+
+    AsyncResponses.asyncResume(asyncResponse, response);
+  }
+
+  @GET
+  @Path("/{partitionId}")
+  @Produces(Versions.JSON_API)
+  public void getPartition(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName,
+      @PathParam("partitionId") Integer partitionId) {
+    CompletableFuture<GetPartitionResponse> response =
+        partitionManager.getPartition(clusterId, topicName, partitionId)
+            .thenApply(
+                partition ->
+                    new GetPartitionResponse(
+                        toPartitionData(partition.orElseThrow(NotFoundException::new))));
+
+    AsyncResponses.asyncResume(asyncResponse, response);
+  }
+
+  private PartitionData toPartitionData(Partition partition) {
+    ResourceLink links =
+        new ResourceLink(
+            urlFactory.create(
+                "v3",
+                "clusters",
+                partition.getClusterId(),
+                "topics",
+                partition.getTopicName(),
+                "partitions",
+                Integer.toString(partition.getPartitionId())));
+    Relationship leader =
+        partition.getLeader()
+            .map(
+                replica ->
+                    new Relationship(
+                        urlFactory.create(
+                            "v3",
+                            "clusters",
+                            partition.getClusterId(),
+                            "topics",
+                            partition.getTopicName(),
+                            "partitions",
+                            Integer.toString(partition.getPartitionId()),
+                            "replicas",
+                            Integer.toString(replica.getBroker()))))
+            .orElse(null);
+    Relationship replicas =
+        new Relationship(
+            urlFactory.create(
+                "v3",
+                "clusters",
+                partition.getClusterId(),
+                "topics",
+                partition.getTopicName(),
+                "partitions",
+                Integer.toString(partition.getPartitionId()),
+                "replicas"));
+
+    return new PartitionData(
+        links,
+        partition.getClusterId(),
+        partition.getTopicName(),
+        partition.getPartitionId(),
+        leader,
+        replicas);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -81,10 +81,8 @@ public final class PartitionsResource {
       @PathParam("partitionId") Integer partitionId) {
     CompletableFuture<GetPartitionResponse> response =
         partitionManager.getPartition(clusterId, topicName, partitionId)
-            .thenApply(
-                partition ->
-                    new GetPartitionResponse(
-                        toPartitionData(partition.orElseThrow(NotFoundException::new))));
+            .thenApply(partition -> partition.orElseThrow(NotFoundException::new))
+            .thenApply(partition -> new GetPartitionResponse(toPartitionData(partition)));
 
     AsyncResponses.asyncResume(asyncResponse, response);
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
@@ -24,6 +24,7 @@ public final class V3ResourcesFeature implements Feature {
   public boolean configure(FeatureContext configurable) {
     configurable.register(BrokersResource.class);
     configurable.register(ClustersResource.class);
+    configurable.register(PartitionsResource.class);
     configurable.register(TopicsResource.class);
     return true;
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/CompletableFutures.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/CompletableFutures.java
@@ -13,16 +13,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafkarest.resources.v3;
+package io.confluent.kafkarest;
 
 import java.util.concurrent.CompletableFuture;
 
-final class CompletableFutures {
+/**
+ * Utilities to deal with {@link CompletableFuture}.
+ */
+public final class CompletableFutures {
 
   private CompletableFutures() {
   }
 
-  static <T> CompletableFuture<T> failedFuture(Throwable exception) {
+  /**
+   * Returns a {@link CompletableFuture} that is completed exceptionally with the given {@code
+   * exception}.
+   */
+  public static <T> CompletableFuture<T> failedFuture(Throwable exception) {
     CompletableFuture<T> future = new CompletableFuture<>();
     future.completeExceptionally(exception);
     return future;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import io.confluent.kafkarest.entities.Partition;
+import io.confluent.kafkarest.entities.PartitionReplica;
+import io.confluent.kafkarest.entities.Topic;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PartitionManagerImplTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String TOPIC_NAME = "topic-1";
+
+  private static final Partition PARTITION_1 =
+      new Partition(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          /* partitionId= */ 0,
+          Arrays.asList(
+              new PartitionReplica(
+                  /* broker= */ 1,
+                  /* leader= */ true,
+                  /* inSync= */ false),
+              new PartitionReplica(
+                  /* broker= */ 2,
+                  /* leader= */ false,
+                  /* inSync= */ true),
+              new PartitionReplica(
+                  /* broker= */ 3,
+                  /* leader= */ false,
+                  /* inSync= */ false)));
+  private static final Partition PARTITION_2 =
+      new Partition(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          /* partitionId= */ 1,
+          Arrays.asList(
+              new PartitionReplica(
+                  /* broker= */ 2,
+                  /* leader= */ true,
+                  /* inSync= */ false),
+              new PartitionReplica(
+                  /* broker= */ 3,
+                  /* leader= */ false,
+                  /* inSync= */ true),
+              new PartitionReplica(
+                  /* broker= */ 1,
+                  /* leader= */ false,
+                  /* inSync= */ false)));
+  private static final Partition PARTITION_3 =
+      new Partition(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          /* partitionId= */ 2,
+          Arrays.asList(
+              new PartitionReplica(
+                  /* broker= */ 3,
+                  /* leader= */ true,
+                  /* inSync= */ false),
+              new PartitionReplica(
+                  /* broker= */ 1,
+                  /* leader= */ false,
+                  /* inSync= */ true),
+              new PartitionReplica(
+                  /* broker= */ 2,
+                  /* leader= */ false,
+                  /* inSync= */ false)));
+
+  private static final Topic TOPIC =
+      new Topic(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          new Properties(),
+          Arrays.asList(PARTITION_1, PARTITION_2, PARTITION_3),
+          /* replicationFactor= */ 3,
+          /* isInternal= */ false);
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private TopicManager topicManager;
+
+  private PartitionManagerImpl partitionManager;
+
+  @Before
+  public void setUp() {
+    partitionManager = new PartitionManagerImpl(topicManager);
+  }
+
+  @Test
+  public void listPartitions_existingTopic_returnsPartitions() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(CompletableFuture.completedFuture(Optional.of(TOPIC)));
+    replay(topicManager);
+
+    List<Partition> partitions = partitionManager.listPartitions(CLUSTER_ID, TOPIC_NAME).get();
+
+    assertEquals(Arrays.asList(PARTITION_1, PARTITION_2, PARTITION_3), partitions);
+  }
+
+  @Test
+  public void listPartitions_nonExistingTopic_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(CompletableFuture.completedFuture(Optional.empty()));
+    replay(topicManager);
+
+    try {
+      partitionManager.listPartitions(CLUSTER_ID, TOPIC_NAME).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void listPartitions_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicManager);
+
+    try {
+      partitionManager.listPartitions(CLUSTER_ID, TOPIC_NAME).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void getPartition_existingPartition_returnsPartition() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(CompletableFuture.completedFuture(Optional.of(TOPIC)));
+    replay(topicManager);
+
+    Optional<Partition> partition =
+        partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId()).get();
+
+    assertEquals(PARTITION_1, partition.get());
+  }
+
+  @Test
+  public void getPartition_nonExistingPartition_returnsEmpty() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(CompletableFuture.completedFuture(Optional.of(TOPIC)));
+    replay(topicManager);
+
+    Optional<Partition> partition =
+        partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, 100).get();
+
+    assertFalse(partition.isPresent());
+  }
+
+  @Test
+  public void getPartition_nonExistingTopic_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(CompletableFuture.completedFuture(Optional.empty()));
+    replay(topicManager);
+
+    try {
+      partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void getPartition_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicManager);
+
+    try {
+      partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -121,22 +121,25 @@ public class TopicManagerImplTest {
           new Properties(),
           Arrays.asList(
               new Partition(
+                  CLUSTER_ID,
+                  "topic-1",
                   /* partition= */ 0,
-                  /* leader= */ 1,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-1",
                   /* partition= */ 1,
-                  /* leader= */ 2,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-1",
                   /* partition= */2,
-                  /* leader= */ 3,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
@@ -151,22 +154,25 @@ public class TopicManagerImplTest {
           new Properties(),
           Arrays.asList(
               new Partition(
-                  /* partition= */ 0,
-                  /* leader= */ 3,
+                  CLUSTER_ID,
+                  "topic-2",
+                  /* partitionId= */ 0,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ true, /* inSync= */ true))),
               new Partition(
-                  /* partition= */ 1,
-                  /* leader= */ 1,
+                  CLUSTER_ID,
+                  "topic-2",
+                  /* partitionId= */ 1,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
-                  /* partition= */2,
-                  /* leader= */ 2,
+                  CLUSTER_ID,
+                  "topic-2",
+                  /* partitionId= */2,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ true, /* inSync= */ true),
@@ -181,22 +187,25 @@ public class TopicManagerImplTest {
           new Properties(),
           Arrays.asList(
               new Partition(
-                  /* partition= */ 0,
-                  /* leader= */ 2,
+                  CLUSTER_ID,
+                  "topic-3",
+                  /* partitionId= */ 0,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
-                  /* partition= */ 1,
-                  /* leader= */ 3,
+                  CLUSTER_ID,
+                  "topic-3",
+                  /* partitionId= */ 1,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ true, /* inSync= */ true))),
               new Partition(
-                  /* partition= */2,
-                  /* leader= */ 1,
+                  CLUSTER_ID,
+                  "topic-3",
+                  /* partitionId= */2,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -44,7 +44,7 @@ public class MetadataAPITest extends ClusterTestHarness {
 
   private static final String topic1Name = "topic1";
   private static final List<Partition> topic1Partitions = Arrays.asList(
-      new Partition(0, 0, Arrays.asList(
+      new Partition(/* clusterId= */ "", "topic1", 0, Arrays.asList(
           new PartitionReplica(0, true, true),
           new PartitionReplica(1, false, false)
       ))
@@ -52,11 +52,11 @@ public class MetadataAPITest extends ClusterTestHarness {
   private static final Topic topic1 = new Topic(topic1Name, new Properties(), topic1Partitions);
   private static final String topic2Name = "topic2";
   private static final List<Partition> topic2Partitions = Arrays.asList(
-      new Partition(0, 0, Arrays.asList(
+      new Partition(/* clusterId= */ "", "topic2", 0, Arrays.asList(
           new PartitionReplica(0, true, true),
           new PartitionReplica(1, false, false)
       )),
-      new Partition(1, 1, Arrays.asList(
+      new Partition(/* clusterId= */ "", "topic2", 1, Arrays.asList(
           new PartitionReplica(0, false, true),
           new PartitionReplica(1, true, true)
       ))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration.v3;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.GetPartitionResponse;
+import io.confluent.kafkarest.entities.v3.ListPartitionsResponse;
+import io.confluent.kafkarest.entities.v3.PartitionData;
+import io.confluent.kafkarest.entities.v3.Relationship;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.integration.ClusterTestHarness;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
+
+  private static final String TOPIC_NAME = "topic-1";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public PartitionsResourceIntegrationTest() {
+    super(/* numBrokers= */ 1, /* withSchemaRegistry= */ false);
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    createTopic(TOPIC_NAME, 1, (short) 1);
+  }
+
+  @Test
+  public void listPartitions_existingTopic_returnPartitions() throws Exception {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    String expected =
+        OBJECT_MAPPER.writeValueAsString(
+            new ListPartitionsResponse(
+                new CollectionLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/topics/" + TOPIC_NAME
+                        + "/partitions",
+                    /* next= */ null),
+                singletonList(
+                    new PartitionData(
+                        new ResourceLink(
+                            baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_NAME
+                            + "/partitions/0"),
+                        clusterId,
+                        TOPIC_NAME,
+                        /* partitionId= */ 0,
+                        new Relationship(
+                            baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_NAME
+                            + "/partitions/0/replicas/0"),
+                        new Relationship(
+                            baseUrl
+                                + "/v3/clusters/" + clusterId
+                                + "/topics/" + TOPIC_NAME
+                                + "/partitions/0/replicas")))));
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/partitions")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(expected, response.readEntity(String.class));
+  }
+
+  @Test
+  public void listPartitions_nonExistingTopic_returnsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/foobar/partitions")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void listPartitions_nonExistingCluster_returnsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/"+ TOPIC_NAME + "/partitions")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getPartition_existingPartition_returnPartition() throws Exception {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    String expected =
+        OBJECT_MAPPER.writeValueAsString(
+            new GetPartitionResponse(
+                new PartitionData(
+                    new ResourceLink(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_NAME
+                            + "/partitions/0"),
+                    clusterId,
+                    TOPIC_NAME,
+                    /* partitionId= */ 0,
+                    new Relationship(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_NAME
+                            + "/partitions/0/replicas/0"),
+                    new Relationship(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_NAME
+                            + "/partitions/0/replicas"))));
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/partitions/0")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(expected, response.readEntity(String.class));
+  }
+
+  @Test
+  public void getPartition_nonExistingPartition_returnsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/partitions/100")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getPartition_nonExistingTopic_returnsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/foobar/partitions/0")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getPartition_nonExistingCluster_returnsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_NAME + "/partitions/0")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v1/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v1/PartitionsResourceTest.java
@@ -50,11 +50,11 @@ public class PartitionsResourceTest
 
   private final String topicName = "topic1";
   private final List<Partition> partitions = Arrays.asList(
-      new Partition(0, 0, Arrays.asList(
+      new Partition(/* clusterId= */ "", "topic1", 0, Arrays.asList(
           new PartitionReplica(0, true, true),
           new PartitionReplica(1, false, false)
       )),
-      new Partition(1, 1, Arrays.asList(
+      new Partition(/* clusterId= */ "", "topic1", 1, Arrays.asList(
           new PartitionReplica(0, false, true),
           new PartitionReplica(1, true, true)
       ))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v1/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v1/TopicsResourceTest.java
@@ -89,17 +89,17 @@ public class TopicsResourceTest
     Properties nonEmptyConfig = new Properties();
     nonEmptyConfig.setProperty("cleanup.policy", "delete");
     final List<Partition> partitions1 = Arrays.asList(
-        new Partition(0, 0, Arrays.asList(
+        new Partition(/* clusterId= */ "", "topic1", 0, Arrays.asList(
             new PartitionReplica(0, true, true),
             new PartitionReplica(1, false, false)
         )),
-        new Partition(1, 1, Arrays.asList(
+        new Partition(/* clusterId= */ "", "topic1", 1, Arrays.asList(
             new PartitionReplica(0, false, true),
             new PartitionReplica(1, true, true)
         ))
     );
     final List<Partition> partitions2 = Arrays.asList(
-        new Partition(0, 0, Arrays.asList(
+        new Partition(/* clusterId= */ "", "topic2", 0, Arrays.asList(
             new PartitionReplica(0, true, true),
             new PartitionReplica(1, false, false)
         ))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
@@ -88,17 +88,17 @@ public class TopicsResourceTest
     Properties nonEmptyConfig = new Properties();
     nonEmptyConfig.setProperty("cleanup.policy", "delete");
     final List<Partition> partitions1 = Arrays.asList(
-        new Partition(0, 0, Arrays.asList(
+        new Partition(/* clusterId= */ "", "topic1", 0, Arrays.asList(
             new PartitionReplica(0, true, true),
             new PartitionReplica(1, false, false)
         )),
-        new Partition(1, 1, Arrays.asList(
+        new Partition(/* clusterId= */ "", "topic1", 1, Arrays.asList(
             new PartitionReplica(0, false, true),
             new PartitionReplica(1, true, true)
         ))
     );
     final List<Partition> partitions2 = Arrays.asList(
-        new Partition(0, 0, Arrays.asList(
+        new Partition(/* clusterId= */ "", "topic2", 0, Arrays.asList(
             new PartitionReplica(0, true, true),
             new PartitionReplica(1, false, false)
         ))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafkarest.resources.v3;
 
-import static io.confluent.kafkarest.resources.v3.CompletableFutures.failedFuture;
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafkarest.resources.v3;
 
-import static io.confluent.kafkarest.resources.v3.CompletableFutures.failedFuture;
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
 import static java.util.Collections.singletonList;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafkarest.controllers.PartitionManager;
+import io.confluent.kafkarest.entities.Partition;
+import io.confluent.kafkarest.entities.PartitionReplica;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.GetPartitionResponse;
+import io.confluent.kafkarest.entities.v3.ListPartitionsResponse;
+import io.confluent.kafkarest.entities.v3.PartitionData;
+import io.confluent.kafkarest.entities.v3.Relationship;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.kafkarest.response.FakeUrlFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PartitionsResourceTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String TOPIC_NAME = "topic-1";
+
+  private static final Partition PARTITION_1 =
+      new Partition(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          /* partitionId= */ 0,
+          Arrays.asList(
+              new PartitionReplica(
+                  /* broker= */ 1,
+                  /* leader= */ true,
+                  /* inSync= */ false),
+              new PartitionReplica(
+                  /* broker= */ 2,
+                  /* leader= */ false,
+                  /* inSync= */ true),
+              new PartitionReplica(
+                  /* broker= */ 3,
+                  /* leader= */ false,
+                  /* inSync= */ false)));
+  private static final Partition PARTITION_2 =
+      new Partition(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          /* partitionId= */ 1,
+          Arrays.asList(
+              new PartitionReplica(
+                  /* broker= */ 2,
+                  /* leader= */ true,
+                  /* inSync= */ false),
+              new PartitionReplica(
+                  /* broker= */ 3,
+                  /* leader= */ false,
+                  /* inSync= */ true),
+              new PartitionReplica(
+                  /* broker= */ 1,
+                  /* leader= */ false,
+                  /* inSync= */ false)));
+  private static final Partition PARTITION_3 =
+      new Partition(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          /* partitionId= */ 2,
+          Arrays.asList(
+              new PartitionReplica(
+                  /* broker= */ 3,
+                  /* leader= */ true,
+                  /* inSync= */ false),
+              new PartitionReplica(
+                  /* broker= */ 1,
+                  /* leader= */ false,
+                  /* inSync= */ true),
+              new PartitionReplica(
+                  /* broker= */ 2,
+                  /* leader= */ false,
+                  /* inSync= */ false)));
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private PartitionManager partitionManager;
+
+  private PartitionsResource partitionsResource;
+
+  @Before
+  public void setUp() {
+    partitionsResource = new PartitionsResource(partitionManager, new FakeUrlFactory());
+  }
+
+  @Test
+  public void listPartitions_existingTopic_returnsPartitions() {
+    expect(partitionManager.listPartitions(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(PARTITION_1, PARTITION_2, PARTITION_3)));
+    replay(partitionManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    partitionsResource.listPartitions(response, CLUSTER_ID, TOPIC_NAME);
+
+    ListPartitionsResponse expected =
+        new ListPartitionsResponse(
+            new CollectionLink("/v3/clusters/cluster-1/topics/topic-1/partitions", /* next= */ null),
+            Arrays.asList(
+                new PartitionData(
+                    new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0"),
+                    CLUSTER_ID,
+                    TOPIC_NAME,
+                    PARTITION_1.getPartitionId(),
+                    new Relationship(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/1"),
+                    new Relationship(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas")),
+                new PartitionData(
+                    new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/1"),
+                    CLUSTER_ID,
+                    TOPIC_NAME,
+                    PARTITION_2.getPartitionId(),
+                    new Relationship(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/2"),
+                    new Relationship(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas")),
+                new PartitionData(
+                    new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/2"),
+                    CLUSTER_ID,
+                    TOPIC_NAME,
+                    PARTITION_3.getPartitionId(),
+                    new Relationship(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/3"),
+                    new Relationship(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas"))));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void listPartitions_nonExistingTopicOrCluster_throwsNotFound() {
+    expect(partitionManager.listPartitions(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(partitionManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    partitionsResource.listPartitions(response, CLUSTER_ID, TOPIC_NAME);
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void getPartition_existingPartition_returnsPartition() {
+    expect(partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId()))
+        .andReturn(CompletableFuture.completedFuture(Optional.of(PARTITION_1)));
+    replay(partitionManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    partitionsResource.getPartition(response, CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId());
+
+    GetPartitionResponse expected =
+        new GetPartitionResponse(
+            new PartitionData(
+                new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0"),
+                CLUSTER_ID,
+                TOPIC_NAME,
+                PARTITION_1.getPartitionId(),
+                new Relationship(
+                    "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/1"),
+                new Relationship(
+                    "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas")));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void getPartition_nonExistingPartition_throwsNotFound() {
+    expect(partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId()))
+        .andReturn(CompletableFuture.completedFuture(Optional.empty()));
+    replay(partitionManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    partitionsResource.getPartition(response, CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void getPartition_nonExistingTopicOrCluster_throwsNotFound() {
+    expect(partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(partitionManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    partitionsResource.getPartition(response, CLUSTER_ID, TOPIC_NAME, PARTITION_1.getPartitionId());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafkarest.resources.v3;
 
-import static io.confluent.kafkarest.resources.v3.CompletableFutures.failedFuture;
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -55,22 +55,25 @@ public class TopicsResourceTest {
           new Properties(),
           Arrays.asList(
               new Partition(
+                  CLUSTER_ID,
+                  "topic-1",
                   /* partition= */ 0,
-                  /* leader= */ 1,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-1",
                   /* partition= */ 1,
-                  /* leader= */ 2,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-1",
                   /* partition= */2,
-                  /* leader= */ 3,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
@@ -85,22 +88,25 @@ public class TopicsResourceTest {
           new Properties(),
           Arrays.asList(
               new Partition(
+                  CLUSTER_ID,
+                  "topic-2",
                   /* partition= */ 0,
-                  /* leader= */ 3,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ true, /* inSync= */ true))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-2",
                   /* partition= */ 1,
-                  /* leader= */ 1,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-2",
                   /* partition= */2,
-                  /* leader= */ 2,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ true, /* inSync= */ true),
@@ -115,22 +121,25 @@ public class TopicsResourceTest {
           new Properties(),
           Arrays.asList(
               new Partition(
+                  CLUSTER_ID,
+                  "topic-3",
                   /* partition= */ 0,
-                  /* leader= */ 2,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(3, /* leader= */ false, /* inSync= */ false))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-3",
                   /* partition= */ 1,
-                  /* leader= */ 3,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),
                       new PartitionReplica(3, /* leader= */ true, /* inSync= */ true))),
               new Partition(
+                  CLUSTER_ID,
+                  "topic-3",
                   /* partition= */2,
-                  /* leader= */ 1,
                   Arrays.asList(
                       new PartitionReplica(1, /* leader= */ true, /* inSync= */ true),
                       new PartitionReplica(2, /* leader= */ false, /* inSync= */ false),

--- a/testing/environments/minimal/docker-compose.yml
+++ b/testing/environments/minimal/docker-compose.yml
@@ -32,11 +32,14 @@ services:
     depends_on:
       - zookeeper
     environment:
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka-1:9191"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-1:9191,EXTERNAL://localhost:9291"
       KAFKA_BROKER_ID: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_LISTENERS: "INTERNAL://0.0.0.0:9191,EXTERNAL://0.0.0.0:9291"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:9091"
     ports:
-      - "9191:9191"
+      - "9291:9291"
 
   kafka-2:
     image: confluentinc/cp-server:latest
@@ -45,11 +48,14 @@ services:
     depends_on:
       - zookeeper
     environment:
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka-2:9192"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-2:9192,EXTERNAL://localhost:9292"
       KAFKA_BROKER_ID: 2
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_LISTENERS: "INTERNAL://0.0.0.0:9192,EXTERNAL://0.0.0.0:9292"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:9091"
     ports:
-      - "9192:9192"
+      - "9292:9292"
 
   kafka-3:
     image: confluentinc/cp-server:latest
@@ -58,11 +64,14 @@ services:
     depends_on:
       - zookeeper
     environment:
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka-3:9193"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-3:9193,EXTERNAL://localhost:9293"
       KAFKA_BROKER_ID: 3
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_LISTENERS: "INTERNAL://0.0.0.0:9193,EXTERNAL://0.0.0.0:9293"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:9091"
     ports:
-      - "9193:9193"
+      - "9293:9293"
 
   kafka-rest:
     build:
@@ -74,9 +83,9 @@ services:
       - zookeeper
       - kafka-1
     environment:
-      KAFKA_REST_ADVERTISED_LISTENERS: "http://localhost:9291"
-      KAFKA_REST_BOOTSTRAP_SERVERS: "PLAINTEXT://kafka-1:9191"
-      KAFKA_REST_LISTENERS: "http://kafka-rest:9291"
+      KAFKA_REST_ADVERTISED_LISTENERS: "http://localhost:9391"
+      KAFKA_REST_BOOTSTRAP_SERVERS: "kafka-1:9191"
+      KAFKA_REST_LISTENERS: "http://0.0.0.0:9391"
       KAFKA_REST_ZOOKEEPER_CONNECT: "zookeeper:9091"
     ports:
-      - "9291:9291"
+      - "9391:9391"


### PR DESCRIPTION
This PR adds endpoints to list and get partitions:

/v3/clusters/{clusterId}/topics/{topicName}/partitions
/v3/clusters/{clusterId}/topics/{topicName}/partitions/{partitionId}
A non-inclusion was (beginning|end)_(offset|timestamp). Somehow, Admin.listOffsets does not seem to be working as I would expect. It always returns beginning_offset as 0 (regardless of the partition being empty or not), and all timestamps are (EPOCH - 1ms). We can add this information later.