### PR TITLE
Remove spurious topic/partitions existence test when producing.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
@@ -194,14 +194,7 @@ public final class PartitionsResource {
       final int partition,
       final EmbeddedFormat format,
       final ProduceRequest<K, V> request
-  ) throws Exception {
-    // If the topic already exists, we can proactively check for the partition
-    if (topicExists(topic)) {
-      if (!ctx.getAdminClientWrapper().partitionExists(topic, partition)) {
-        throw Errors.partitionNotFoundException();
-      }
-    }
-
+  ) {
     log.trace(
         "Executing topic produce request id={} topic={} partition={} format={} request={}",
         asyncResponse, topic, partition, format, request


### PR DESCRIPTION
The Producer will throw an exception if the topic/partition does not exist, and the exception is mapped.

Having the produce-to-topic use the AdminClient actually breaks confluent-security-plugins. This is a short-term solution.