### PR TITLE
SEC-929--Added one testing for verifying a feature addd to rest-utils repo.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestStartUpIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestStartUpIntegrationTest.java
@@ -18,6 +18,7 @@ public class KafkaRestStartUpIntegrationTest extends ClusterTestHarness {
     restProperties.put("client.security.protocol", "SASL_PLAINTEXT");
     restProperties.put("client.sasl.mechanism", "OAUTHBEARER");
     restProperties.put("client.sasl.kerberos.service.name", "kafka");
+    restProperties.put("response.http.headers.config", "add X-XSS-Protection: 1; mode=block");
   }
 
   @Test
@@ -29,5 +30,11 @@ public class KafkaRestStartUpIntegrationTest extends ClusterTestHarness {
     // The server started up successfully. Now make sure doing a request that require Admin fails.
     Response response = request("/v3/clusters").accept("application/vnd.api+json").get();
     assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testHttpResponseHeader() {
+    Response response = request("/v3/clusters").accept("application/vnd.api+json").get();
+    assertEquals(response.getHeaderString("X-XSS-Protection"), "1; mode=block");
   }
 }


### PR DESCRIPTION
This PR is an extra verification testing after a new feature, which customizes HTTP response headers, added to rest-utils due to Kafka REST application based on rest-utils.
confluentinc/rest-utils#177
https://confluentinc.atlassian.net/wiki/spaces/CONNECT/pages/1047197302/One+Pager+-+Customize+HTTP+Response+Headers+on+Kafka+Connect+REST+and+CP+REST+Applications