### PR TITLE
Fix test due to changes in MockAdminClient.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AdminClientWrapperTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AdminClientWrapperTest.java
@@ -1,34 +1,92 @@
 package io.confluent.kafkarest.unit;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
 import io.confluent.kafkarest.AdminClientWrapper;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.entities.Topic;
-import org.apache.kafka.clients.admin.MockAdminClient;
+import java.util.HashSet;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.config.ConfigResource;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
-
+@RunWith(JUnit4.class)
 public class AdminClientWrapperTest {
+
+  private static final String TOPIC_NAME = "topic";
+
+  private static final Node NODE = new Node(1, "broker-1", 9091);
+
+  private static final TopicDescription TOPIC_WITH_NULL_LEADER =
+      new TopicDescription(
+          TOPIC_NAME,
+          /* internal= */ true,
+          singletonList(
+              new TopicPartitionInfo(
+                  /* partition= */ 0,
+                  /* leader= */ null,
+                  /* replicas= */ singletonList(NODE),
+                  /* isr= */ singletonList(NODE))),
+          /* authorizedOperations= */ new HashSet<>());
+
+  private static final ConfigResource CONFIG_RESOURCE =
+      new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME);
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private AdminClient adminClient;
+
+  @Mock
+  private ListTopicsResult listTopicsResult;
+
+  @Mock
+  private DescribeTopicsResult describeTopicResult;
+
+  @Mock
+  private DescribeConfigsResult describeConfigsResult;
+
   @Test
   public void testGetTopicOnNullLeaderDoesntThrowNPE() throws Exception {
+    expect(adminClient.listTopics()).andReturn(listTopicsResult);
+    expect(listTopicsResult.names()).andReturn(KafkaFuture.completedFuture(singleton(TOPIC_NAME)));
+    expect(adminClient.describeTopics(singletonList(TOPIC_NAME))).andReturn(describeTopicResult);
+    expect(describeTopicResult.values())
+        .andReturn(singletonMap(TOPIC_NAME, KafkaFuture.completedFuture(TOPIC_WITH_NULL_LEADER)));
+    expect(adminClient.describeConfigs(singletonList(CONFIG_RESOURCE)))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(CONFIG_RESOURCE, KafkaFuture.completedFuture(new Config(emptyList()))));
+    replay(adminClient, listTopicsResult, describeTopicResult, describeConfigsResult);
+
     Properties props = new Properties();
     props.put(KafkaRestConfig.KAFKACLIENT_INIT_TIMEOUT_CONFIG, "100");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    Node controller = new Node(1, "a", 1);
 
-    MockAdminClient adminClient = new MockAdminClient(Arrays.asList(controller, null), controller);
-    TopicPartitionInfo partition = new TopicPartitionInfo(1, null, Collections.singletonList(controller), Collections.singletonList(controller));
-    adminClient.addTopic(false, "topic", Collections.singletonList(partition), new HashMap<String, String>());
+    Topic topic = new AdminClientWrapper(config, adminClient).getTopic(TOPIC_NAME);
 
-    Topic topic = new AdminClientWrapper(config, adminClient).getTopic("topic");
-    assertEquals(topic.getName(), "topic");
+    assertEquals(topic.getName(), TOPIC_NAME);
   }
 }


### PR DESCRIPTION
`MockAdminClient` changed behaviour in https://github.com/apache/kafka/commit/56051e763965d439f11f20f876475732eed7b307 to not allow partitions with `null` leader. That breaks a test in kafka-rest that test specifically the behaviour of the server when Kafka returns a topic with a partition with null leader.

This commit changes the test to use a `@Mock AdminClient` instead of `MockAdminClient`, so that we can keep testing defensive behaviour against this corner case.