### PR TITLE
Fix default Content-Type, when none or any (*/*) is provided.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
@@ -183,7 +183,7 @@ public final class ConsumersResource {
   @GET
   @Path("/{group}/instances/{instance}/records")
   @PerformanceMetric("consumer.records.read-json+v2")
-  @Produces({Versions.KAFKA_V2_JSON_JSON_WEIGHTED})
+  @Produces({Versions.KAFKA_V2_JSON_JSON_WEIGHTED_LOW})
   // Using low weight ensures binary is default
   public void readRecordJson(
       final @Suspended AsyncResponse asyncResponse,
@@ -205,7 +205,7 @@ public final class ConsumersResource {
   @GET
   @Path("/{group}/instances/{instance}/records")
   @PerformanceMetric("consumer.records.read-avro+v2")
-  @Produces({Versions.KAFKA_V2_JSON_AVRO_WEIGHTED})
+  @Produces({Versions.KAFKA_V2_JSON_AVRO_WEIGHTED_LOW})
   // Using low weight ensures binary is default
   public void readRecordAvro(
       final @Suspended AsyncResponse asyncResponse,
@@ -227,7 +227,7 @@ public final class ConsumersResource {
   @GET
   @Path("/{group}/instances/{instance}/records")
   @PerformanceMetric("consumer.records.read-jsonschema+v2")
-  @Produces({Versions.KAFKA_V2_JSON_JSON_SCHEMA_WEIGHTED})
+  @Produces({Versions.KAFKA_V2_JSON_JSON_SCHEMA_WEIGHTED_LOW})
   // Using low weight ensures binary is default
   public void readRecordJsonSchema(
       final @Suspended AsyncResponse asyncResponse,
@@ -249,7 +249,7 @@ public final class ConsumersResource {
   @GET
   @Path("/{group}/instances/{instance}/records")
   @PerformanceMetric("consumer.records.read-protobuf+v2")
-  @Produces({Versions.KAFKA_V2_JSON_PROTOBUF_WEIGHTED})
+  @Produces({Versions.KAFKA_V2_JSON_PROTOBUF_WEIGHTED_LOW})
   // Using low weight ensures binary is default
   public void readRecordProtobuf(
       final @Suspended AsyncResponse asyncResponse,


### PR DESCRIPTION
The V1, and intended V2, behaviour was to default to BINARY. Unfortunately V2 uses the same weight for all types, which makes the server choose any of them. Sometimes it chooses the wrong one (thus the flakiness in the build).