### PR TITLE
Migrate to use AK library instead of common-metrics

### DIFF
--- a/kafka-rest-common/src/main/java/io/confluent/kafkarest/SystemTime.java
+++ b/kafka-rest-common/src/main/java/io/confluent/kafkarest/SystemTime.java
@@ -18,7 +18,7 @@ package io.confluent.kafkarest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
-public class SystemTime extends io.confluent.common.utils.SystemTime implements Time {
+public class SystemTime extends org.apache.kafka.common.utils.SystemTime implements Time {
 
   @Override
   public void waitOn(Object on, long ms) throws InterruptedException {

--- a/kafka-rest-common/src/main/java/io/confluent/kafkarest/Time.java
+++ b/kafka-rest-common/src/main/java/io/confluent/kafkarest/Time.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafkarest;
 
-public interface Time extends io.confluent.common.utils.Time {
+public interface Time extends org.apache.kafka.common.utils.Time {
 
   public long milliseconds();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/mock/MockTime.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/mock/MockTime.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.mock;
 import java.util.concurrent.TimeUnit;
 
 import io.confluent.kafkarest.Time;
+import java.util.function.Supplier;
 
 public class MockTime implements Time {
 
@@ -35,6 +36,11 @@ public class MockTime implements Time {
   @Override
   public void sleep(long ms) {
     currentMs += ms;
+  }
+
+  @Override
+  public void waitObject(Object o, Supplier<Boolean> supplier, long l) throws InterruptedException {
+
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
@@ -19,11 +19,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import io.confluent.common.utils.Time;
 import io.confluent.kafkarest.ConsumerReadCallback;
 import io.confluent.kafkarest.KafkaRestConfig;
-import io.confluent.kafkarest.SystemTime;
+import io.confluent.kafkarest.Time;
 import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
+import io.confluent.kafkarest.SystemTime;
 import io.confluent.kafkarest.entities.ConsumerRecord;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.v2.ConsumerSubscriptionRecord;


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/MMA-7237

**Why**
As part of the efforts to converge on a single telemetry pipelines for Cloud, Hosted Monitoring, and Proactive Support, we want to standardize on one metrics library and associated metrics collection framework.

NOTE: The change here is necessary once https://github.com/confluentinc/rest-utils/pull/178 is merged. 
