### PR TITLE
Add LIST/GET/UPDATE/RESET Topic Configurations.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -27,6 +27,7 @@ public final class ControllersModule extends AbstractBinder {
     bind(ClusterManagerImpl.class).to(ClusterManager.class);
     bind(PartitionManagerImpl.class).to(PartitionManager.class);
     bind(ReplicaManagerImpl.class).to(ReplicaManager.class);
+    bind(TopicConfigurationManagerImpl.class).to(TopicConfigurationManager.class);
     bind(TopicManagerImpl.class).to(TopicManager.class);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 
-class PartitionManagerImpl implements PartitionManager {
+final class PartitionManagerImpl implements PartitionManager {
 
   private final TopicManager topicManager;
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigurationManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigurationManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import io.confluent.kafkarest.entities.TopicConfiguration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A service to manage Kafka {@link TopicConfiguration TopicConfigurations}.
+ */
+public interface TopicConfigurationManager {
+
+  /**
+   * Returns the list of Kafka {@link TopicConfiguration TopicConfigurations} belonging to the
+   * {@link io.confluent.kafkarest.entities.Topic} with the given {@code topicName}.
+   */
+  CompletableFuture<List<TopicConfiguration>> listTopicConfigurations(
+      String clusterId, String topicName);
+
+  /**
+   * Returns the Kafka {@link TopicConfiguration} with the given {@code name}.
+   */
+  CompletableFuture<Optional<TopicConfiguration>> getTopicConfiguration(
+      String clusterId, String topicName, String name);
+
+  /**
+   * Updates the Kafka {@link TopicConfiguration} with the given {@code name} to the given {@code
+   * newValue}.
+   */
+  CompletableFuture<Void> updateTopicConfiguration(
+      String clusterId, String topicName, String name, String newValue);
+
+  /**
+   * Resets the Kafka {@link TopicConfiguration} with the given {@code name} to its default value.
+   */
+  CompletableFuture<Void> resetTopicConfiguration(
+      String clusterId, String topicName, String name);
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigurationManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigurationManagerImpl.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static io.confluent.kafkarest.controllers.Entities.checkEntityExists;
+import static io.confluent.kafkarest.controllers.Entities.findEntityByKey;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+
+import io.confluent.kafkarest.entities.TopicConfiguration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.common.config.ConfigResource;
+
+final class TopicConfigurationManagerImpl implements TopicConfigurationManager {
+
+  private final Admin adminClient;
+  private final TopicManager topicManager;
+
+  @Inject
+  TopicConfigurationManagerImpl(Admin adminClient, TopicManager topicManager) {
+    this.adminClient = Objects.requireNonNull(adminClient);
+    this.topicManager = Objects.requireNonNull(topicManager);
+  }
+
+  @Override
+  public CompletableFuture<List<TopicConfiguration>> listTopicConfigurations(
+      String clusterId, String topicName) {
+    ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+
+    return topicManager.getTopic(clusterId, topicName)
+        .thenApply(
+            topic ->
+                checkEntityExists(
+                    topic, "Topic %s cannot be found in cluster %s.", topicName, clusterId))
+        .thenCompose(
+            topic ->
+                KafkaFutures.toCompletableFuture(
+                    adminClient.describeConfigs(singletonList(resource)).values().get(resource)))
+        .thenApply(
+            config ->
+                config.entries().stream()
+                    .map(
+                        entry ->
+                            new TopicConfiguration(
+                                clusterId,
+                                topicName,
+                                entry.name(),
+                                entry.value(),
+                                entry.isDefault(),
+                                entry.isReadOnly(),
+                                entry.isSensitive()))
+                    .collect(Collectors.toList()));
+  }
+
+  @Override
+  public CompletableFuture<Optional<TopicConfiguration>> getTopicConfiguration(
+      String clusterId, String topicName, String name) {
+    return listTopicConfigurations(clusterId, topicName)
+        .thenApply(
+            configurations -> findEntityByKey(configurations, TopicConfiguration::getName, name));
+  }
+
+  @Override
+  public CompletableFuture<Void> updateTopicConfiguration(
+      String clusterId, String topicName, String name, String newValue) {
+    ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+
+    return getTopicConfiguration(clusterId, topicName, name)
+        .thenApply(
+            configuration ->
+                checkEntityExists(
+                    configuration,
+                    "Configuration %s cannot be found for topic %s in cluster %s.",
+                    name,
+                    topicName,
+                    clusterId))
+        .thenCompose(
+            topic ->
+                KafkaFutures.toCompletableFuture(
+                    adminClient.incrementalAlterConfigs(
+                        singletonMap(
+                            resource,
+                            singletonList(
+                                new AlterConfigOp(
+                                    new ConfigEntry(name, newValue), AlterConfigOp.OpType.SET))))
+                        .values()
+                        .get(resource)));
+  }
+
+  @Override
+  public CompletableFuture<Void> resetTopicConfiguration(
+      String clusterId, String topicName, String name) {
+    ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+
+    return getTopicConfiguration(clusterId, topicName, name)
+        .thenApply(
+            configuration ->
+                checkEntityExists(
+                    configuration,
+                    "Configuration %s cannot be found for topic %s in cluster %s.",
+                    name,
+                    topicName,
+                    clusterId))
+        .thenCompose(
+            topic ->
+                KafkaFutures.toCompletableFuture(
+                    adminClient.incrementalAlterConfigs(
+                        singletonMap(
+                            resource,
+                            singletonList(
+                                new AlterConfigOp(
+                                    new ConfigEntry(name, /* value= */ null),
+                                    AlterConfigOp.OpType.DELETE))))
+                        .values()
+                        .get(resource)));
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -18,6 +18,7 @@ package io.confluent.kafkarest.controllers;
 import io.confluent.kafkarest.entities.Topic;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -41,7 +42,11 @@ public interface TopicManager {
    * Creates a new Kafka {@link Topic}.
    */
   CompletableFuture<Void> createTopic(
-      String clusterId, String topicName, int partitionsCount, short replicationFactor);
+      String clusterId,
+      String topicName,
+      int partitionsCount,
+      short replicationFactor,
+      Map<String, String> configurations);
 
   /**
    * Deletes the Kafka {@link Topic} with the given {@code topicName}.

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -25,9 +25,9 @@ import io.confluent.kafkarest.entities.Topic;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -103,7 +103,6 @@ final class TopicManagerImpl implements TopicManager {
     return new Topic(
         clusterId,
         topicDescription.name(),
-        new Properties(),
         topicDescription.partitions().stream()
             .map(partition -> toPartition(clusterId, topicDescription.name(), partition))
             .collect(Collectors.toList()),
@@ -130,10 +129,15 @@ final class TopicManagerImpl implements TopicManager {
 
   @Override
   public CompletableFuture<Void> createTopic(
-      String clusterId, String topicName, int partitionsCount, short replicationFactor) {
+      String clusterId,
+      String topicName,
+      int partitionsCount,
+      short replicationFactor,
+      Map<String, String> configurations) {
     Objects.requireNonNull(topicName);
 
-    NewTopic createTopicRequest = new NewTopic(topicName, partitionsCount, replicationFactor);
+    NewTopic createTopicRequest =
+        new NewTopic(topicName, partitionsCount, replicationFactor).configs(configurations);
 
     return clusterManager.getCluster(clusterId)
         .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Topic.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Topic.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafkarest.entities;
 
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -27,6 +26,7 @@ public final class Topic {
 
   private final String name;
 
+  @Deprecated
   private final Properties configurations;
 
   private final List<Partition> partitions;
@@ -36,6 +36,35 @@ public final class Topic {
   private final boolean isInternal;
 
   public Topic(
+      String clusterId,
+      String name,
+      List<Partition> partitions,
+      short replicationFactor,
+      boolean isInternal) {
+    this(
+        clusterId,
+        name,
+        /* configurations= */ new Properties(),
+        partitions,
+        replicationFactor,
+        isInternal);
+  }
+
+  /**
+   * @deprecated use {@link #Topic(String, String, Properties, List, short, boolean)} instead
+   */
+  @Deprecated
+  public Topic(String name, Properties configs, List<Partition> partitions) {
+    this(
+        /* clusterId= */ "",
+        name,
+        configs,
+        partitions,
+        /* replicationFactor= */ (short) 0,
+        /* isInternal= */ false);
+  }
+
+  private Topic(
       String clusterId,
       String name,
       Properties configurations,
@@ -53,24 +82,20 @@ public final class Topic {
     this.isInternal = isInternal;
   }
 
-  /**
-   * @deprecated use {@link #Topic(String, String, Properties, List, short, boolean)} instead
-   */
-  @Deprecated
-  public Topic(String name, Properties configs, List<Partition> partitions) {
-    this(
-        /* clusterId= */ "",
-        name,
-        configs,
-        partitions,
-        /* replicationFactor= */ (short) 0,
-        /* isInternal= */ false);
+  public String getClusterId() {
+    return clusterId;
   }
 
   public String getName() {
     return name;
   }
 
+  /**
+   * @deprecated Use {@link
+   * io.confluent.kafkarest.controllers.TopicConfigurationManager#listTopicConfigurations(String,
+   * String)} instead.
+   */
+  @Deprecated
   public Properties getConfigs() {
     return configurations;
   }
@@ -85,10 +110,6 @@ public final class Topic {
 
   public boolean getIsInternal() {
     return isInternal;
-  }
-
-  public String getClusterId() {
-    return clusterId;
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicConfiguration.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicConfiguration.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+
+/**
+ * A Kafka Topic Configuration.
+ */
+public final class TopicConfiguration {
+
+  private final String clusterId;
+
+  private final String topicName;
+
+  private final String name;
+
+  @Nullable
+  private final String value;
+
+  private final boolean isDefault;
+
+  private final boolean isReadOnly;
+
+  private final boolean isSensitive;
+
+  public TopicConfiguration(
+      String clusterId,
+      String topicName,
+      String name,
+      @Nullable String value,
+      boolean isDefault,
+      boolean isReadOnly,
+      boolean isSensitive) {
+    this.clusterId = Objects.requireNonNull(clusterId);
+    this.topicName = Objects.requireNonNull(topicName);
+    this.name = Objects.requireNonNull(name);
+    this.value = value;
+    this.isDefault = isDefault;
+    this.isReadOnly = isReadOnly;
+    this.isSensitive = isSensitive;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getValue() {
+    return value;
+  }
+
+  public boolean isDefault() {
+    return isDefault;
+  }
+
+  public boolean isReadOnly() {
+    return isReadOnly;
+  }
+
+  public boolean isSensitive() {
+    return isSensitive;
+  }
+
+  // CHECKSTYLE:OFF:CyclomaticComplexity
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicConfiguration that = (TopicConfiguration) o;
+    return isDefault == that.isDefault
+        && isReadOnly == that.isReadOnly
+        && isSensitive == that.isSensitive
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(topicName, that.topicName)
+        && Objects.equals(name, that.name)
+        && Objects.equals(value, that.value);
+  }
+  // CHECKSTYLE:ON:CyclomaticComplexity
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clusterId, topicName, name, value, isDefault, isSensitive);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", TopicConfiguration.class.getSimpleName() + "[", "]")
+        .add("clusterId='" + clusterId + "'")
+        .add("topicName='" + topicName + "'")
+        .add("name='" + name + "'")
+        .add("value='" + value + "'")
+        .add("isDefault=" + isDefault)
+        .add("isSensitive=" + isSensitive)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
@@ -15,8 +15,13 @@
 
 package io.confluent.kafkarest.entities.v3;
 
+import static java.util.Collections.emptyMap;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.annotation.Nullable;
@@ -115,15 +120,20 @@ public final class CreateTopicRequest {
 
       private final short replicationFactor;
 
+      @Nullable
+      private final List<Configuration> configurations;
+
       @JsonCreator
       public Attributes(
           @JsonProperty("topic_name") @Nullable String topicName,
           @JsonProperty("partitions_count") int partitionsCount,
-          @JsonProperty("replication_factor") short replicationFactor
+          @JsonProperty("replication_factor") short replicationFactor,
+          @JsonProperty("configurations") @Nullable List<Configuration> configurations
       ) {
         this.topicName = topicName;
         this.partitionsCount = partitionsCount;
         this.replicationFactor = replicationFactor;
+        this.configurations = configurations;
       }
 
       @Nullable
@@ -139,6 +149,18 @@ public final class CreateTopicRequest {
         return replicationFactor;
       }
 
+      public Map<String, String> getConfigurations() {
+        if (this.configurations == null) {
+          return emptyMap();
+        }
+
+        HashMap<String, String> configurations = new HashMap<>();
+        for (Configuration configuration : this.configurations) {
+          configurations.put(configuration.getName(), configuration.getValue());
+        }
+        return configurations;
+      }
+
       @Override
       public boolean equals(Object o) {
         if (this == o) {
@@ -150,12 +172,13 @@ public final class CreateTopicRequest {
         Attributes that = (Attributes) o;
         return partitionsCount == that.partitionsCount
             && replicationFactor == that.replicationFactor
-            && Objects.equals(topicName, that.topicName);
+            && Objects.equals(topicName, that.topicName)
+            && Objects.equals(configurations, that.configurations);
       }
 
       @Override
       public int hashCode() {
-        return Objects.hash(topicName, partitionsCount, replicationFactor);
+        return Objects.hash(topicName, partitionsCount, replicationFactor, configurations);
       }
 
       @Override
@@ -164,7 +187,61 @@ public final class CreateTopicRequest {
             .add("topicName='" + topicName + "'")
             .add("partitionsCount=" + partitionsCount)
             .add("replicationFactor=" + replicationFactor)
+            .add("configurations=" + configurations)
             .toString();
+      }
+
+      public static final class Configuration {
+
+        @NotNull
+        @Nullable
+        private final String name;
+
+        @Nullable
+        private final String value;
+
+        @JsonCreator
+        public Configuration(
+            @JsonProperty("name") @Nullable String name,
+            @JsonProperty("value") @Nullable String value) {
+          this.name = name;
+          this.value = value;
+        }
+
+        @Nullable
+        public String getName() {
+          return name;
+        }
+
+        @Nullable
+        public String getValue() {
+          return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+          if (this == o) {
+            return true;
+          }
+          if (o == null || getClass() != o.getClass()) {
+            return false;
+          }
+          Configuration that = (Configuration) o;
+          return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+          return Objects.hash(name, value);
+        }
+
+        @Override
+        public String toString() {
+          return new StringJoiner(", ", Configuration.class.getSimpleName() + "[", "]")
+              .add("name='" + name + "'")
+              .add("value='" + value + "'")
+              .toString();
+        }
       }
     }
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetTopicConfigurationResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetTopicConfigurationResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Response body for {@code GET /v3/clusters/<clusterId>/topics/<topicName>/configurations/<name>}
+ * requests.
+ */
+public final class GetTopicConfigurationResponse {
+
+  private final TopicConfigurationData data;
+
+  public GetTopicConfigurationResponse(TopicConfigurationData data) {
+    this.data = Objects.requireNonNull(data);
+  }
+
+  @JsonProperty("data")
+  public TopicConfigurationData getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    GetTopicConfigurationResponse that = (GetTopicConfigurationResponse) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(
+        ", ", GetTopicConfigurationResponse.class.getSimpleName() + "[", "]")
+        .add("data=" + data)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListTopicConfigurationsResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListTopicConfigurationsResponse.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Response body for {@code GET /v3/clusters/<clusterId>/topics/<topicName>/configurations}
+ * requests.
+ */
+public final class ListTopicConfigurationsResponse {
+
+  private final CollectionLink links;
+
+  private final List<TopicConfigurationData> data;
+
+  public ListTopicConfigurationsResponse(CollectionLink links, List<TopicConfigurationData> data) {
+    this.links = Objects.requireNonNull(links);
+    this.data = Objects.requireNonNull(data);
+  }
+
+  @JsonProperty("links")
+  public CollectionLink getLinks() {
+    return links;
+  }
+
+  @JsonProperty("data")
+  public List<TopicConfigurationData> getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ListTopicConfigurationsResponse that = (ListTopicConfigurationsResponse) o;
+    return Objects.equals(links, that.links) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(links, data);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(
+        ", ", ListTopicConfigurationsResponse.class.getSimpleName() + "[", "]")
+        .add("links=" + links)
+        .add("data=" + data)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigurationData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigurationData.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+
+/**
+ * A KafkaTopicConfiguration resource type.
+ */
+public final class TopicConfigurationData {
+
+  private final ResourceLink links;
+
+  private final Attributes attributes;
+
+  public TopicConfigurationData(
+      ResourceLink links,
+      String clusterId,
+      String topicName,
+      String name,
+      @Nullable String value,
+      boolean isDefault,
+      boolean isReadOnly,
+      boolean isSensitive) {
+    this.links = Objects.requireNonNull(links);
+    attributes =
+        new Attributes(clusterId, topicName, name, value, isDefault, isReadOnly, isSensitive);
+  }
+
+  @JsonProperty("type")
+  public String getType() {
+    return "KafkaTopicConfiguration";
+  }
+
+  @JsonProperty("id")
+  public String getId() {
+    return String.format(
+        "%s/%s/%s", attributes.getClusterId(), attributes.getTopicName(), attributes.getName());
+  }
+
+  @JsonProperty("links")
+  public ResourceLink getLinks() {
+    return links;
+  }
+
+  @JsonProperty("attributes")
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicConfigurationData that = (TopicConfigurationData) o;
+    return Objects.equals(links, that.links) && Objects.equals(attributes, that.attributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(links, attributes);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", TopicConfigurationData.class.getSimpleName() + "[", "]")
+        .add("links=" + links)
+        .add("attributes=" + attributes)
+        .toString();
+  }
+
+  public static final class Attributes {
+
+    private final String clusterId;
+
+    private final String topicName;
+
+    private final String name;
+
+    @Nullable
+    private final String value;
+
+    private final boolean isDefault;
+
+    private final boolean isReadOnly;
+
+    private final boolean isSensitive;
+
+    public Attributes(
+        String clusterId,
+        String topicName,
+        String name,
+        @Nullable String value,
+        boolean isDefault,
+        boolean isReadOnly,
+        boolean isSensitive) {
+      this.clusterId = Objects.requireNonNull(clusterId);
+      this.topicName = Objects.requireNonNull(topicName);
+      this.name = Objects.requireNonNull(name);
+      this.value = value;
+      this.isDefault = isDefault;
+      this.isReadOnly = isReadOnly;
+      this.isSensitive = isSensitive;
+    }
+
+    @JsonProperty("cluster_id")
+    public String getClusterId() {
+      return clusterId;
+    }
+
+    @JsonProperty("topic_name")
+    public String getTopicName() {
+      return topicName;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+      return name;
+    }
+
+    @JsonProperty("value")
+    @Nullable
+    public String getValue() {
+      return value;
+    }
+
+    @JsonProperty("is_default")
+    public boolean isDefault() {
+      return isDefault;
+    }
+
+    @JsonProperty("is_read_only")
+    public boolean isReadOnly() {
+      return isReadOnly;
+    }
+
+    @JsonProperty("is_sensitive")
+    public boolean isSensitive() {
+      return isSensitive;
+    }
+
+    // CHECKSTYLE:OFF:CyclomaticComplexity
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Attributes that = (Attributes) o;
+      return isDefault == that.isDefault
+          && isReadOnly == that.isReadOnly
+          && isSensitive == that.isSensitive
+          && Objects.equals(clusterId, that.clusterId)
+          && Objects.equals(topicName, that.topicName)
+          && Objects.equals(name, that.name)
+          && Objects.equals(value, that.value);
+    }
+    // CHECKSTYLE:ON:CyclomaticComplexity
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(clusterId, topicName, name, value, isDefault, isReadOnly, isSensitive);
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(", ", Attributes.class.getSimpleName() + "[", "]")
+          .add("clusterId='" + clusterId + "'")
+          .add("topicName='" + topicName + "'")
+          .add("name='" + name + "'")
+          .add("value='" + value + "'")
+          .add("isDefault=" + isDefault)
+          .add("isReadOnly=" + isReadOnly)
+          .add("isSensitive=" + isSensitive)
+          .toString();
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/UpdateTopicConfigurationRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/UpdateTopicConfigurationRequest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Request body for {@code PUT /v3/clusters/<clusterId>/topics/<topicName>/configurations/<name>}
+ * requests.
+ */
+public final class UpdateTopicConfigurationRequest {
+
+  @NotNull
+  @Nullable
+  private final Data data;
+
+  @JsonCreator
+  public UpdateTopicConfigurationRequest(@JsonProperty("data") @Nullable Data data) {
+    this.data = data;
+  }
+
+  @Nullable
+  public Data getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UpdateTopicConfigurationRequest that = (UpdateTopicConfigurationRequest) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ",
+        UpdateTopicConfigurationRequest.class.getSimpleName() + "[", "]")
+        .add("data=" + data)
+        .toString();
+  }
+
+  public static final class Data {
+
+    @NotNull
+    @Nullable
+    private final Attributes attributes;
+
+    @JsonCreator
+    public Data(@JsonProperty("attributes") @Nullable Attributes attributes) {
+      this.attributes = attributes;
+    }
+
+    @Nullable
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Data data = (Data) o;
+      return Objects.equals(attributes, data.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(attributes);
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(", ", Data.class.getSimpleName() + "[", "]")
+          .add("attributes=" + attributes)
+          .toString();
+    }
+
+    public static final class Attributes {
+
+      @Nullable
+      private final String value;
+
+      @JsonCreator
+      public Attributes(@JsonProperty("value") @Nullable String value) {
+        this.value = value;
+      }
+
+      @Nullable
+      public String getValue() {
+        return value;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (this == o) {
+          return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+          return false;
+        }
+        Attributes that = (Attributes) o;
+        return Objects.equals(value, that.value);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(value);
+      }
+
+      @Override
+      public String toString() {
+        return new StringJoiner(", ", Attributes.class.getSimpleName() + "[", "]")
+            .add("value='" + value + "'")
+            .toString();
+      }
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.controllers.TopicConfigurationManager;
+import io.confluent.kafkarest.entities.TopicConfiguration;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.GetTopicConfigurationResponse;
+import io.confluent.kafkarest.entities.v3.ListTopicConfigurationsResponse;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.TopicConfigurationData;
+import io.confluent.kafkarest.entities.v3.UpdateTopicConfigurationRequest;
+import io.confluent.kafkarest.resources.v3.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.kafkarest.response.UrlFactory;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+@Path("/v3/clusters/{clusterId}/topics/{topicName}/configurations")
+public final class TopicConfigurationsResource {
+
+  private final TopicConfigurationManager topicConfigurationManager;
+  private final UrlFactory urlFactory;
+
+  @Inject
+  public TopicConfigurationsResource(
+      TopicConfigurationManager topicConfigurationManager, UrlFactory urlFactory) {
+    this.topicConfigurationManager = Objects.requireNonNull(topicConfigurationManager);
+    this.urlFactory = Objects.requireNonNull(urlFactory);
+  }
+
+  @GET
+  @Produces(Versions.JSON_API)
+  public void listTopicConfigurations(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName) {
+    CompletableFuture<ListTopicConfigurationsResponse> response =
+        topicConfigurationManager.listTopicConfigurations(clusterId, topicName)
+            .thenApply(
+                configurations ->
+                    new ListTopicConfigurationsResponse(
+                        new CollectionLink(
+                            urlFactory.create(
+                                "v3", "clusters", clusterId, "topics", topicName, "configurations"),
+                            /* next= */ null),
+                        configurations.stream()
+                            .sorted(Comparator.comparing(TopicConfiguration::getName))
+                            .map(this::toTopicConfigurationData)
+                            .collect(Collectors.toList())));
+
+    AsyncResponses.asyncResume(asyncResponse, response);
+  }
+
+  @GET
+  @Path("/{name}")
+  @Produces(Versions.JSON_API)
+  public void getTopicConfiguration(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName,
+      @PathParam("name") String name
+  ) {
+    CompletableFuture<GetTopicConfigurationResponse> response =
+        topicConfigurationManager.getTopicConfiguration(clusterId, topicName, name)
+            .thenApply(topic -> topic.orElseThrow(NotFoundException::new))
+            .thenApply(topic -> new GetTopicConfigurationResponse(toTopicConfigurationData(topic)));
+
+    AsyncResponses.asyncResume(asyncResponse, response);
+  }
+
+  @PUT
+  @Path("/{name}")
+  @Consumes(Versions.JSON_API)
+  public void updateTopicConfiguration(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName,
+      @PathParam("name") String name,
+      @Valid UpdateTopicConfigurationRequest request
+  ) {
+    String newValue = request.getData().getAttributes().getValue();
+
+    CompletableFuture<Void> response =
+        topicConfigurationManager.updateTopicConfiguration(clusterId, topicName, name, newValue);
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+
+  @DELETE
+  @Path("/{name}")
+  public void resetTopicConfiguration(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName,
+      @PathParam("name") String name
+  ) {
+    CompletableFuture<Void> response =
+        topicConfigurationManager.resetTopicConfiguration(clusterId, topicName, name);
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+
+  private TopicConfigurationData toTopicConfigurationData(TopicConfiguration topicConfiguration) {
+    return new TopicConfigurationData(
+        new ResourceLink(
+            urlFactory.create(
+                "v3",
+                "clusters",
+                topicConfiguration.getClusterId(),
+                "topics",
+                topicConfiguration.getTopicName(),
+                "configurations",
+                topicConfiguration.getName())),
+        topicConfiguration.getClusterId(),
+        topicConfiguration.getTopicName(),
+        topicConfiguration.getName(),
+        topicConfiguration.getValue(),
+        topicConfiguration.isDefault(),
+        topicConfiguration.isReadOnly(),
+        topicConfiguration.isSensitive());
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -32,8 +32,8 @@ import io.confluent.kafkarest.resources.v3.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.net.URI;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -110,19 +110,20 @@ public final class TopicsResource {
     String topicName = request.getData().getAttributes().getTopicName();
     int partitionsCount =  request.getData().getAttributes().getPartitionsCount();
     short replicationFactor = request.getData().getAttributes().getReplicationFactor();
+    Map<String, String> configurations = request.getData().getAttributes().getConfigurations();
 
     TopicData topicData =
         toTopicData(
             new Topic(
                 clusterId,
                 topicName,
-                /* configurations= */ new Properties(),
                 /* partitions= */ emptyList(),
                 replicationFactor,
                 /* isInternal= */ false));
 
     CompletableFuture<CreateTopicResponse> response =
-        topicManager.createTopic(clusterId, topicName, partitionsCount, replicationFactor)
+        topicManager.createTopic(
+            clusterId, topicName, partitionsCount, replicationFactor, configurations)
             .thenApply(none -> new CreateTopicResponse(topicData));
 
     AsyncResponseBuilder.from(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
@@ -26,6 +26,7 @@ public final class V3ResourcesFeature implements Feature {
     configurable.register(ClustersResource.class);
     configurable.register(PartitionsResource.class);
     configurable.register(ReplicasResource.class);
+    configurable.register(TopicConfigurationsResource.class);
     configurable.register(TopicsResource.class);
     return true;
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
@@ -28,7 +28,6 @@ import io.confluent.kafkarest.entities.Topic;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.NotFoundException;
@@ -132,7 +131,6 @@ public class PartitionManagerImplTest {
       new Topic(
           CLUSTER_ID,
           TOPIC_NAME,
-          new Properties(),
           Arrays.asList(PARTITION_1, PARTITION_2, PARTITION_3),
           /* replicationFactor= */ (short) 3,
           /* isInternal= */ false);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigurationManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigurationManagerImplTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import io.confluent.kafkarest.entities.Topic;
+import io.confluent.kafkarest.entities.TopicConfiguration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import javax.ws.rs.NotFoundException;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.AlterConfigsResult;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.ConfigResource;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TopicConfigurationManagerImplTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String TOPIC_NAME = "topic-1";
+
+  private static final Topic TOPIC =
+      new Topic(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          emptyList(),
+          /* replicationFactor= */ (short) 1,
+          /* isInternal= */ false);
+
+  private static final TopicConfiguration CONFIGURATION_1 =
+      new TopicConfiguration(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-1",
+          "value-1",
+          /* isDefault= */ true,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ false);
+  private static final TopicConfiguration CONFIGURATION_2 =
+      new TopicConfiguration(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ true,
+          /* isSensitive= */ false);
+  private static final TopicConfiguration CONFIGURATION_3 =
+      new TopicConfiguration(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-3",
+          null,
+          /* isDefault= */ false,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ true);
+
+  private static final Config CONFIG =
+      new Config(
+          Arrays.asList(
+              new ConfigEntry(
+                  CONFIGURATION_1.getName(),
+                  CONFIGURATION_1.getValue(),
+                  CONFIGURATION_1.isDefault(),
+                  CONFIGURATION_1.isSensitive(),
+                  CONFIGURATION_1.isReadOnly()),
+              new ConfigEntry(
+                  CONFIGURATION_2.getName(),
+                  CONFIGURATION_2.getValue(),
+                  CONFIGURATION_2.isDefault(),
+                  CONFIGURATION_2.isSensitive(),
+                  CONFIGURATION_2.isReadOnly()),
+              new ConfigEntry(
+                  CONFIGURATION_3.getName(),
+                  CONFIGURATION_3.getValue(),
+                  CONFIGURATION_3.isDefault(),
+                  CONFIGURATION_3.isSensitive(),
+                  CONFIGURATION_3.isReadOnly())));
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private Admin adminClient;
+
+  @Mock
+  private TopicManager topicManager;
+
+  @Mock
+  private DescribeConfigsResult describeConfigsResult;
+
+  @Mock
+  private AlterConfigsResult alterConfigsResult;
+
+  private TopicConfigurationManagerImpl topicConfigurationManager;
+
+  @Before
+  public void setUp() {
+    topicConfigurationManager = new TopicConfigurationManagerImpl(adminClient, topicManager);
+  }
+
+  @Test
+  public void listTopicConfigurations_existingTopic_returnsConfigurations() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(adminClient, topicManager, describeConfigsResult);
+
+    List<TopicConfiguration> configurations =
+        topicConfigurationManager.listTopicConfigurations(CLUSTER_ID, TOPIC_NAME).get();
+
+    assertEquals(
+        new HashSet<>(Arrays.asList(CONFIGURATION_1, CONFIGURATION_2, CONFIGURATION_3)),
+        new HashSet<>(configurations));
+  }
+
+  @Test
+  public void listTopicConfigurations_nonExistingTopic_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.empty()));
+    replay(topicManager);
+
+    try {
+      topicConfigurationManager.listTopicConfigurations(CLUSTER_ID, TOPIC_NAME).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void listTopicConfigurations_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicManager);
+
+    try {
+      topicConfigurationManager.listTopicConfigurations(CLUSTER_ID, TOPIC_NAME).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void getTopicConfiguration_existingConfiguration_returnsConfiguration() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(adminClient, topicManager, describeConfigsResult);
+
+    TopicConfiguration configuration =
+        topicConfigurationManager.getTopicConfiguration(
+            CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName())
+            .get()
+            .get();
+
+    assertEquals(CONFIGURATION_1, configuration);
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingConfiguration_returnsEmpty() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(adminClient, topicManager, describeConfigsResult);
+
+    Optional<TopicConfiguration> configuration =
+        topicConfigurationManager.getTopicConfiguration(CLUSTER_ID, TOPIC_NAME, "foobar").get();
+
+    assertFalse(configuration.isPresent());
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingTopic_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.empty()));
+    replay(topicManager);
+
+    try {
+      topicConfigurationManager.getTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicManager);
+
+    try {
+      topicConfigurationManager.getTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void updateTopicConfiguration_existingConfiguration_updatesConfiguration()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    expect(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                singletonList(
+                    new AlterConfigOp(
+                        new ConfigEntry(CONFIGURATION_1.getName(), "new-value"),
+                        AlterConfigOp.OpType.SET)))))
+        .andReturn(alterConfigsResult);
+    expect(alterConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(null)));
+    replay(topicManager, adminClient, describeConfigsResult, alterConfigsResult);
+
+    topicConfigurationManager.updateTopicConfiguration(
+        CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName(), "new-value").get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingConfiguration_throwsNotFound()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(topicManager, adminClient, describeConfigsResult);
+
+    try {
+      topicConfigurationManager.updateTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, "foobar", "new-value").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingTopic_throwsNotFound()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.empty()));
+    replay(topicManager, adminClient);
+
+    try {
+      topicConfigurationManager.updateTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName(), "new-value").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingCluster_throwsNotFound()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicManager, adminClient);
+
+    try {
+      topicConfigurationManager.updateTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName(), "new-value").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetTopicConfiguration_existingConfiguration_resetsConfiguration()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    expect(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                singletonList(
+                    new AlterConfigOp(
+                        new ConfigEntry(CONFIGURATION_1.getName(), /* value= */ null),
+                        AlterConfigOp.OpType.DELETE)))))
+        .andReturn(alterConfigsResult);
+    expect(alterConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(null)));
+    replay(topicManager, adminClient, describeConfigsResult, alterConfigsResult);
+
+    topicConfigurationManager.resetTopicConfiguration(
+        CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()).get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingConfiguration_throwsNotFound()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.of(TOPIC)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(topicManager, adminClient, describeConfigsResult);
+
+    try {
+      topicConfigurationManager.resetTopicConfiguration(CLUSTER_ID, TOPIC_NAME, "foobar").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingTopic_throwsNotFound()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(completedFuture(Optional.empty()));
+    replay(topicManager, adminClient);
+
+    try {
+      topicConfigurationManager.resetTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingCluster_throwsNotFound()
+      throws Exception {
+    expect(topicManager.getTopic(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicManager, adminClient);
+
+    try {
+      topicConfigurationManager.resetTopicConfiguration(
+          CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.controllers;
 
 import static io.confluent.kafkarest.TestUtils.failedFuture;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
@@ -37,7 +38,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.NotFoundException;
 import org.apache.kafka.clients.admin.Admin;
@@ -124,7 +124,6 @@ public class TopicManagerImplTest {
       new Topic(
           CLUSTER_ID,
           "topic-1",
-          new Properties(),
           Arrays.asList(
               new Partition(
                   CLUSTER_ID,
@@ -211,7 +210,6 @@ public class TopicManagerImplTest {
       new Topic(
           CLUSTER_ID,
           "topic-2",
-          new Properties(),
           Arrays.asList(
               new Partition(
                   CLUSTER_ID,
@@ -298,7 +296,6 @@ public class TopicManagerImplTest {
       new Topic(
           CLUSTER_ID,
           "topic-3",
-          new Properties(),
           Arrays.asList(
               new Partition(
                   CLUSTER_ID,
@@ -503,7 +500,8 @@ public class TopicManagerImplTest {
                 new NewTopic(
                     TOPIC_1.getName(),
                     TOPIC_1.getPartitions().size(),
-                    TOPIC_1.getReplicationFactor()))))
+                    TOPIC_1.getReplicationFactor())
+            .configs(singletonMap("cleanup.policy", "compact")))))
         .andReturn(createTopicsResult);
     expect(createTopicsResult.all()).andReturn(KafkaFuture.completedFuture(null));
     replay(clusterManager, adminClient, createTopicsResult);
@@ -512,7 +510,8 @@ public class TopicManagerImplTest {
         CLUSTER_ID,
         TOPIC_1.getName(),
         TOPIC_1.getPartitions().size(),
-        TOPIC_1.getReplicationFactor()).get();
+        TOPIC_1.getReplicationFactor(),
+        singletonMap("cleanup.policy", "compact")).get();
 
     verify(adminClient);
   }
@@ -526,7 +525,8 @@ public class TopicManagerImplTest {
                 new NewTopic(
                     TOPIC_1.getName(),
                     TOPIC_1.getPartitions().size(),
-                    TOPIC_1.getReplicationFactor()))))
+                    TOPIC_1.getReplicationFactor())
+            .configs(singletonMap("cleanup.policy", "compact")))))
         .andReturn(createTopicsResult);
     expect(createTopicsResult.all()).andReturn(failedFuture(new TopicExistsException("")));
     replay(clusterManager, adminClient, createTopicsResult);
@@ -536,7 +536,8 @@ public class TopicManagerImplTest {
           CLUSTER_ID,
           TOPIC_1.getName(),
           TOPIC_1.getPartitions().size(),
-          TOPIC_1.getReplicationFactor()).get();
+          TOPIC_1.getReplicationFactor(),
+          singletonMap("cleanup.policy", "compact")).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(TopicExistsException.class, e.getCause().getClass());
@@ -555,7 +556,8 @@ public class TopicManagerImplTest {
           CLUSTER_ID,
           TOPIC_1.getName(),
           TOPIC_1.getPartitions().size(),
-          TOPIC_1.getReplicationFactor()).get();
+          TOPIC_1.getReplicationFactor(),
+          singletonMap("cleanup.policy", "compact")).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
@@ -1,0 +1,372 @@
+package io.confluent.kafkarest.integration.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.GetTopicConfigurationResponse;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.TopicConfigurationData;
+import io.confluent.kafkarest.integration.ClusterTestHarness;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarness {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String TOPIC_1 = "topic-1";
+
+  public TopicConfigurationsResourceIntegrationTest() {
+    super(/* numBrokers= */ 1, /* withSchemaRegistry= */ false);
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    createTopic(TOPIC_1, 1, (short) 1);
+  }
+
+  @Test
+  public void listTopicConfigurations_existingTopic_returnsConfigurations() throws Exception {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    String expectedLinks =
+        OBJECT_MAPPER.writeValueAsString(
+            new CollectionLink(
+                baseUrl
+                    + "/v3/clusters/" + clusterId
+                    + "/topics/" + TOPIC_1
+                    + "/configurations",
+                /* next= */ null));
+    String expectedConfig1 =
+        OBJECT_MAPPER.writeValueAsString(
+            new TopicConfigurationData(
+                new ResourceLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/topics/" + TOPIC_1
+                        + "/configurations/cleanup.policy"),
+                clusterId,
+                TOPIC_1,
+                "cleanup.policy",
+                "delete",
+                /* isDefault= */ true,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false));
+    String expectedConfig2 =
+        OBJECT_MAPPER.writeValueAsString(
+            new TopicConfigurationData(
+                new ResourceLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/topics/" + TOPIC_1
+                        + "/configurations/compression.type"),
+                clusterId,
+                TOPIC_1,
+                "compression.type",
+                "producer",
+                /* isDefault= */ true,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false));
+    String expectedConfig3 =
+        OBJECT_MAPPER.writeValueAsString(
+            new TopicConfigurationData(
+                new ResourceLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/topics/" + TOPIC_1
+                        + "/configurations/delete.retention.ms"),
+                clusterId,
+                TOPIC_1,
+                "delete.retention.ms",
+                "86400000",
+                /* isDefault= */ true,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false));
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configurations")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    String responseBody = response.readEntity(String.class);
+    assertTrue(
+        String.format("Not true that `%s' contains `%s'.", responseBody, expectedLinks),
+        responseBody.contains(expectedLinks));
+    assertTrue(
+        String.format("Not true that `%s' contains `%s'.", responseBody, expectedConfig1),
+        responseBody.contains(expectedConfig1));
+    assertTrue(
+        String.format("Not true that `%s' contains `%s'.", responseBody, expectedConfig2),
+        responseBody.contains(expectedConfig2));
+    assertTrue(
+        String.format("Not true that `%s' contains `%s'.", responseBody, expectedConfig3),
+        responseBody.contains(expectedConfig3));
+  }
+
+  @Test
+  public void listTopicConfigurations_nonExistingTopic_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/foobar/configurations")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void listTopicConfigurations_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getTopicConfiguration_existingConfiguration_returnsConfiguration() throws Exception {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    String expected =
+        OBJECT_MAPPER.writeValueAsString(
+            new GetTopicConfigurationResponse(
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_1
+                            + "/configurations/cleanup.policy"),
+                    clusterId,
+                    TOPIC_1,
+                    "cleanup.policy",
+                    "delete",
+                    /* isDefault= */ true,
+                    /* isReadOnly= */ false,
+                    /* isSensitive= */ false)));
+
+    Response response =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/topics/" + TOPIC_1
+                + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(expected, response.readEntity(String.class));
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingConfiguration_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configurations/foobar")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingTopic_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/foobar/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void
+  getThenUpdateThenGetThenResetThenGet_existingConfiguration_returnsDefaultThenUpdatesThenReturnsUpdatedThenResetsThenReturnsDefault
+      () throws Exception {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    String expectedBeforeUpdate =
+        OBJECT_MAPPER.writeValueAsString(
+            new GetTopicConfigurationResponse(
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_1
+                            + "/configurations/cleanup.policy"),
+                    clusterId,
+                    TOPIC_1,
+                    "cleanup.policy",
+                    "delete",
+                    /* isDefault= */ true,
+                    /* isReadOnly= */ false,
+                    /* isSensitive= */ false)));
+
+    Response responseBeforeUpdate =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/topics/" + TOPIC_1
+                + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseBeforeUpdate.getStatus());
+    assertEquals(expectedBeforeUpdate, responseBeforeUpdate.readEntity(String.class));
+
+    Response updateResponse =
+        request(
+            "/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"compact\"}}}", Versions.JSON_API));
+    assertEquals(Status.NO_CONTENT.getStatusCode(), updateResponse.getStatus());
+
+    String expectedAfterUpdate =
+        OBJECT_MAPPER.writeValueAsString(
+            new GetTopicConfigurationResponse(
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_1
+                            + "/configurations/cleanup.policy"),
+                    clusterId,
+                    TOPIC_1,
+                    "cleanup.policy",
+                    "compact",
+                    /* isDefault= */ false,
+                    /* isReadOnly= */ false,
+                    /* isSensitive= */ false)));
+
+    Response responseAfterUpdate =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/topics/" + TOPIC_1
+                + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
+    assertEquals(expectedAfterUpdate, responseAfterUpdate.readEntity(String.class));
+
+    Response resetResponse =
+        request(
+            "/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NO_CONTENT.getStatusCode(), resetResponse.getStatus());
+
+    String expectedAfterReset =
+        OBJECT_MAPPER.writeValueAsString(
+            new GetTopicConfigurationResponse(
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_1
+                            + "/configurations/cleanup.policy"),
+                    clusterId,
+                    TOPIC_1,
+                    "cleanup.policy",
+                    "delete",
+                    /* isDefault= */ true,
+                    /* isReadOnly= */ false,
+                    /* isSensitive= */ false)));
+
+    Response responseAfterReset =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/topics/" + TOPIC_1
+                + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterReset.getStatus());
+    assertEquals(expectedAfterReset, responseAfterReset.readEntity(String.class));
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingConfiguration_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configurations/foobar")
+            .accept(Versions.JSON_API)
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"compact\"}}}", Versions.JSON_API));
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingTopic_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/foobar/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"compact\"}}}", Versions.JSON_API));
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"compact\"}}}", Versions.JSON_API));
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingConfiguration_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configurations/foobar")
+            .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingTopic_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/foobar/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.kafkarest.integration.v3;
 
 import static org.junit.Assert.assertEquals;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
+import io.confluent.kafkarest.entities.v3.GetTopicConfigurationResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicsResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.TopicConfigurationData;
 import io.confluent.kafkarest.entities.v3.TopicData;
 import io.confluent.kafkarest.integration.ClusterTestHarness;
 import java.util.Arrays;
@@ -338,7 +340,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .post(
                 Entity.entity(
                     "{\"data\":{\"attributes\":{\"topic_name\":\""
-                        + topicName + "\",\"partitions_count\":1,\"replication_factor\":1}}}",
+                        + topicName + "\",\"partitions_count\":1,\"replication_factor\":1,"
+                        + "\"configurations\":[{\"name\":\"cleanup.policy\",\"value\":\"compact\"}]"
+                        + "}}}",
                     Versions.JSON_API));
     assertEquals(Status.CREATED.getStatusCode(), createTopicResponse.getStatus());
     assertEquals(expectedCreateTopicResponse, createTopicResponse.readEntity(String.class));
@@ -373,6 +377,35 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .get();
     assertEquals(Status.OK.getStatusCode(), existingTopicResponse.getStatus());
     assertEquals(expectedExistingGetTopicResponse, existingTopicResponse.readEntity(String.class));
+
+    String expectedExistingGetTopicConfigurationResponse =
+        OBJECT_MAPPER.writeValueAsString(
+            new GetTopicConfigurationResponse(
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/configurations/cleanup.policy"),
+                    clusterId,
+                    topicName,
+                    "cleanup.policy",
+                    "compact",
+                    /* isDefault= */ false,
+                    /* isReadOnly= */ false,
+                    /* isSensitive= */ false)));
+
+    Response existingGetTopicConfigurationResponse =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/topics/" + topicName
+                + "/configurations/cleanup.policy")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), existingGetTopicConfigurationResponse.getStatus());
+    assertEquals(
+        expectedExistingGetTopicConfigurationResponse,
+        existingGetTopicConfigurationResponse.readEntity(String.class));
 
     Response deleteTopicResponse =
         request("/v3/clusters/" + clusterId + "/topics/" + topicName)

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResourceTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static io.confluent.kafkarest.CompletableFutures.failedFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafkarest.controllers.TopicConfigurationManager;
+import io.confluent.kafkarest.entities.TopicConfiguration;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.GetTopicConfigurationResponse;
+import io.confluent.kafkarest.entities.v3.ListTopicConfigurationsResponse;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.TopicConfigurationData;
+import io.confluent.kafkarest.entities.v3.UpdateTopicConfigurationRequest;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.kafkarest.response.FakeUrlFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TopicConfigurationsResourceTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String TOPIC_NAME = "topic-1";
+
+  private static final TopicConfiguration CONFIGURATION_1 =
+      new TopicConfiguration(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-1",
+          "value-1",
+          /* isDefault= */ true,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ false);
+  private static final TopicConfiguration CONFIGURATION_2 =
+      new TopicConfiguration(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ true,
+          /* isSensitive= */ false);
+  private static final TopicConfiguration CONFIGURATION_3 =
+      new TopicConfiguration(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-3",
+          null,
+          /* isDefault= */ false,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ true);
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private TopicConfigurationManager topicConfigurationManager;
+
+  private TopicConfigurationsResource topicConfigurationsResource;
+
+  @Before
+  public void setUp() {
+    topicConfigurationsResource =
+        new TopicConfigurationsResource(topicConfigurationManager, new FakeUrlFactory());
+  }
+
+  @Test
+  public void listTopicConfigurations_existingTopic_returnsConfigurations() {
+    expect(topicConfigurationManager.listTopicConfigurations(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(
+            completedFuture(Arrays.asList(CONFIGURATION_1, CONFIGURATION_2, CONFIGURATION_3)));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.listTopicConfigurations(response, CLUSTER_ID, TOPIC_NAME);
+
+    ListTopicConfigurationsResponse expected =
+        new ListTopicConfigurationsResponse(
+            new CollectionLink(
+                "/v3/clusters/cluster-1/topics/topic-1/configurations", /* next= */ null),
+            Arrays.asList(
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        "/v3/clusters/cluster-1/topics/topic-1/configurations/config-1"),
+                    CLUSTER_ID,
+                    TOPIC_NAME,
+                    CONFIGURATION_1.getName(),
+                    CONFIGURATION_1.getValue(),
+                    CONFIGURATION_1.isDefault(),
+                    CONFIGURATION_1.isReadOnly(),
+                    CONFIGURATION_1.isSensitive()),
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        "/v3/clusters/cluster-1/topics/topic-1/configurations/config-2"),
+                    CLUSTER_ID,
+                    TOPIC_NAME,
+                    CONFIGURATION_2.getName(),
+                    CONFIGURATION_2.getValue(),
+                    CONFIGURATION_2.isDefault(),
+                    CONFIGURATION_2.isReadOnly(),
+                    CONFIGURATION_2.isSensitive()),
+                new TopicConfigurationData(
+                    new ResourceLink(
+                        "/v3/clusters/cluster-1/topics/topic-1/configurations/config-3"),
+                    CLUSTER_ID,
+                    TOPIC_NAME,
+                    CONFIGURATION_3.getName(),
+                    CONFIGURATION_3.getValue(),
+                    CONFIGURATION_3.isDefault(),
+                    CONFIGURATION_3.isReadOnly(),
+                    CONFIGURATION_3.isSensitive())));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void listTopicConfigurations_nonExistingTopicOrCluster_throwsNotFound() {
+    expect(topicConfigurationManager.listTopicConfigurations(CLUSTER_ID, TOPIC_NAME))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.listTopicConfigurations(response, CLUSTER_ID, TOPIC_NAME);
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void getTopicConfiguration_existingConfiguration_returnsConfiguration() {
+    expect(
+        topicConfigurationManager.getTopicConfiguration(
+            CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()))
+        .andReturn(completedFuture(Optional.of(CONFIGURATION_1)));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.getTopicConfiguration(
+        response, CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName());
+
+    GetTopicConfigurationResponse expected =
+        new GetTopicConfigurationResponse(
+            new TopicConfigurationData(
+                new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/configurations/config-1"),
+                CLUSTER_ID,
+                TOPIC_NAME,
+                CONFIGURATION_1.getName(),
+                CONFIGURATION_1.getValue(),
+                CONFIGURATION_1.isDefault(),
+                CONFIGURATION_1.isReadOnly(),
+                CONFIGURATION_1.isSensitive()));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingConfiguration_throwsNotFound() {
+    expect(
+        topicConfigurationManager.getTopicConfiguration(
+            CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()))
+        .andReturn(completedFuture(Optional.empty()));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.getTopicConfiguration(
+        response, CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void getTopicConfiguration_nonExistingTopicOrCluster_throwsNotFound() {
+    expect(
+        topicConfigurationManager.getTopicConfiguration(
+            CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.getTopicConfiguration(
+        response, CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void updateTopicConfiguration_existingConfiguration_updatesConfiguration() {
+    expect(
+        topicConfigurationManager.updateTopicConfiguration(
+            CLUSTER_ID,
+            TOPIC_NAME,
+            CONFIGURATION_1.getName(),
+            "new-value"))
+        .andReturn(completedFuture(null));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.updateTopicConfiguration(
+        response,
+        CLUSTER_ID,
+        TOPIC_NAME,
+        CONFIGURATION_1.getName(),
+        new UpdateTopicConfigurationRequest(
+            new UpdateTopicConfigurationRequest.Data(
+                new UpdateTopicConfigurationRequest.Data.Attributes("new-value"))));
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void updateTopicConfiguration_nonExistingConfigurationOrTopicOrCluster_throwsNotFound() {
+    expect(
+        topicConfigurationManager.updateTopicConfiguration(
+            CLUSTER_ID,
+            TOPIC_NAME,
+            CONFIGURATION_1.getName(),
+            "new-value"))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.updateTopicConfiguration(
+        response,
+        CLUSTER_ID,
+        TOPIC_NAME,
+        CONFIGURATION_1.getName(),
+        new UpdateTopicConfigurationRequest(
+            new UpdateTopicConfigurationRequest.Data(
+                new UpdateTopicConfigurationRequest.Data.Attributes("new-value"))));
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void resetTopicConfiguration_existingConfiguration_resetsConfiguration() {
+    expect(
+        topicConfigurationManager.resetTopicConfiguration(
+            CLUSTER_ID,
+            TOPIC_NAME,
+            CONFIGURATION_1.getName()))
+        .andReturn(completedFuture(null));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.resetTopicConfiguration(
+        response, CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName());
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingConfigurationOrTopicOrCluster_throwsNotFound() {
+    expect(
+        topicConfigurationManager.resetTopicConfiguration(
+            CLUSTER_ID,
+            TOPIC_NAME,
+            CONFIGURATION_1.getName()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicConfigurationManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicConfigurationsResource.resetTopicConfiguration(
+        response, CLUSTER_ID, TOPIC_NAME, CONFIGURATION_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -16,6 +16,8 @@
 package io.confluent.kafkarest.resources.v3;
 
 import static io.confluent.kafkarest.CompletableFutures.failedFuture;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -39,7 +41,6 @@ import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 import javax.ws.rs.NotFoundException;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -49,7 +50,10 @@ import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class TopicsResourceTest {
 
   private static final String CLUSTER_ID = "cluster-1";
@@ -58,7 +62,6 @@ public class TopicsResourceTest {
       new Topic(
           CLUSTER_ID,
           "topic-1",
-          new Properties(),
           Arrays.asList(
               new Partition(
                   CLUSTER_ID,
@@ -145,7 +148,6 @@ public class TopicsResourceTest {
       new Topic(
           CLUSTER_ID,
           "topic-2",
-          new Properties(),
           Arrays.asList(
               new Partition(
                   CLUSTER_ID,
@@ -232,7 +234,6 @@ public class TopicsResourceTest {
       new Topic(
           CLUSTER_ID,
           "topic-3",
-          new Properties(),
           Arrays.asList(
               new Partition(
                   CLUSTER_ID,
@@ -446,7 +447,8 @@ public class TopicsResourceTest {
             CLUSTER_ID,
             TOPIC_1.getName(),
             TOPIC_1.getPartitions().size(),
-            TOPIC_1.getReplicationFactor()))
+            TOPIC_1.getReplicationFactor(),
+            singletonMap("cleanup.policy", "compact")))
         .andReturn(completedFuture(null));
     replay(topicManager);
 
@@ -459,7 +461,10 @@ public class TopicsResourceTest {
                 new CreateTopicRequest.Data.Attributes(
                     TOPIC_1.getName(),
                     TOPIC_1.getPartitions().size(),
-                    TOPIC_1.getReplicationFactor()))));
+                    TOPIC_1.getReplicationFactor(),
+                    singletonList(
+                        new CreateTopicRequest.Data.Attributes.Configuration(
+                            "cleanup.policy", "compact"))))));
 
     CreateTopicResponse expected = new CreateTopicResponse(
         new TopicData(
@@ -482,7 +487,8 @@ public class TopicsResourceTest {
             CLUSTER_ID,
             TOPIC_1.getName(),
             TOPIC_1.getPartitions().size(),
-            TOPIC_1.getReplicationFactor()))
+            TOPIC_1.getReplicationFactor(),
+            singletonMap("cleanup.policy", "compact")))
         .andReturn(failedFuture(new TopicExistsException("")));
     replay(topicManager);
 
@@ -495,7 +501,10 @@ public class TopicsResourceTest {
                 new CreateTopicRequest.Data.Attributes(
                     TOPIC_1.getName(),
                     TOPIC_1.getPartitions().size(),
-                    TOPIC_1.getReplicationFactor()))));
+                    TOPIC_1.getReplicationFactor(),
+                    singletonList(
+                        new CreateTopicRequest.Data.Attributes.Configuration(
+                            "cleanup.policy", "compact"))))));
 
     assertEquals(TopicExistsException.class, response.getException().getClass());
   }
@@ -507,7 +516,8 @@ public class TopicsResourceTest {
             CLUSTER_ID,
             TOPIC_1.getName(),
             TOPIC_1.getPartitions().size(),
-            TOPIC_1.getReplicationFactor()))
+            TOPIC_1.getReplicationFactor(),
+            singletonMap("cleanup.policy", "compact")))
         .andReturn(failedFuture(new NotFoundException()));
     replay(topicManager);
 
@@ -520,7 +530,10 @@ public class TopicsResourceTest {
                 new CreateTopicRequest.Data.Attributes(
                     TOPIC_1.getName(),
                     TOPIC_1.getPartitions().size(),
-                    TOPIC_1.getReplicationFactor()))));
+                    TOPIC_1.getReplicationFactor(),
+                    singletonList(
+                        new CreateTopicRequest.Data.Attributes.Configuration(
+                            "cleanup.policy", "compact"))))));
 
     assertEquals(NotFoundException.class, response.getException().getClass());
   }


### PR DESCRIPTION
* CLIENTS-1502: Add LIST/GET Topic Configurations
* CLIENTS-1507: Add UPDATE Topic Configurations
* CLIENTS-1508: Add DELETE Topic Configurations

This PR adds endpoints to LIST/GET/UPDATE/RESET Topic Configurations:

* LIST:   GET    /v3/clusters/{clusterId}/topics/{topicName}/configurations
* GET:    GET    /v3/clusters/{clusterId}/topics/{topicName}/configurations/{name}
* UPDATE: PUT    /v3/clusters/{clusterId}/topics/{topicName}/configurations/{name} --data { "data": { "attributes": { "value": "new_value" } } }
* RESET:  DELETE /v3/clusters/{clusterId}/topics/{topicName}/configurations/{name}

It also adds the ability to specify topic configurations when creating a new topic.

* CREATE: POST /v3/clusters/{clusterId}/topics --data { "data": { "attributes": { "topic_name": "foobar", "partitions_count": 1, "replication_factor": 3, "configurations": [ { "name": "cleanup.policy", "value": "compact" } ] } } }