### PR TITLE
CLIENTS-1513: Change Type and ID to Confluent Resource Names and Iden…

### DIFF
--- a/kafka-rest-common/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest-common/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -319,6 +319,14 @@ public class KafkaRestConfig extends RestConfig {
       + " like filters to Rest Proxy. Typically used to add custom capability like logging, "
       + " security, etc.";
   private static final boolean ZOOKEEPER_SET_ACL_DEFAULT = false;
+
+  public static final String CRN_AUTHORITY_CONFIG =
+      "confluent.resource.name.authority";
+  private static final String CONFLUENT_RESOURCE_NAME_AUTHORITY_DOC =
+      "Authority to which the governance of the name space defined by the remainder of the CRN "
+          + "should be delegated to. Examples: confluent.cloud, mds-01.example.com.";
+  private static final String CONFLUENT_RESOURCE_NAME_AUTHORITY_DEFAULT = "";
+
   private static final ConfigDef config;
 
   public static final String HTTPS = "https";
@@ -625,7 +633,13 @@ public class KafkaRestConfig extends RestConfig {
         "",
         Importance.LOW,
         KAFKA_REST_RESOURCE_EXTENSION_DOC
-    );
+    )
+    .define(
+        CRN_AUTHORITY_CONFIG,
+        Type.STRING,
+        CONFLUENT_RESOURCE_NAME_AUTHORITY_DEFAULT,
+        Importance.LOW,
+        CONFLUENT_RESOURCE_NAME_AUTHORITY_DOC);
   }
 
   private Time time;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -51,6 +51,10 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new AdvertisedListenersConfigImpl())
         .to(new TypeLiteral<List<String>>() { });
 
+    bind(config.getString(KafkaRestConfig.CRN_AUTHORITY_CONFIG))
+        .qualifiedBy(new CrnAuthorityConfigImpl())
+        .to(String.class);
+
     bind(config.getString(KafkaRestConfig.HOST_NAME_CONFIG))
         .qualifiedBy(new HostNameConfigImpl())
         .to(String.class);
@@ -72,6 +76,16 @@ public final class ConfigModule extends AbstractBinder {
 
   private static final class AdvertisedListenersConfigImpl
       extends AnnotationLiteral<AdvertisedListenersConfig> implements AdvertisedListenersConfig {
+  }
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+  public @interface CrnAuthorityConfig {
+  }
+
+  private static final class CrnAuthorityConfigImpl
+      extends AnnotationLiteral<CrnAuthorityConfig> implements CrnAuthorityConfig {
   }
 
   @Qualifier

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/BrokerData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/BrokerData.java
@@ -21,9 +21,13 @@ import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
- * A KafkaBroker resource type.
+ * A broker resource type.
  */
 public final class BrokerData {
+
+  public static final String TYPE = "broker";
+
+  private final String id;
 
   private final ResourceLink links;
 
@@ -32,6 +36,7 @@ public final class BrokerData {
   private final Relationships relationships;
 
   public BrokerData(
+      String id,
       ResourceLink links,
       String clusterId,
       Integer brokerId,
@@ -40,6 +45,7 @@ public final class BrokerData {
       @Nullable String rack,
       Relationship configurations,
       Relationship partitionReplicas) {
+    this.id = Objects.requireNonNull(id);
     this.links = Objects.requireNonNull(links);
     attributes = new Attributes(clusterId, brokerId, host, port, rack);
     relationships = new Relationships(configurations, partitionReplicas);
@@ -47,12 +53,12 @@ public final class BrokerData {
 
   @JsonProperty("type")
   public String getType() {
-    return "KafkaBroker";
+    return TYPE;
   }
 
   @JsonProperty("id")
   public String getId() {
-    return String.format("%s/%s", attributes.getClusterId(), attributes.getBrokerId());
+    return id;
   }
 
   @JsonProperty("links")
@@ -79,19 +85,21 @@ public final class BrokerData {
       return false;
     }
     BrokerData that = (BrokerData) o;
-    return Objects.equals(links, that.links)
+    return Objects.equals(id, that.id)
+        && Objects.equals(links, that.links)
         && Objects.equals(attributes, that.attributes)
         && Objects.equals(relationships, that.relationships);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(links, attributes, relationships);
+    return Objects.hash(id, links, attributes, relationships);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", BrokerData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
         .add("links=" + links)
         .add("attributes=" + attributes)
         .add("relationships=" + relationships)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/BrokerData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/BrokerData.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  */
 public final class BrokerData {
 
-  public static final String TYPE = "broker";
+  public static final String ELEMENT_TYPE = "broker";
 
   private final String id;
 
@@ -53,7 +53,7 @@ public final class BrokerData {
 
   @JsonProperty("type")
   public String getType() {
-    return TYPE;
+    return "KafkaBroker";
   }
 
   @JsonProperty("id")

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  */
 public final class ClusterData {
 
-  public static final String TYPE = "kafka";
+  public static final String ELEMENT_TYPE = "kafka";
 
   private final String id;
 
@@ -52,7 +52,7 @@ public final class ClusterData {
 
   @JsonProperty("type")
   public String getType() {
-    return TYPE;
+    return "KafkaCluster";
   }
 
   @JsonProperty("id")

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
@@ -22,9 +22,13 @@ import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
- * A KafkaCluster resource type.
+ * A kafka resource type.
  */
 public final class ClusterData {
+
+  public static final String TYPE = "kafka";
+
+  private final String id;
 
   private final ResourceLink links;
 
@@ -33,12 +37,14 @@ public final class ClusterData {
   private final Relationships relationships;
 
   public ClusterData(
+      String id,
       ResourceLink links,
       String clusterId,
       Relationship controller,
       Relationship brokers,
       Relationship topics
   ) {
+    this.id = Objects.requireNonNull(id);
     this.links = Objects.requireNonNull(links);
     this.attributes = new Attributes(clusterId);
     this.relationships = new Relationships(controller, brokers, topics);
@@ -46,12 +52,12 @@ public final class ClusterData {
 
   @JsonProperty("type")
   public String getType() {
-    return "KafkaCluster";
+    return TYPE;
   }
 
   @JsonProperty("id")
   public String getId() {
-    return attributes.getClusterId();
+    return id;
   }
 
   @JsonProperty("links")
@@ -78,7 +84,8 @@ public final class ClusterData {
       return false;
     }
     ClusterData that = (ClusterData) o;
-    return Objects.equals(links, that.links)
+    return Objects.equals(id, that.id)
+        && Objects.equals(links, that.links)
         && Objects.equals(attributes, that.attributes)
         && Objects.equals(relationships, that.relationships);
 
@@ -86,12 +93,13 @@ public final class ClusterData {
 
   @Override
   public int hashCode() {
-    return Objects.hash(links, attributes, relationships);
+    return Objects.hash(id, links, attributes, relationships);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", ClusterData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
         .add("links=" + links)
         .add("attributes=" + attributes)
         .add("relationships=" + relationships)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionData.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  */
 public final class PartitionData {
 
-  public static final String TYPE = "partition";
+  public static final String ELEMENT_TYPE = "partition";
 
   private final String id;
 
@@ -52,7 +52,7 @@ public final class PartitionData {
 
   @JsonProperty("type")
   public String getType() {
-    return TYPE;
+    return "KafkaPartition";
   }
 
   @JsonProperty("id")

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionData.java
@@ -21,9 +21,13 @@ import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
- * A KafkaPartition resource type.
+ * A partition resource type.
  */
 public final class PartitionData {
+
+  public static final String TYPE = "partition";
+
+  private final String id;
 
   private final ResourceLink links;
 
@@ -32,6 +36,7 @@ public final class PartitionData {
   private final Relationships relationships;
 
   public PartitionData(
+      String id,
       ResourceLink links,
       String clusterId,
       String topicName,
@@ -39,6 +44,7 @@ public final class PartitionData {
       @Nullable Relationship leader,
       Relationship replicas
   ) {
+    this.id = Objects.requireNonNull(id);
     this.links = Objects.requireNonNull(links);
     attributes = new Attributes(clusterId, topicName, partitionId);
     relationships = new Relationships(leader, replicas);
@@ -46,16 +52,12 @@ public final class PartitionData {
 
   @JsonProperty("type")
   public String getType() {
-    return "KafkaPartition";
+    return TYPE;
   }
 
   @JsonProperty("id")
   public String getId() {
-    return String.format(
-        "%s/%s/%s",
-        attributes.getClusterId(),
-        attributes.getTopicName(),
-        attributes.getPartitionId());
+    return id;
   }
 
   @JsonProperty("links")
@@ -82,19 +84,21 @@ public final class PartitionData {
       return false;
     }
     PartitionData that = (PartitionData) o;
-    return Objects.equals(links, that.links)
+    return Objects.equals(id, that.id)
+        && Objects.equals(links, that.links)
         && Objects.equals(attributes, that.attributes)
         && Objects.equals(relationships, that.relationships);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(links, attributes, relationships);
+    return Objects.hash(id, links, attributes, relationships);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", PartitionData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
         .add("links=" + links)
         .add("attributes=" + attributes)
         .add("relationships=" + relationships)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ReplicaData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ReplicaData.java
@@ -24,7 +24,7 @@ import java.util.StringJoiner;
  */
 public final class ReplicaData {
 
-  public static final String TYPE = "replica";
+  public static final String ELEMENT_TYPE = "replica";
 
   private final String id;
 
@@ -52,7 +52,7 @@ public final class ReplicaData {
 
   @JsonProperty("type")
   public String getType() {
-    return TYPE;
+    return "KafkaReplica";
   }
 
   @JsonProperty("id")

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ReplicaData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ReplicaData.java
@@ -20,9 +20,13 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
- * A KafkaPartition resource type.
+ * A replica resource type.
  */
 public final class ReplicaData {
+
+  public static final String TYPE = "replica";
+
+  private final String id;
 
   private final ResourceLink links;
 
@@ -31,6 +35,7 @@ public final class ReplicaData {
   private final Relationships relationships;
 
   public ReplicaData(
+      String id,
       ResourceLink links,
       String clusterId,
       String topicName,
@@ -39,6 +44,7 @@ public final class ReplicaData {
       Boolean isLeader,
       Boolean isInSync,
       Relationship broker) {
+    this.id = Objects.requireNonNull(id);
     this.links = Objects.requireNonNull(links);
     attributes = new Attributes(clusterId, topicName, partitionId, brokerId, isLeader, isInSync);
     relationships = new Relationships(broker);
@@ -46,17 +52,12 @@ public final class ReplicaData {
 
   @JsonProperty("type")
   public String getType() {
-    return "KafkaReplica";
+    return TYPE;
   }
 
   @JsonProperty("id")
   public String getId() {
-    return String.format(
-        "%s/%s/%s/%s",
-        attributes.getClusterId(),
-        attributes.getTopicName(),
-        attributes.getPartitionId(),
-        attributes.getBrokerId());
+    return id;
   }
 
   @JsonProperty("links")
@@ -83,19 +84,21 @@ public final class ReplicaData {
       return false;
     }
     ReplicaData that = (ReplicaData) o;
-    return Objects.equals(links, that.links)
+    return Objects.equals(id, that.id)
+        && Objects.equals(links, that.links)
         && Objects.equals(attributes, that.attributes)
         && Objects.equals(relationships, that.relationships);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(links, attributes, relationships);
+    return Objects.hash(id, links, attributes, relationships);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", ReplicaData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
         .add("links=" + links)
         .add("attributes=" + attributes)
         .add("relationships=" + relationships)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigurationData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigurationData.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  */
 public final class TopicConfigurationData {
 
-  public static final String TYPE = "configuration";
+  public static final String ELEMENT_TYPE = "configuration";
 
   private final String id;
 
@@ -51,7 +51,7 @@ public final class TopicConfigurationData {
 
   @JsonProperty("type")
   public String getType() {
-    return "configuration";
+    return "KafkaTopicConfiguration";
   }
 
   @JsonProperty("id")

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigurationData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigurationData.java
@@ -21,15 +21,20 @@ import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
- * A KafkaTopicConfiguration resource type.
+ * A (Topic) configuration resource type.
  */
 public final class TopicConfigurationData {
+
+  public static final String TYPE = "configuration";
+
+  private final String id;
 
   private final ResourceLink links;
 
   private final Attributes attributes;
 
   public TopicConfigurationData(
+      String id,
       ResourceLink links,
       String clusterId,
       String topicName,
@@ -38,6 +43,7 @@ public final class TopicConfigurationData {
       boolean isDefault,
       boolean isReadOnly,
       boolean isSensitive) {
+    this.id = Objects.requireNonNull(id);
     this.links = Objects.requireNonNull(links);
     attributes =
         new Attributes(clusterId, topicName, name, value, isDefault, isReadOnly, isSensitive);
@@ -45,13 +51,12 @@ public final class TopicConfigurationData {
 
   @JsonProperty("type")
   public String getType() {
-    return "KafkaTopicConfiguration";
+    return "configuration";
   }
 
   @JsonProperty("id")
   public String getId() {
-    return String.format(
-        "%s/%s/%s", attributes.getClusterId(), attributes.getTopicName(), attributes.getName());
+    return id;
   }
 
   @JsonProperty("links")
@@ -73,17 +78,20 @@ public final class TopicConfigurationData {
       return false;
     }
     TopicConfigurationData that = (TopicConfigurationData) o;
-    return Objects.equals(links, that.links) && Objects.equals(attributes, that.attributes);
+    return Objects.equals(id, that.id)
+        && Objects.equals(links, that.links)
+        && Objects.equals(attributes, that.attributes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(links, attributes);
+    return Objects.hash(id, links, attributes);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", TopicConfigurationData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
         .add("links=" + links)
         .add("attributes=" + attributes)
         .toString();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -20,9 +20,13 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
- * A KafkaTopic resource type.
+ * A topic resource type.
  */
 public final class TopicData {
+
+  public static final String TYPE = "topic";
+
+  private final String id;
 
   private final ResourceLink links;
 
@@ -31,6 +35,7 @@ public final class TopicData {
   private final Relationships relationships;
 
   public TopicData(
+      String id,
       ResourceLink links,
       String clusterId,
       String topicName,
@@ -39,6 +44,7 @@ public final class TopicData {
       Relationship configurations,
       Relationship partitions
   ) {
+    this.id = Objects.requireNonNull(id);
     this.links = Objects.requireNonNull(links);
     attributes = new Attributes(clusterId, topicName, isInternal, replicationFactor);
     relationships = new Relationships(configurations, partitions);
@@ -46,12 +52,12 @@ public final class TopicData {
 
   @JsonProperty("type")
   public String getType() {
-    return "KafkaTopic";
+    return TYPE;
   }
 
   @JsonProperty("id")
   public String getId() {
-    return String.format("%s/%s", attributes.getClusterId(), attributes.getTopicName());
+    return id;
   }
 
   @JsonProperty("links")
@@ -78,19 +84,21 @@ public final class TopicData {
       return false;
     }
     TopicData topicData = (TopicData) o;
-    return Objects.equals(links, topicData.links)
+    return Objects.equals(id, topicData.id)
+        && Objects.equals(links, topicData.links)
         && Objects.equals(attributes, topicData.attributes)
         && Objects.equals(relationships, topicData.relationships);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(links, attributes, relationships);
+    return Objects.hash(id, links, attributes, relationships);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", TopicData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
         .add("links=" + links)
         .add("attributes=" + attributes)
         .add("relationships=" + relationships)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -24,7 +24,7 @@ import java.util.StringJoiner;
  */
 public final class TopicData {
 
-  public static final String TYPE = "topic";
+  public static final String ELEMENT_TYPE = "topic";
 
   private final String id;
 
@@ -52,7 +52,7 @@ public final class TopicData {
 
   @JsonProperty("type")
   public String getType() {
-    return TYPE;
+    return "KafkaTopic";
   }
 
   @JsonProperty("id")

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
@@ -135,9 +135,9 @@ public final class BrokersResource {
 
     return new BrokerData(
         crnFactory.create(
-            ClusterData.TYPE,
+            ClusterData.ELEMENT_TYPE,
             broker.getClusterId(),
-            BrokerData.TYPE,
+            BrokerData.ELEMENT_TYPE,
             Integer.toString(broker.getBrokerId())),
         links,
         broker.getClusterId(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
@@ -19,11 +19,13 @@ import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.BrokerManager;
 import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.v3.BrokerData;
+import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.GetBrokerResponse;
 import io.confluent.kafkarest.entities.v3.ListBrokersResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -43,11 +45,14 @@ import javax.ws.rs.core.Response.Status;
 public final class BrokersResource {
 
   private final BrokerManager brokerManager;
+  private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
-  public BrokersResource(BrokerManager brokerManager, UrlFactory urlFactory) {
+  public BrokersResource(
+      BrokerManager brokerManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.brokerManager = Objects.requireNonNull(brokerManager);
+    this.crnFactory = Objects.requireNonNull(crnFactory);
     this.urlFactory = Objects.requireNonNull(urlFactory);
   }
 
@@ -129,6 +134,11 @@ public final class BrokersResource {
                 "partition_replicas"));
 
     return new BrokerData(
+        crnFactory.create(
+            ClusterData.TYPE,
+            broker.getClusterId(),
+            BrokerData.TYPE,
+            Integer.toString(broker.getBrokerId())),
         links,
         broker.getClusterId(),
         broker.getBrokerId(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
@@ -24,6 +24,7 @@ import io.confluent.kafkarest.entities.v3.GetClusterResponse;
 import io.confluent.kafkarest.entities.v3.ListClustersResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -41,11 +42,14 @@ import javax.ws.rs.container.Suspended;
 public final class ClustersResource {
 
   private final ClusterManager clusterManager;
+  private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
-  public ClustersResource(ClusterManager clusterManager, UrlFactory urlFactory) {
+  public ClustersResource(
+      ClusterManager clusterManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.clusterManager = Objects.requireNonNull(clusterManager);
+    this.crnFactory = Objects.requireNonNull(crnFactory);
     this.urlFactory = Objects.requireNonNull(urlFactory);
   }
 
@@ -97,6 +101,7 @@ public final class ClustersResource {
         new Relationship(urlFactory.create("v3", "clusters", cluster.getClusterId(), "topics"));
 
     return new ClusterData(
+        crnFactory.create(ClusterData.TYPE, cluster.getClusterId()),
         new ResourceLink(urlFactory.create("v3", "clusters", cluster.getClusterId())),
         cluster.getClusterId(),
         controller,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
@@ -101,7 +101,7 @@ public final class ClustersResource {
         new Relationship(urlFactory.create("v3", "clusters", cluster.getClusterId(), "topics"));
 
     return new ClusterData(
-        crnFactory.create(ClusterData.TYPE, cluster.getClusterId()),
+        crnFactory.create(ClusterData.ELEMENT_TYPE, cluster.getClusterId()),
         new ResourceLink(urlFactory.create("v3", "clusters", cluster.getClusterId())),
         cluster.getClusterId(),
         controller,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -134,11 +134,11 @@ public final class PartitionsResource {
 
     return new PartitionData(
         crnFactory.create(
-            ClusterData.TYPE,
+            ClusterData.ELEMENT_TYPE,
             partition.getClusterId(),
-            TopicData.TYPE,
+            TopicData.ELEMENT_TYPE,
             partition.getTopicName(),
-            PartitionData.TYPE,
+            PartitionData.ELEMENT_TYPE,
             Integer.toString(partition.getPartitionId())),
         links,
         partition.getClusterId(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -18,12 +18,15 @@ package io.confluent.kafkarest.resources.v3;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.PartitionManager;
 import io.confluent.kafkarest.entities.Partition;
+import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.GetPartitionResponse;
 import io.confluent.kafkarest.entities.v3.ListPartitionsResponse;
 import io.confluent.kafkarest.entities.v3.PartitionData;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.TopicData;
+import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -41,11 +44,14 @@ import javax.ws.rs.container.Suspended;
 public final class PartitionsResource {
 
   private final PartitionManager partitionManager;
+  private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
-  public PartitionsResource(PartitionManager partitionManager, UrlFactory urlFactory) {
+  public PartitionsResource(
+      PartitionManager partitionManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.partitionManager = Objects.requireNonNull(partitionManager);
+    this.crnFactory = Objects.requireNonNull(crnFactory);
     this.urlFactory = Objects.requireNonNull(urlFactory);
   }
 
@@ -127,6 +133,13 @@ public final class PartitionsResource {
                 "replicas"));
 
     return new PartitionData(
+        crnFactory.create(
+            ClusterData.TYPE,
+            partition.getClusterId(),
+            TopicData.TYPE,
+            partition.getTopicName(),
+            PartitionData.TYPE,
+            Integer.toString(partition.getPartitionId())),
         links,
         partition.getClusterId(),
         partition.getTopicName(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
@@ -129,13 +129,13 @@ public final class ReplicasResource {
 
     return new ReplicaData(
         crnFactory.create(
-            ClusterData.TYPE,
+            ClusterData.ELEMENT_TYPE,
             replica.getClusterId(),
-            TopicData.TYPE,
+            TopicData.ELEMENT_TYPE,
             replica.getTopicName(),
-            PartitionData.TYPE,
+            PartitionData.ELEMENT_TYPE,
             Integer.toString(replica.getPartitionId()),
-            ReplicaData.TYPE,
+            ReplicaData.ELEMENT_TYPE,
             Integer.toString(replica.getBrokerId())),
         links,
         replica.getClusterId(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
@@ -18,12 +18,16 @@ package io.confluent.kafkarest.resources.v3;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.ReplicaManager;
 import io.confluent.kafkarest.entities.PartitionReplica;
+import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.GetReplicaResponse;
 import io.confluent.kafkarest.entities.v3.ListReplicasResponse;
+import io.confluent.kafkarest.entities.v3.PartitionData;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ReplicaData;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.TopicData;
+import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -41,11 +45,14 @@ import javax.ws.rs.container.Suspended;
 public final class ReplicasResource {
 
   private final ReplicaManager replicaManager;
+  private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
-  public ReplicasResource(ReplicaManager replicaManager, UrlFactory urlFactory) {
+  public ReplicasResource(
+      ReplicaManager replicaManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.replicaManager = Objects.requireNonNull(replicaManager);
+    this.crnFactory = Objects.requireNonNull(crnFactory);
     this.urlFactory = Objects.requireNonNull(urlFactory);
   }
 
@@ -121,6 +128,15 @@ public final class ReplicasResource {
                 Integer.toString(replica.getBrokerId())));
 
     return new ReplicaData(
+        crnFactory.create(
+            ClusterData.TYPE,
+            replica.getClusterId(),
+            TopicData.TYPE,
+            replica.getTopicName(),
+            PartitionData.TYPE,
+            Integer.toString(replica.getPartitionId()),
+            ReplicaData.TYPE,
+            Integer.toString(replica.getBrokerId())),
         links,
         replica.getClusterId(),
         replica.getTopicName(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
@@ -18,13 +18,16 @@ package io.confluent.kafkarest.resources.v3;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.TopicConfigurationManager;
 import io.confluent.kafkarest.entities.TopicConfiguration;
+import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigurationResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicConfigurationsResponse;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
 import io.confluent.kafkarest.entities.v3.TopicConfigurationData;
+import io.confluent.kafkarest.entities.v3.TopicData;
 import io.confluent.kafkarest.entities.v3.UpdateTopicConfigurationRequest;
 import io.confluent.kafkarest.resources.v3.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.util.Comparator;
 import java.util.Objects;
@@ -49,12 +52,16 @@ import javax.ws.rs.core.Response.Status;
 public final class TopicConfigurationsResource {
 
   private final TopicConfigurationManager topicConfigurationManager;
+  private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
   public TopicConfigurationsResource(
-      TopicConfigurationManager topicConfigurationManager, UrlFactory urlFactory) {
+      TopicConfigurationManager topicConfigurationManager,
+      CrnFactory crnFactory,
+      UrlFactory urlFactory) {
     this.topicConfigurationManager = Objects.requireNonNull(topicConfigurationManager);
+    this.crnFactory = Objects.requireNonNull(crnFactory);
     this.urlFactory = Objects.requireNonNull(urlFactory);
   }
 
@@ -136,6 +143,13 @@ public final class TopicConfigurationsResource {
 
   private TopicConfigurationData toTopicConfigurationData(TopicConfiguration topicConfiguration) {
     return new TopicConfigurationData(
+        crnFactory.create(
+            ClusterData.TYPE,
+            topicConfiguration.getClusterId(),
+            TopicData.TYPE,
+            topicConfiguration.getTopicName(),
+            TopicConfigurationData.TYPE,
+            topicConfiguration.getName()),
         new ResourceLink(
             urlFactory.create(
                 "v3",

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
@@ -144,11 +144,11 @@ public final class TopicConfigurationsResource {
   private TopicConfigurationData toTopicConfigurationData(TopicConfiguration topicConfiguration) {
     return new TopicConfigurationData(
         crnFactory.create(
-            ClusterData.TYPE,
+            ClusterData.ELEMENT_TYPE,
             topicConfiguration.getClusterId(),
-            TopicData.TYPE,
+            TopicData.ELEMENT_TYPE,
             topicConfiguration.getTopicName(),
-            TopicConfigurationData.TYPE,
+            TopicConfigurationData.ELEMENT_TYPE,
             topicConfiguration.getName()),
         new ResourceLink(
             urlFactory.create(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -170,9 +170,9 @@ public final class TopicsResource {
 
     return new TopicData(
         crnFactory.create(
-            ClusterData.TYPE,
+            ClusterData.ELEMENT_TYPE,
             topic.getClusterId(),
-            TopicData.TYPE,
+            TopicData.ELEMENT_TYPE,
             topic.getName()),
         new ResourceLink(
             urlFactory.create("v3", "clusters", topic.getClusterId(), "topics", topic.getName())),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.TopicManager;
 import io.confluent.kafkarest.entities.Topic;
+import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
@@ -29,6 +30,7 @@ import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
 import io.confluent.kafkarest.entities.v3.TopicData;
 import io.confluent.kafkarest.resources.v3.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import java.net.URI;
 import java.util.Comparator;
@@ -55,11 +57,13 @@ import javax.ws.rs.core.Response.Status;
 public final class TopicsResource {
 
   private final TopicManager topicManager;
+  private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
-  public TopicsResource(TopicManager topicManager, UrlFactory urlFactory) {
+  public TopicsResource(TopicManager topicManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.topicManager = Objects.requireNonNull(topicManager);
+    this.crnFactory = Objects.requireNonNull(crnFactory);
     this.urlFactory = Objects.requireNonNull(urlFactory);
   }
 
@@ -165,6 +169,11 @@ public final class TopicsResource {
             "partitions"));
 
     return new TopicData(
+        crnFactory.create(
+            ClusterData.TYPE,
+            topic.getClusterId(),
+            TopicData.TYPE,
+            topic.getName()),
         new ResourceLink(
             urlFactory.create("v3", "clusters", topic.getClusterId(), "topics", topic.getName())),
         topic.getClusterId(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/CrnFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/CrnFactory.java
@@ -15,13 +15,18 @@
 
 package io.confluent.kafkarest.response;
 
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.process.internal.RequestScoped;
+/**
+ * A factory to create Confluent Resource Names to resources in this application.
+ */
+public interface CrnFactory {
 
-public final class ResponseModule extends AbstractBinder {
-
-  protected void configure() {
-    bind(CrnFactoryImpl.class).to(CrnFactory.class);
-    bind(UrlFactoryImpl.class).to(UrlFactory.class).in(RequestScoped.class);
-  }
+  /**
+   * Returns an Confluent Resource Name that uniquely identifies a resource from the given {@code
+   * components}.
+   *
+   * <p>The components are expected to be even numbered, with adjacent pairs on the format type1,
+   * id1, type2, id2, typeN, idN, where typeK is the k-th Confluent Resource Type, and idK is the
+   * k-th Confluent Resource Identifier. Scopes are resolved from left to right.</p>
+   */
+  String create(String... components);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/CrnFactoryImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/CrnFactoryImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.response;
+
+import io.confluent.kafkarest.config.ConfigModule.CrnAuthorityConfig;
+import java.util.StringJoiner;
+import javax.inject.Inject;
+
+/**
+ * A {@link CrnFactory} that uses the given {@code crnAuthorityConfig} as the Confluent Resource
+ * Authority for the generated CRNs.
+ */
+public final class CrnFactoryImpl implements CrnFactory {
+
+  private static final char SEPARATOR = '/';
+
+  private final String baseCrn;
+
+  @Inject
+  public CrnFactoryImpl(@CrnAuthorityConfig String crnAuthorityConfig) {
+    baseCrn = computeBaseCrn(crnAuthorityConfig);
+  }
+
+  @Override
+  public String create(String... components) {
+    if (components.length % 2 != 0) {
+      throw new IllegalArgumentException(
+          "Expected an even number of components on the form: type1, id1, type2, id2, etc.");
+    }
+    StringJoiner joiner = new StringJoiner(String.valueOf(SEPARATOR), baseCrn, "");
+    for (int i = 0; i < components.length; i += 2) {
+      joiner.add(
+          String.format("%s=%s", trimSeparator(components[i]), trimSeparator(components[i + 1])));
+    }
+    return joiner.toString();
+  }
+
+  private static String computeBaseCrn(String crnAuthorityConfig) {
+    String trimmedAuthority = trimSeparator(crnAuthorityConfig);
+    return String.format("crn://%s%s", trimmedAuthority, trimmedAuthority.isEmpty() ? "" : "/");
+  }
+
+  private static String trimSeparator(String component) {
+    int beginning = 0;
+    while (beginning < component.length() && component.charAt(beginning) == SEPARATOR) {
+      beginning++;
+    }
+    int end = component.length() - 1;
+    while (end >= 0 && component.charAt(end) == SEPARATOR) {
+      end--;
+    }
+    return beginning <= end ? component.substring(beginning, end + 1) : "";
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/CrnFactoryImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/CrnFactoryImpl.java
@@ -40,7 +40,7 @@ public final class CrnFactoryImpl implements CrnFactory {
       throw new IllegalArgumentException(
           "Expected an even number of components on the form: type1, id1, type2, id2, etc.");
     }
-    StringJoiner joiner = new StringJoiner(String.valueOf(SEPARATOR), baseCrn, "");
+    StringJoiner joiner = new StringJoiner(String.valueOf(SEPARATOR)).add(baseCrn);
     for (int i = 0; i < components.length; i += 2) {
       joiner.add(
           String.format("%s=%s", trimSeparator(components[i]), trimSeparator(components[i + 1])));
@@ -49,8 +49,7 @@ public final class CrnFactoryImpl implements CrnFactory {
   }
 
   private static String computeBaseCrn(String crnAuthorityConfig) {
-    String trimmedAuthority = trimSeparator(crnAuthorityConfig);
-    return String.format("crn://%s%s", trimmedAuthority, trimmedAuthority.isEmpty() ? "" : "/");
+    return String.format("crn://%s", trimSeparator(crnAuthorityConfig));
   }
 
   private static String trimSeparator(String component) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokersResourceIntegrationTest.java
@@ -54,7 +54,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
                     baseUrl + "/v3/clusters/" + clusterId + "/brokers", /* next= */ null),
                 Arrays.asList(
                     new BrokerData(
-                        "crn://kafka=" + clusterId + "/broker=" + nodes.get(0).id(),
+                        "crn:///kafka=" + clusterId + "/broker=" + nodes.get(0).id(),
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -75,7 +75,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
                                 + "/brokers/" + nodes.get(0).id()
                                 + "/partition_replicas")),
                     new BrokerData(
-                        "crn://kafka=" + clusterId + "/broker=" + nodes.get(1).id(),
+                        "crn:///kafka=" + clusterId + "/broker=" + nodes.get(1).id(),
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -96,7 +96,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
                                 + "/brokers/" + nodes.get(1).id()
                                 + "/partition_replicas")),
                     new BrokerData(
-                        "crn://kafka=" + clusterId + "/broker=" + nodes.get(2).id(),
+                        "crn:///kafka=" + clusterId + "/broker=" + nodes.get(2).id(),
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -139,7 +139,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetBrokerResponse(
                 new BrokerData(
-                    "crn://kafka=" + clusterId + "/broker=" + nodes.get(0).id(),
+                    "crn:///kafka=" + clusterId + "/broker=" + nodes.get(0).id(),
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokersResourceIntegrationTest.java
@@ -54,6 +54,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
                     baseUrl + "/v3/clusters/" + clusterId + "/brokers", /* next= */ null),
                 Arrays.asList(
                     new BrokerData(
+                        "crn://kafka=" + clusterId + "/broker=" + nodes.get(0).id(),
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -74,6 +75,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
                                 + "/brokers/" + nodes.get(0).id()
                                 + "/partition_replicas")),
                     new BrokerData(
+                        "crn://kafka=" + clusterId + "/broker=" + nodes.get(1).id(),
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -94,6 +96,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
                                 + "/brokers/" + nodes.get(1).id()
                                 + "/partition_replicas")),
                     new BrokerData(
+                        "crn://kafka=" + clusterId + "/broker=" + nodes.get(2).id(),
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -136,6 +139,7 @@ public class BrokersResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetBrokerResponse(
                 new BrokerData(
+                    "crn://kafka=" + clusterId + "/broker=" + nodes.get(0).id(),
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -51,6 +51,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                 new CollectionLink(baseUrl + "/v3/clusters", /* next= */ null),
                 singletonList(
                     new ClusterData(
+                        "crn://kafka=" + clusterId,
                         new ResourceLink(baseUrl + "/v3/clusters/" + clusterId),
                         clusterId,
                         new Relationship(
@@ -73,6 +74,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetClusterResponse(
                 new ClusterData(
+                    "crn://kafka=" + clusterId,
                     new ResourceLink(baseUrl + "/v3/clusters/" + clusterId),
                     clusterId,
                     new Relationship(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -51,7 +51,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                 new CollectionLink(baseUrl + "/v3/clusters", /* next= */ null),
                 singletonList(
                     new ClusterData(
-                        "crn://kafka=" + clusterId,
+                        "crn:///kafka=" + clusterId,
                         new ResourceLink(baseUrl + "/v3/clusters/" + clusterId),
                         clusterId,
                         new Relationship(
@@ -74,7 +74,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetClusterResponse(
                 new ClusterData(
-                    "crn://kafka=" + clusterId,
+                    "crn:///kafka=" + clusterId,
                     new ResourceLink(baseUrl + "/v3/clusters/" + clusterId),
                     clusterId,
                     new Relationship(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
@@ -66,7 +66,7 @@ public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
                     /* next= */ null),
                 singletonList(
                     new PartitionData(
-                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_NAME + "/partition=0",
+                        "crn:///kafka=" + clusterId + "/topic=" + TOPIC_NAME + "/partition=0",
                         new ResourceLink(
                             baseUrl
                             + "/v3/clusters/" + clusterId
@@ -123,7 +123,7 @@ public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetPartitionResponse(
                 new PartitionData(
-                    "crn://kafka=" + clusterId + "/topic=" + TOPIC_NAME + "/partition=0",
+                    "crn:///kafka=" + clusterId + "/topic=" + TOPIC_NAME + "/partition=0",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
@@ -66,6 +66,7 @@ public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
                     /* next= */ null),
                 singletonList(
                     new PartitionData(
+                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_NAME + "/partition=0",
                         new ResourceLink(
                             baseUrl
                             + "/v3/clusters/" + clusterId
@@ -122,6 +123,7 @@ public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetPartitionResponse(
                 new PartitionData(
+                    "crn://kafka=" + clusterId + "/topic=" + TOPIC_NAME + "/partition=0",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ReplicasResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ReplicasResourceIntegrationTest.java
@@ -66,6 +66,9 @@ public class ReplicasResourceIntegrationTest extends ClusterTestHarness {
                     /* next= */ null),
                 singletonList(
                     new ReplicaData(
+                        "crn://kafka=" + clusterId
+                            + "/topic=" + TOPIC_NAME
+                            + "/partition=0/replica=0",
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -127,6 +130,9 @@ public class ReplicasResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetReplicaResponse(
                 new ReplicaData(
+                    "crn://kafka=" + clusterId
+                        + "/topic=" + TOPIC_NAME
+                        + "/partition=0/replica=0",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ReplicasResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ReplicasResourceIntegrationTest.java
@@ -66,7 +66,7 @@ public class ReplicasResourceIntegrationTest extends ClusterTestHarness {
                     /* next= */ null),
                 singletonList(
                     new ReplicaData(
-                        "crn://kafka=" + clusterId
+                        "crn:///kafka=" + clusterId
                             + "/topic=" + TOPIC_NAME
                             + "/partition=0/replica=0",
                         new ResourceLink(
@@ -130,7 +130,7 @@ public class ReplicasResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetReplicaResponse(
                 new ReplicaData(
-                    "crn://kafka=" + clusterId
+                    "crn:///kafka=" + clusterId
                         + "/topic=" + TOPIC_NAME
                         + "/partition=0/replica=0",
                     new ResourceLink(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
@@ -65,6 +65,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     String expectedConfig1 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigurationData(
+                "crn://kafka=" + clusterId + "/topic=" + TOPIC_1 + "/configuration=cleanup.policy",
                 new ResourceLink(
                     baseUrl
                         + "/v3/clusters/" + clusterId
@@ -80,6 +81,9 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     String expectedConfig2 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigurationData(
+                "crn://kafka=" + clusterId
+                    + "/topic=" + TOPIC_1
+                    + "/configuration=compression.type",
                 new ResourceLink(
                     baseUrl
                         + "/v3/clusters/" + clusterId
@@ -95,6 +99,9 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     String expectedConfig3 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigurationData(
+                "crn://kafka=" + clusterId
+                    + "/topic=" + TOPIC_1
+                    + "/configuration=delete.retention.ms",
                 new ResourceLink(
                     baseUrl
                         + "/v3/clusters/" + clusterId
@@ -157,6 +164,9 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
+                    "crn://kafka=" + clusterId
+                        + "/topic=" + TOPIC_1
+                        + "/configuration=cleanup.policy",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -223,6 +233,9 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
+                    "crn://kafka=" + clusterId
+                        + "/topic=" + TOPIC_1
+                        + "/configuration=cleanup.policy",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -259,6 +272,9 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
+                    "crn://kafka=" + clusterId
+                        + "/topic=" + TOPIC_1
+                        + "/configuration=cleanup.policy",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -293,6 +309,9 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
+                    "crn://kafka=" + clusterId
+                        + "/topic=" + TOPIC_1
+                        + "/configuration=cleanup.policy",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
@@ -65,7 +65,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     String expectedConfig1 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigurationData(
-                "crn://kafka=" + clusterId + "/topic=" + TOPIC_1 + "/configuration=cleanup.policy",
+                "crn:///kafka=" + clusterId + "/topic=" + TOPIC_1 + "/configuration=cleanup.policy",
                 new ResourceLink(
                     baseUrl
                         + "/v3/clusters/" + clusterId
@@ -81,7 +81,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     String expectedConfig2 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigurationData(
-                "crn://kafka=" + clusterId
+                "crn:///kafka=" + clusterId
                     + "/topic=" + TOPIC_1
                     + "/configuration=compression.type",
                 new ResourceLink(
@@ -99,7 +99,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     String expectedConfig3 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigurationData(
-                "crn://kafka=" + clusterId
+                "crn:///kafka=" + clusterId
                     + "/topic=" + TOPIC_1
                     + "/configuration=delete.retention.ms",
                 new ResourceLink(
@@ -164,7 +164,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
-                    "crn://kafka=" + clusterId
+                    "crn:///kafka=" + clusterId
                         + "/topic=" + TOPIC_1
                         + "/configuration=cleanup.policy",
                     new ResourceLink(
@@ -233,7 +233,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
-                    "crn://kafka=" + clusterId
+                    "crn:///kafka=" + clusterId
                         + "/topic=" + TOPIC_1
                         + "/configuration=cleanup.policy",
                     new ResourceLink(
@@ -272,7 +272,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
-                    "crn://kafka=" + clusterId
+                    "crn:///kafka=" + clusterId
                         + "/topic=" + TOPIC_1
                         + "/configuration=cleanup.policy",
                     new ResourceLink(
@@ -309,7 +309,7 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
-                    "crn://kafka=" + clusterId
+                    "crn:///kafka=" + clusterId
                         + "/topic=" + TOPIC_1
                         + "/configuration=cleanup.policy",
                     new ResourceLink(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -79,7 +79,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                     baseUrl + "/v3/clusters/" + clusterId + "/topics", /* next= */ null),
                 Arrays.asList(
                     new TopicData(
-                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_1,
+                        "crn:///kafka=" + clusterId + "/topic=" + TOPIC_1,
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -99,7 +99,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                 + "/topics/" + TOPIC_1
                                 + "/partitions")),
                     new TopicData(
-                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_2,
+                        "crn:///kafka=" + clusterId + "/topic=" + TOPIC_2,
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -119,7 +119,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                 + "/topics/" + TOPIC_2
                                 + "/partitions")),
                     new TopicData(
-                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_3,
+                        "crn:///kafka=" + clusterId + "/topic=" + TOPIC_3,
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -160,7 +160,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicResponse(
                 new TopicData(
-                    "crn://kafka=" + clusterId + "/topic=" + TOPIC_1,
+                    "crn:///kafka=" + clusterId + "/topic=" + TOPIC_1,
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -212,7 +212,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new CreateTopicResponse(
                 new TopicData(
-                    "crn://kafka=" + clusterId + "/topic=" + topicName,
+                    "crn:///kafka=" + clusterId + "/topic=" + topicName,
                     new ResourceLink(
                         baseUrl + "/v3/clusters/" + clusterId + "/topics/" + topicName),
                     clusterId,
@@ -322,7 +322,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new CreateTopicResponse(
                 new TopicData(
-                    "crn://kafka=" + clusterId + "/topic=" + topicName,
+                    "crn:///kafka=" + clusterId + "/topic=" + topicName,
                     new ResourceLink(
                         baseUrl + "/v3/clusters/" + clusterId + "/topics/" + topicName),
                     clusterId,
@@ -358,7 +358,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicResponse(
                 new TopicData(
-                    "crn://kafka=" + clusterId + "/topic=" + topicName,
+                    "crn:///kafka=" + clusterId + "/topic=" + topicName,
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -389,7 +389,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
-                    "crn://kafka=" + clusterId
+                    "crn:///kafka=" + clusterId
                         + "/topic=" + topicName
                         + "/configuration=cleanup.policy",
                     new ResourceLink(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -79,6 +79,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                     baseUrl + "/v3/clusters/" + clusterId + "/topics", /* next= */ null),
                 Arrays.asList(
                     new TopicData(
+                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_1,
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -98,6 +99,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                 + "/topics/" + TOPIC_1
                                 + "/partitions")),
                     new TopicData(
+                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_2,
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -117,6 +119,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                 + "/topics/" + TOPIC_2
                                 + "/partitions")),
                     new TopicData(
+                        "crn://kafka=" + clusterId + "/topic=" + TOPIC_3,
                         new ResourceLink(
                             baseUrl
                                 + "/v3/clusters/" + clusterId
@@ -157,6 +160,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicResponse(
                 new TopicData(
+                    "crn://kafka=" + clusterId + "/topic=" + TOPIC_1,
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -208,6 +212,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new CreateTopicResponse(
                 new TopicData(
+                    "crn://kafka=" + clusterId + "/topic=" + topicName,
                     new ResourceLink(
                         baseUrl + "/v3/clusters/" + clusterId + "/topics/" + topicName),
                     clusterId,
@@ -317,6 +322,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new CreateTopicResponse(
                 new TopicData(
+                    "crn://kafka=" + clusterId + "/topic=" + topicName,
                     new ResourceLink(
                         baseUrl + "/v3/clusters/" + clusterId + "/topics/" + topicName),
                     clusterId,
@@ -352,6 +358,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicResponse(
                 new TopicData(
+                    "crn://kafka=" + clusterId + "/topic=" + topicName,
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -382,6 +389,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         OBJECT_MAPPER.writeValueAsString(
             new GetTopicConfigurationResponse(
                 new TopicConfigurationData(
+                    "crn://kafka=" + clusterId
+                        + "/topic=" + topicName
+                        + "/configuration=cleanup.policy",
                     new ResourceLink(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
@@ -80,7 +80,7 @@ public final class BrokersResourceTest {
             new CollectionLink("/v3/clusters/cluster-1/brokers", /* next= */ null),
             Arrays.asList(
                 new BrokerData(
-                    "crn://kafka=cluster-1/broker=1",
+                    "crn:///kafka=cluster-1/broker=1",
                     new ResourceLink("/v3/clusters/cluster-1/brokers/1"),
                     CLUSTER_ID,
                     BROKER_1.getBrokerId(),
@@ -90,7 +90,7 @@ public final class BrokersResourceTest {
                     new Relationship("/v3/clusters/cluster-1/brokers/1/configurations"),
                     new Relationship("/v3/clusters/cluster-1/brokers/1/partition_replicas")),
                 new BrokerData(
-                    "crn://kafka=cluster-1/broker=2",
+                    "crn:///kafka=cluster-1/broker=2",
                     new ResourceLink("/v3/clusters/cluster-1/brokers/2"),
                     CLUSTER_ID,
                     BROKER_2.getBrokerId(),
@@ -100,7 +100,7 @@ public final class BrokersResourceTest {
                     new Relationship("/v3/clusters/cluster-1/brokers/2/configurations"),
                     new Relationship("/v3/clusters/cluster-1/brokers/2/partition_replicas")),
                 new BrokerData(
-                    "crn://kafka=cluster-1/broker=3",
+                    "crn:///kafka=cluster-1/broker=3",
                     new ResourceLink("/v3/clusters/cluster-1/brokers/3"),
                     CLUSTER_ID,
                     BROKER_3.getBrokerId(),
@@ -136,7 +136,7 @@ public final class BrokersResourceTest {
     GetBrokerResponse expected =
         new GetBrokerResponse(
             new BrokerData(
-                "crn://kafka=cluster-1/broker=1",
+                "crn:///kafka=cluster-1/broker=1",
                 new ResourceLink("/v3/clusters/cluster-1/brokers/1"),
                 CLUSTER_ID,
                 BROKER_1.getBrokerId(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
@@ -28,6 +28,7 @@ import io.confluent.kafkarest.entities.v3.GetBrokerResponse;
 import io.confluent.kafkarest.entities.v3.ListBrokersResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
@@ -60,7 +61,9 @@ public final class BrokersResourceTest {
 
   @Before
   public void setUp() {
-    brokersResource = new BrokersResource(brokerManager, new FakeUrlFactory());
+    brokersResource =
+        new BrokersResource(
+            brokerManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
   }
 
   @Test
@@ -77,6 +80,7 @@ public final class BrokersResourceTest {
             new CollectionLink("/v3/clusters/cluster-1/brokers", /* next= */ null),
             Arrays.asList(
                 new BrokerData(
+                    "crn://kafka=cluster-1/broker=1",
                     new ResourceLink("/v3/clusters/cluster-1/brokers/1"),
                     CLUSTER_ID,
                     BROKER_1.getBrokerId(),
@@ -86,6 +90,7 @@ public final class BrokersResourceTest {
                     new Relationship("/v3/clusters/cluster-1/brokers/1/configurations"),
                     new Relationship("/v3/clusters/cluster-1/brokers/1/partition_replicas")),
                 new BrokerData(
+                    "crn://kafka=cluster-1/broker=2",
                     new ResourceLink("/v3/clusters/cluster-1/brokers/2"),
                     CLUSTER_ID,
                     BROKER_2.getBrokerId(),
@@ -95,6 +100,7 @@ public final class BrokersResourceTest {
                     new Relationship("/v3/clusters/cluster-1/brokers/2/configurations"),
                     new Relationship("/v3/clusters/cluster-1/brokers/2/partition_replicas")),
                 new BrokerData(
+                    "crn://kafka=cluster-1/broker=3",
                     new ResourceLink("/v3/clusters/cluster-1/brokers/3"),
                     CLUSTER_ID,
                     BROKER_3.getBrokerId(),
@@ -130,6 +136,7 @@ public final class BrokersResourceTest {
     GetBrokerResponse expected =
         new GetBrokerResponse(
             new BrokerData(
+                "crn://kafka=cluster-1/broker=1",
                 new ResourceLink("/v3/clusters/cluster-1/brokers/1"),
                 CLUSTER_ID,
                 BROKER_1.getBrokerId(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.entities.v3.GetClusterResponse;
 import io.confluent.kafkarest.entities.v3.ListClustersResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
@@ -64,7 +65,9 @@ public class ClustersResourceTest {
 
   @Before
   public void setUp() {
-    clustersResource = new ClustersResource(clusterManager, new FakeUrlFactory());
+    clustersResource =
+        new ClustersResource(
+            clusterManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
   }
 
   @Test
@@ -81,6 +84,7 @@ public class ClustersResourceTest {
             new CollectionLink("/v3/clusters", /* next= */ null),
             singletonList(
                 new ClusterData(
+                    "crn://kafka=cluster-1",
                     new ResourceLink("/v3/clusters/cluster-1"),
                     "cluster-1",
                     new Relationship("/v3/clusters/cluster-1/brokers/1"),
@@ -113,6 +117,7 @@ public class ClustersResourceTest {
     GetClusterResponse expected =
         new GetClusterResponse(
             new ClusterData(
+                "crn://kafka=cluster-1",
                 new ResourceLink("/v3/clusters/cluster-1"),
                 "cluster-1",
                 new Relationship("/v3/clusters/cluster-1/brokers/1"),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -84,7 +84,7 @@ public class ClustersResourceTest {
             new CollectionLink("/v3/clusters", /* next= */ null),
             singletonList(
                 new ClusterData(
-                    "crn://kafka=cluster-1",
+                    "crn:///kafka=cluster-1",
                     new ResourceLink("/v3/clusters/cluster-1"),
                     "cluster-1",
                     new Relationship("/v3/clusters/cluster-1/brokers/1"),
@@ -117,7 +117,7 @@ public class ClustersResourceTest {
     GetClusterResponse expected =
         new GetClusterResponse(
             new ClusterData(
-                "crn://kafka=cluster-1",
+                "crn:///kafka=cluster-1",
                 new ResourceLink("/v3/clusters/cluster-1"),
                 "cluster-1",
                 new Relationship("/v3/clusters/cluster-1/brokers/1"),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
@@ -165,7 +165,7 @@ public class PartitionsResourceTest {
             new CollectionLink("/v3/clusters/cluster-1/topics/topic-1/partitions", /* next= */ null),
             Arrays.asList(
                 new PartitionData(
-                    "crn://kafka=cluster-1/topic=topic-1/partition=0",
+                    "crn:///kafka=cluster-1/topic=topic-1/partition=0",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0"),
                     CLUSTER_ID,
                     TOPIC_NAME,
@@ -175,7 +175,7 @@ public class PartitionsResourceTest {
                     new Relationship(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas")),
                 new PartitionData(
-                    "crn://kafka=cluster-1/topic=topic-1/partition=1",
+                    "crn:///kafka=cluster-1/topic=topic-1/partition=1",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/1"),
                     CLUSTER_ID,
                     TOPIC_NAME,
@@ -185,7 +185,7 @@ public class PartitionsResourceTest {
                     new Relationship(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas")),
                 new PartitionData(
-                    "crn://kafka=cluster-1/topic=topic-1/partition=2",
+                    "crn:///kafka=cluster-1/topic=topic-1/partition=2",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/2"),
                     CLUSTER_ID,
                     TOPIC_NAME,
@@ -222,7 +222,7 @@ public class PartitionsResourceTest {
     GetPartitionResponse expected =
         new GetPartitionResponse(
             new PartitionData(
-                "crn://kafka=cluster-1/topic=topic-1/partition=0",
+                "crn:///kafka=cluster-1/topic=topic-1/partition=0",
                 new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0"),
                 CLUSTER_ID,
                 TOPIC_NAME,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.entities.v3.ListPartitionsResponse;
 import io.confluent.kafkarest.entities.v3.PartitionData;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
@@ -141,7 +142,11 @@ public class PartitionsResourceTest {
 
   @Before
   public void setUp() {
-    partitionsResource = new PartitionsResource(partitionManager, new FakeUrlFactory());
+    partitionsResource =
+        new PartitionsResource(
+            partitionManager,
+            new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
+            new FakeUrlFactory());
   }
 
   @Test
@@ -160,6 +165,7 @@ public class PartitionsResourceTest {
             new CollectionLink("/v3/clusters/cluster-1/topics/topic-1/partitions", /* next= */ null),
             Arrays.asList(
                 new PartitionData(
+                    "crn://kafka=cluster-1/topic=topic-1/partition=0",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0"),
                     CLUSTER_ID,
                     TOPIC_NAME,
@@ -169,6 +175,7 @@ public class PartitionsResourceTest {
                     new Relationship(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas")),
                 new PartitionData(
+                    "crn://kafka=cluster-1/topic=topic-1/partition=1",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/1"),
                     CLUSTER_ID,
                     TOPIC_NAME,
@@ -178,6 +185,7 @@ public class PartitionsResourceTest {
                     new Relationship(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas")),
                 new PartitionData(
+                    "crn://kafka=cluster-1/topic=topic-1/partition=2",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/2"),
                     CLUSTER_ID,
                     TOPIC_NAME,
@@ -214,6 +222,7 @@ public class PartitionsResourceTest {
     GetPartitionResponse expected =
         new GetPartitionResponse(
             new PartitionData(
+                "crn://kafka=cluster-1/topic=topic-1/partition=0",
                 new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0"),
                 CLUSTER_ID,
                 TOPIC_NAME,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
@@ -105,7 +105,7 @@ public class ReplicasResourceTest {
                 "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas", /* next= */ null),
             Arrays.asList(
                 new ReplicaData(
-                    "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=1",
+                    "crn:///kafka=cluster-1/topic=topic-1/partition=0/replica=1",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/1"),
                     CLUSTER_ID,
@@ -116,7 +116,7 @@ public class ReplicasResourceTest {
                     /* isInSync= */ true,
                     new Relationship("/v3/clusters/cluster-1/brokers/1")),
                 new ReplicaData(
-                    "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=2",
+                    "crn:///kafka=cluster-1/topic=topic-1/partition=0/replica=2",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/2"),
                     CLUSTER_ID,
@@ -127,7 +127,7 @@ public class ReplicasResourceTest {
                     /* isInSync= */ true,
                     new Relationship("/v3/clusters/cluster-1/brokers/2")),
                 new ReplicaData(
-                    "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=3",
+                    "crn:///kafka=cluster-1/topic=topic-1/partition=0/replica=3",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/3"),
                     CLUSTER_ID,
@@ -166,7 +166,7 @@ public class ReplicasResourceTest {
     GetReplicaResponse expected =
         new GetReplicaResponse(
             new ReplicaData(
-                "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=1",
+                "crn:///kafka=cluster-1/topic=topic-1/partition=0/replica=1",
                 new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/1"),
                 CLUSTER_ID,
                 TOPIC_NAME,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.entities.v3.ListReplicasResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ReplicaData;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
@@ -84,7 +85,9 @@ public class ReplicasResourceTest {
 
   @Before
   public void setUp() {
-    replicasResource = new ReplicasResource(replicaManager, new FakeUrlFactory());
+    replicasResource =
+        new ReplicasResource(
+            replicaManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
   }
 
   @Test
@@ -102,6 +105,7 @@ public class ReplicasResourceTest {
                 "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas", /* next= */ null),
             Arrays.asList(
                 new ReplicaData(
+                    "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=1",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/1"),
                     CLUSTER_ID,
@@ -112,6 +116,7 @@ public class ReplicasResourceTest {
                     /* isInSync= */ true,
                     new Relationship("/v3/clusters/cluster-1/brokers/1")),
                 new ReplicaData(
+                    "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=2",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/2"),
                     CLUSTER_ID,
@@ -122,6 +127,7 @@ public class ReplicasResourceTest {
                     /* isInSync= */ true,
                     new Relationship("/v3/clusters/cluster-1/brokers/2")),
                 new ReplicaData(
+                    "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=3",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/3"),
                     CLUSTER_ID,
@@ -160,6 +166,7 @@ public class ReplicasResourceTest {
     GetReplicaResponse expected =
         new GetReplicaResponse(
             new ReplicaData(
+                "crn://kafka=cluster-1/topic=topic-1/partition=0/replica=1",
                 new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas/1"),
                 CLUSTER_ID,
                 TOPIC_NAME,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResourceTest.java
@@ -31,6 +31,7 @@ import io.confluent.kafkarest.entities.v3.ListTopicConfigurationsResponse;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
 import io.confluent.kafkarest.entities.v3.TopicConfigurationData;
 import io.confluent.kafkarest.entities.v3.UpdateTopicConfigurationRequest;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
@@ -89,7 +90,10 @@ public class TopicConfigurationsResourceTest {
   @Before
   public void setUp() {
     topicConfigurationsResource =
-        new TopicConfigurationsResource(topicConfigurationManager, new FakeUrlFactory());
+        new TopicConfigurationsResource(
+            topicConfigurationManager,
+            new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
+            new FakeUrlFactory());
   }
 
   @Test
@@ -108,6 +112,7 @@ public class TopicConfigurationsResourceTest {
                 "/v3/clusters/cluster-1/topics/topic-1/configurations", /* next= */ null),
             Arrays.asList(
                 new TopicConfigurationData(
+                    "crn://kafka=cluster-1/topic=topic-1/configuration=config-1",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/configurations/config-1"),
                     CLUSTER_ID,
@@ -118,6 +123,7 @@ public class TopicConfigurationsResourceTest {
                     CONFIGURATION_1.isReadOnly(),
                     CONFIGURATION_1.isSensitive()),
                 new TopicConfigurationData(
+                    "crn://kafka=cluster-1/topic=topic-1/configuration=config-2",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/configurations/config-2"),
                     CLUSTER_ID,
@@ -128,6 +134,7 @@ public class TopicConfigurationsResourceTest {
                     CONFIGURATION_2.isReadOnly(),
                     CONFIGURATION_2.isSensitive()),
                 new TopicConfigurationData(
+                    "crn://kafka=cluster-1/topic=topic-1/configuration=config-3",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/configurations/config-3"),
                     CLUSTER_ID,
@@ -168,6 +175,7 @@ public class TopicConfigurationsResourceTest {
     GetTopicConfigurationResponse expected =
         new GetTopicConfigurationResponse(
             new TopicConfigurationData(
+                "crn://kafka=cluster-1/topic=topic-1/configuration=config-1",
                 new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/configurations/config-1"),
                 CLUSTER_ID,
                 TOPIC_NAME,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResourceTest.java
@@ -112,7 +112,7 @@ public class TopicConfigurationsResourceTest {
                 "/v3/clusters/cluster-1/topics/topic-1/configurations", /* next= */ null),
             Arrays.asList(
                 new TopicConfigurationData(
-                    "crn://kafka=cluster-1/topic=topic-1/configuration=config-1",
+                    "crn:///kafka=cluster-1/topic=topic-1/configuration=config-1",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/configurations/config-1"),
                     CLUSTER_ID,
@@ -123,7 +123,7 @@ public class TopicConfigurationsResourceTest {
                     CONFIGURATION_1.isReadOnly(),
                     CONFIGURATION_1.isSensitive()),
                 new TopicConfigurationData(
-                    "crn://kafka=cluster-1/topic=topic-1/configuration=config-2",
+                    "crn:///kafka=cluster-1/topic=topic-1/configuration=config-2",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/configurations/config-2"),
                     CLUSTER_ID,
@@ -134,7 +134,7 @@ public class TopicConfigurationsResourceTest {
                     CONFIGURATION_2.isReadOnly(),
                     CONFIGURATION_2.isSensitive()),
                 new TopicConfigurationData(
-                    "crn://kafka=cluster-1/topic=topic-1/configuration=config-3",
+                    "crn:///kafka=cluster-1/topic=topic-1/configuration=config-3",
                     new ResourceLink(
                         "/v3/clusters/cluster-1/topics/topic-1/configurations/config-3"),
                     CLUSTER_ID,
@@ -175,7 +175,7 @@ public class TopicConfigurationsResourceTest {
     GetTopicConfigurationResponse expected =
         new GetTopicConfigurationResponse(
             new TopicConfigurationData(
-                "crn://kafka=cluster-1/topic=topic-1/configuration=config-1",
+                "crn:///kafka=cluster-1/topic=topic-1/configuration=config-1",
                 new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/configurations/config-1"),
                 CLUSTER_ID,
                 TOPIC_NAME,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -346,7 +346,7 @@ public class TopicsResourceTest {
             new CollectionLink("/v3/clusters/cluster-1/topics", null),
             Arrays.asList(
                 new TopicData(
-                    "crn://kafka=cluster-1/topic=topic-1",
+                    "crn:///kafka=cluster-1/topic=topic-1",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1"),
                     "cluster-1",
                     "topic-1",
@@ -355,7 +355,7 @@ public class TopicsResourceTest {
                     new Relationship("/v3/clusters/cluster-1/topics/topic-1/configurations"),
                     new Relationship("/v3/clusters/cluster-1/topics/topic-1/partitions")),
                 new TopicData(
-                    "crn://kafka=cluster-1/topic=topic-2",
+                    "crn:///kafka=cluster-1/topic=topic-2",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-2"),
                     "cluster-1",
                     "topic-2",
@@ -364,7 +364,7 @@ public class TopicsResourceTest {
                     new Relationship("/v3/clusters/cluster-1/topics/topic-2/configurations"),
                     new Relationship("/v3/clusters/cluster-1/topics/topic-2/partitions")),
                 new TopicData(
-                    "crn://kafka=cluster-1/topic=topic-3",
+                    "crn:///kafka=cluster-1/topic=topic-3",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-3"),
                     "cluster-1",
                     "topic-3",
@@ -411,7 +411,7 @@ public class TopicsResourceTest {
 
     GetTopicResponse expected = new GetTopicResponse(
         new TopicData(
-            "crn://kafka=cluster-1/topic=topic-1",
+            "crn:///kafka=cluster-1/topic=topic-1",
             new ResourceLink("/v3/clusters/cluster-1/topics/topic-1"),
             "cluster-1",
             "topic-1",
@@ -475,7 +475,7 @@ public class TopicsResourceTest {
 
     CreateTopicResponse expected = new CreateTopicResponse(
         new TopicData(
-            "crn://kafka=cluster-1/topic=topic-1",
+            "crn:///kafka=cluster-1/topic=topic-1",
             new ResourceLink("/v3/clusters/cluster-1/topics/topic-1"),
             "cluster-1",
             "topic-1",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -37,6 +37,7 @@ import io.confluent.kafkarest.entities.v3.ListTopicsResponse;
 import io.confluent.kafkarest.entities.v3.Relationship;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
 import io.confluent.kafkarest.entities.v3.TopicData;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
@@ -326,7 +327,9 @@ public class TopicsResourceTest {
 
   @Before
   public void setUp() {
-    topicsResource = new TopicsResource(topicManager, new FakeUrlFactory());
+    topicsResource =
+        new TopicsResource(
+            topicManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
   }
 
   @Test
@@ -343,6 +346,7 @@ public class TopicsResourceTest {
             new CollectionLink("/v3/clusters/cluster-1/topics", null),
             Arrays.asList(
                 new TopicData(
+                    "crn://kafka=cluster-1/topic=topic-1",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1"),
                     "cluster-1",
                     "topic-1",
@@ -351,6 +355,7 @@ public class TopicsResourceTest {
                     new Relationship("/v3/clusters/cluster-1/topics/topic-1/configurations"),
                     new Relationship("/v3/clusters/cluster-1/topics/topic-1/partitions")),
                 new TopicData(
+                    "crn://kafka=cluster-1/topic=topic-2",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-2"),
                     "cluster-1",
                     "topic-2",
@@ -359,6 +364,7 @@ public class TopicsResourceTest {
                     new Relationship("/v3/clusters/cluster-1/topics/topic-2/configurations"),
                     new Relationship("/v3/clusters/cluster-1/topics/topic-2/partitions")),
                 new TopicData(
+                    "crn://kafka=cluster-1/topic=topic-3",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-3"),
                     "cluster-1",
                     "topic-3",
@@ -405,6 +411,7 @@ public class TopicsResourceTest {
 
     GetTopicResponse expected = new GetTopicResponse(
         new TopicData(
+            "crn://kafka=cluster-1/topic=topic-1",
             new ResourceLink("/v3/clusters/cluster-1/topics/topic-1"),
             "cluster-1",
             "topic-1",
@@ -468,6 +475,7 @@ public class TopicsResourceTest {
 
     CreateTopicResponse expected = new CreateTopicResponse(
         new TopicData(
+            "crn://kafka=cluster-1/topic=topic-1",
             new ResourceLink("/v3/clusters/cluster-1/topics/topic-1"),
             "cluster-1",
             "topic-1",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/CrnFactoryImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/CrnFactoryImplTest.java
@@ -13,7 +13,7 @@ public class CrnFactoryImplTest {
   @Test
   public void create_noAuthority_returnsCrnWithNoAuthority() {
     CrnFactoryImpl crnFactory = new CrnFactoryImpl(/* crnAuthorityConfig= */ "");
-    assertEquals("crn://foo=xxx/bar=yyy", crnFactory.create("foo", "xxx", "bar", "yyy"));
+    assertEquals("crn:///foo=xxx/bar=yyy", crnFactory.create("foo", "xxx", "bar", "yyy"));
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/CrnFactoryImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/CrnFactoryImplTest.java
@@ -1,0 +1,36 @@
+package io.confluent.kafkarest.response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CrnFactoryImplTest {
+
+  @Test
+  public void create_noAuthority_returnsCrnWithNoAuthority() {
+    CrnFactoryImpl crnFactory = new CrnFactoryImpl(/* crnAuthorityConfig= */ "");
+    assertEquals("crn://foo=xxx/bar=yyy", crnFactory.create("foo", "xxx", "bar", "yyy"));
+  }
+
+  @Test
+  public void create_withAuthority_returnsCrnWithAuthority() {
+    CrnFactoryImpl crnFactory = new CrnFactoryImpl(/* crnAuthorityConfig= */ "example.com");
+    assertEquals(
+        "crn://example.com/foo=xxx/bar=yyy", crnFactory.create("foo", "xxx", "bar", "yyy"));
+  }
+
+  @Test
+  public void create_oddComponents_throwsIllegalArgument() {
+    CrnFactoryImpl crnFactory = new CrnFactoryImpl(/* crnAuthorityConfig= */ "");
+    try {
+      crnFactory.create("foo", "xxx", "bar");
+      fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+}

--- a/testing/environments/minimal/run.sh
+++ b/testing/environments/minimal/run.sh
@@ -33,7 +33,9 @@ env_dir=$(dirname "$0")
 base_dir=$env_dir/../../..
 
 # Make sure kafka-rest is packaged.
-mvn -f "$base_dir"/kafka-rest/pom.xml -Dmaven.test.skip=true package
+mvn -f "$base_dir"/kafka-rest-common/pom.xml          -Dmaven.test.skip=true install
+mvn -f "$base_dir"/kafka-rest-scala-consumer/pom.xml -Dmaven.test.skip=true install
+mvn -f "$base_dir"/kafka-rest/pom.xml                 -Dmaven.test.skip=true package
 
 # For some reason `up --build --force-recreate` is not enough. Make sure everything is clean.
 docker-compose -f "$env_dir"/docker-compose.yml rm -fsv


### PR DESCRIPTION
This change switches all Type and IDs of resources to be Confluent Resource Names.

The types/CRNs are:

| Resource | Type | Element Type | Scope | Example |
| --- | --- | --- | --- | --- |
| Cluster | KafkaCluster | kafka | | crn:///kafka=vRv7HRngS_C-VAni-qCo_g |
| Broker | KafkaBroker | broker | KafkaCluster | crn:///kafka=vRv7HRngS_C-VAni-qCo_g/broker=1 |
| Topic | KafkaTopic | topic | KafkaCluster | crn:///kafka=vRv7HRngS_C-VAni-qCo_g/topic=_confluent-license |
| Partition | KafkaPartition | partition | KafkaTopic | crn:///kafka=vRv7HRngS_C-VAni-qCo_g/topic=_confluent-license/partition=0 |
| Replica | KafkaReplica | replica | KafkaPartition | crn:///kafka=vRv7HRngS_C-VAni-qCo_g/topic=_confluent-license/partition=0/replica=3 |
| Topic Configuration | KafkaTopicConfiguration | configuration | KafkaTopic | crn:///kafka=vRv7HRngS_C-VAni-qCo_g/topic=_confluent-license/configuration=cleanup.policy |

For example, the request below for a Replica resource:

```
$ curl http://localhost:9391/v3/clusters/vRv7HRngS_C-VAni-qCo_g/topics/_confluent-license/partitions/0/replicas/3 | jq
```

Would return the following result:

```
{
  "data": {
    "id": "crn:///kafka=vRv7HRngS_C-VAni-qCo_g/topic=_confluent-license/partition=0/replica=3",
    "links": {
      "self": "http://localhost:9391/v3/clusters/vRv7HRngS_C-VAni-qCo_g/topics/_confluent-license/partitions/0/replicas/3"
    },
    "attributes": {
      "cluster_id": "vRv7HRngS_C-VAni-qCo_g",
      "topic_name": "_confluent-license",
      "partition_id": 0,
      "broker_id": 3,
      "is_in_sync": true,
      "is_leader": true
    },
    "relationships": {
      "broker": {
        "links": {
          "related": "http://localhost:9391/v3/clusters/vRv7HRngS_C-VAni-qCo_g/brokers/3"
        }
      }
    },
    "type": "KafkaReplica"
  }
}
```

A new configuration is also added, `confluent.resource.name.authority`, that allows specifying what to use for the `authority` part of the CRNs. This configurations defaults to empty string, which is the value used in the examples above. Setting it to `example.com` for example, would result in CRN `crn://example.com/kafka=vRv7HRngS_C-VAni-qCo_g` for a Cluster with cluster_id = vRv7HRngS_C-VAni-qCo_g.