### PR TITLE
CLIENTS-1514: Defaults to JSON:API Content-Type when no Accept header in request.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigurationsResource.java
@@ -108,6 +108,7 @@ public final class TopicConfigurationsResource {
   @PUT
   @Path("/{name}")
   @Consumes(Versions.JSON_API)
+  @Produces(Versions.JSON_API)
   public void updateTopicConfiguration(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -127,6 +128,7 @@ public final class TopicConfigurationsResource {
 
   @DELETE
   @Path("/{name}")
+  @Produces(Versions.JSON_API)
   public void resetTopicConfiguration(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -138,6 +138,7 @@ public final class TopicsResource {
 
   @DELETE
   @Path("/{topicName}")
+  @Produces(Versions.JSON_API)
   public void deleteTopic(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigurationsResourceIntegrationTest.java
@@ -374,6 +374,16 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
   }
 
   @Test
+  public void updateTopicConfiguration_nonExistingCluster_noContentType_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"compact\"}}}", Versions.JSON_API));
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
   public void resetTopicConfiguration_nonExistingConfiguration_throwsNotFound() {
     String clusterId = getClusterId();
 
@@ -400,6 +410,14 @@ public class TopicConfigurationsResourceIntegrationTest extends ClusterTestHarne
     Response response =
         request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
             .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void resetTopicConfiguration_nonExistingCluster_noContentType_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/topics/" + TOPIC_1 + "/configurations/cleanup.policy")
             .delete();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -305,6 +305,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
+  public void deleteTopic_nonExistingCluster_noContentType_returnsNotFound() {
+    Response response = request("/v3/clusters/foobar/topics/" + TOPIC_1).delete();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
   public void
   getTopic_nonExistingTopic_returnsEmpty_thenCreateTopicAndGetTopic_returnsCreatedTopic_thenDeleteTopicAndGetTopic_returnsEmpty
       () throws Exception {


### PR DESCRIPTION
Right now, for requests that return 204 No Content on successful completion, if you don't specify a Accept header, and and error happens, 500 is returned, instead of the code mapped to the error. That is because the server is defaulting to `text/html` Content-Type, and Jackson does not know how to serialize the JSON error response body to `text/html`. This PR makes sure the Content-Type of responses is `application/vnd.api+json` by default.