### PR TITLE
CLIENTS-1505: Add broker config delete endpoint

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManager.java
@@ -40,4 +40,9 @@ public interface BrokerConfigManager {
    */
   CompletableFuture<Void> updateBrokerConfig(
       String clusterId, int brokerId, String name, String newValue);
+
+  /**
+   * Resets the Kafka {@link BrokerConfig} with the given {@code name} to its default value.
+   */
+  CompletableFuture<Void> resetBrokerConfig(String clusterId, int brokerId, String name);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PUT;
@@ -121,6 +122,23 @@ public final class BrokerConfigsResource {
 
     CompletableFuture<Void> response =
         brokerConfigManager.updateBrokerConfig(clusterId, brokerId, name, newValue);
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+
+  @DELETE
+  @Path("/{name}")
+  @Produces(Versions.JSON_API)
+  public void resetBrokerConfig(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("brokerId") int brokerId,
+      @PathParam("name") String name
+  ) {
+    CompletableFuture<Void> response =
+        brokerConfigManager.resetBrokerConfig(clusterId, brokerId, name);
 
     AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
         .entity(response)

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImplTest.java
@@ -37,14 +37,12 @@ import java.util.concurrent.ExecutionException;
 import javax.ws.rs.NotFoundException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.config.ConfigResource.Type;
 import org.easymock.EasyMockRule;
 import org.easymock.Mock;
 import org.junit.Before;
@@ -139,12 +137,13 @@ public class BrokerConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 KafkaFuture.completedFuture(CONFIG)));
     replay(adminClient, clusterManager, describeConfigsResult);
 
@@ -159,12 +158,13 @@ public class BrokerConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 TestUtils.failedFuture(new NotFoundException("Broker not found."))));
     replay(clusterManager, adminClient, describeConfigsResult);
 
@@ -193,12 +193,12 @@ public class BrokerConfigManagerImplTest {
   public void getBrokerConfig_existingConfig_returnsConfig() throws Exception {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(adminClient.describeConfigs(
-        singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+        singletonList(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 KafkaFuture.completedFuture(CONFIG)));
     replay(adminClient, clusterManager, describeConfigsResult);
 
@@ -216,12 +216,13 @@ public class BrokerConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 KafkaFuture.completedFuture(CONFIG)));
     replay(adminClient, clusterManager, describeConfigsResult);
 
@@ -236,12 +237,13 @@ public class BrokerConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 TestUtils.failedFuture(new NotFoundException("Broker not found."))));
     replay(clusterManager, adminClient, describeConfigsResult);
 
@@ -272,7 +274,8 @@ public class BrokerConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -282,16 +285,16 @@ public class BrokerConfigManagerImplTest {
     expect(
         adminClient.incrementalAlterConfigs(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 singletonList(
                     new AlterConfigOp(
                         new ConfigEntry(CONFIG_1.getName(), "new-value"),
-                        OpType.SET)))))
+                        AlterConfigOp.OpType.SET)))))
         .andReturn(alterConfigsResult);
     expect(alterConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 KafkaFuture.completedFuture(null)));
     replay(clusterManager, adminClient, describeConfigsResult, alterConfigsResult);
 
@@ -306,7 +309,8 @@ public class BrokerConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -327,16 +331,17 @@ public class BrokerConfigManagerImplTest {
   }
 
   @Test
-  public void updateTopicConfig_nonExistingBroker_throwsNotFound() throws Exception {
+  public void updateBrokerConfig_nonExistingBroker_throwsNotFound() throws Exception {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)))))
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
             singletonMap(
-                new ConfigResource(Type.BROKER, String.valueOf(BROKER_ID)),
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
                 TestUtils.failedFuture(new NotFoundException())));
     replay(clusterManager, adminClient, describeConfigsResult);
 
@@ -359,6 +364,105 @@ public class BrokerConfigManagerImplTest {
     try {
       brokerConfigManager.updateBrokerConfig(
           CLUSTER_ID, BROKER_ID, CONFIG_1.getName(), "new-value").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetBrokerConfig_existingConfig_resetsConfig() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
+                KafkaFuture.completedFuture(CONFIG)));
+    expect(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
+                singletonList(
+                    new AlterConfigOp(
+                        new ConfigEntry(CONFIG_1.getName(), /* value= */ null),
+                        AlterConfigOp.OpType.DELETE)))))
+        .andReturn(alterConfigsResult);
+    expect(alterConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
+                KafkaFuture.completedFuture(null)));
+    replay(clusterManager, adminClient, describeConfigsResult, alterConfigsResult);
+
+    brokerConfigManager.resetBrokerConfig(
+        CLUSTER_ID, BROKER_ID, CONFIG_1.getName()).get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetBrokerConfig_nonExistingConfig_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(adminClient.describeConfigs(
+        singletonList(new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(clusterManager, adminClient, describeConfigsResult);
+
+    try {
+      brokerConfigManager.resetBrokerConfig(CLUSTER_ID, BROKER_ID, "foobar").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetBrokerConfig_nonExistingBroker_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.describeConfigs(
+            singletonList(new ConfigResource(ConfigResource.Type.BROKER,
+                String.valueOf(BROKER_ID)))))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(singletonMap(
+            new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(BROKER_ID)),
+            TestUtils.failedFuture(new NotFoundException())));
+    replay(clusterManager, adminClient, describeConfigsResult);
+
+    try {
+      brokerConfigManager.resetBrokerConfig(
+          CLUSTER_ID, BROKER_ID, CONFIG_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetBrokerConfig_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.empty()));
+    replay(clusterManager, adminClient);
+
+    try {
+      brokerConfigManager.resetBrokerConfig(
+          CLUSTER_ID, BROKER_ID, CONFIG_1.getName()).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
@@ -223,9 +223,7 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void
-  getThenUpdateThenGetThenResetThenGet_existingConfig_returnsDefaultThenUpdatesThenReturnsUpdatedThenResetsThenReturnsDefault
-      () throws Exception {
+  public void getUpdateReset_withExistingConfig() throws Exception {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokerConfigResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokerConfigResourceTest.java
@@ -243,4 +243,40 @@ public final class BrokerConfigResourceTest {
 
     assertEquals(NotFoundException.class, response.getException().getClass());
   }
+
+  @Test
+  public void resetBrokerConfig_existingConfig_resetsConfig() {
+    expect(
+        brokerConfigManager.resetBrokerConfig(
+            CLUSTER_ID,
+            BROKER_ID,
+            CONFIG_1.getName()))
+        .andReturn(completedFuture(null));
+    replay(brokerConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    brokerConfigsResource.resetBrokerConfig(
+        response, CLUSTER_ID, BROKER_ID, CONFIG_1.getName());
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void resetBrokerConfig_nonExistingConfigOrBrokerOrCluster_throwsNotFound() {
+    expect(
+        brokerConfigManager.resetBrokerConfig(
+            CLUSTER_ID,
+            BROKER_ID,
+            CONFIG_1.getName()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(brokerConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    brokerConfigsResource.resetBrokerConfig(
+        response, CLUSTER_ID, BROKER_ID, CONFIG_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
 }


### PR DESCRIPTION
### What
Add delete endpoint for broker configs.

### Testing

1. Added unit tests for manager and resource classes.
2. Added integration tests.

### References
Jira - https://confluentinc.atlassian.net/browse/CLIENTS-1505