### PR TITLE
Remove RestConfigException from constructor signatures

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -28,7 +28,6 @@ import io.confluent.kafkarest.resources.ResourcesFeature;
 import io.confluent.kafkarest.response.ResponseModule;
 import io.confluent.kafkarest.v2.KafkaConsumerManager;
 import io.confluent.rest.Application;
-import io.confluent.rest.RestConfigException;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
@@ -46,11 +45,11 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
 
   List<RestResourceExtension> restResourceExtensions;
 
-  public KafkaRestApplication() throws RestConfigException {
+  public KafkaRestApplication() {
     this(new Properties());
   }
 
-  public KafkaRestApplication(Properties props) throws RestConfigException {
+  public KafkaRestApplication(Properties props) {
     super(new KafkaRestConfig(props));
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -19,6 +19,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Range;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -646,7 +647,7 @@ public class KafkaRestConfig extends RestConfig {
   private Time time;
   private Properties originalProperties;
 
-  public KafkaRestConfig() throws RestConfigException {
+  public KafkaRestConfig() {
     this(new Properties());
   }
 
@@ -669,16 +670,15 @@ public class KafkaRestConfig extends RestConfig {
     this(getPropsFromFile(propsFile));
   }
 
-  public KafkaRestConfig(Properties props) throws RestConfigException {
+  public KafkaRestConfig(Properties props) {
     this(props, new SystemTime());
   }
 
-  public KafkaRestConfig(Properties props, Time time) throws RestConfigException {
+  public KafkaRestConfig(Properties props, Time time) {
     this(config, props, time);
   }
 
-  public KafkaRestConfig(ConfigDef configDef, Properties props, Time time)
-      throws RestConfigException {
+  public KafkaRestConfig(ConfigDef configDef, Properties props, Time time) {
     super(configDef, props);
     this.originalProperties = props;
     this.time = time;
@@ -777,7 +777,7 @@ public class KafkaRestConfig extends RestConfig {
 
     try {
       return new KafkaRestConfig(newProps, config.getTime());
-    } catch (io.confluent.rest.RestConfigException e) {
+    } catch (ConfigException e) {
       throw new RestServerErrorException(
               String.format("Invalid configuration for new consumer: %s", newProps),
               Response.Status.BAD_REQUEST.getStatusCode(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -9,8 +9,7 @@ import org.junit.Test;
 public class KafkaRestConfigTest {
 
   @Test
-  public void getProducerProperties_propagatesSchemaRegistryProperties()
-      throws RestConfigException {
+  public void getProducerProperties_propagatesSchemaRegistryProperties() {
     Properties properties = new Properties();
     properties.put("schema.registry.url", "https://schemaregistry:8085");
     KafkaRestConfig config = new KafkaRestConfig(properties);
@@ -20,8 +19,7 @@ public class KafkaRestConfigTest {
   }
 
   @Test
-  public void getConsumerProperties_propagatesSchemaRegistryProperties()
-      throws RestConfigException{
+  public void getConsumerProperties_propagatesSchemaRegistryProperties() {
     Properties properties = new Properties();
     properties.put("schema.registry.url", "https://schemaregistry:8085");
     KafkaRestConfig config = new KafkaRestConfig(properties);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
@@ -42,7 +42,7 @@ public class UriUtilsTest {
   }
 
   @Test
-  public void testAbsoluteURIBuilderDefaultHost() throws RestConfigException {
+  public void testAbsoluteURIBuilderDefaultHost()  {
     KafkaRestConfig config = new KafkaRestConfig();
     EasyMock.expect(uriInfo.getAbsolutePathBuilder())
         .andReturn(UriBuilder.fromUri("http://foo.com"));
@@ -52,7 +52,7 @@ public class UriUtilsTest {
   }
 
   @Test
-  public void testAbsoluteURIBuilderOverrideHost() throws RestConfigException {
+  public void testAbsoluteURIBuilderOverrideHost() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     KafkaRestConfig config = new KafkaRestConfig(props);
@@ -65,7 +65,7 @@ public class UriUtilsTest {
   }
 
   @Test
-  public void testAbsoluteURIBuilderWithPort() throws RestConfigException {
+  public void testAbsoluteURIBuilderWithPort() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.PORT_CONFIG, 5000);
@@ -80,7 +80,7 @@ public class UriUtilsTest {
   }
 
   @Test(expected=ConfigException.class)
-  public void testAbsoluteURIBuilderWithInvalidListener() throws RestConfigException {
+  public void testAbsoluteURIBuilderWithInvalidListener() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http:||0.0.0.0:9091");
@@ -94,7 +94,7 @@ public class UriUtilsTest {
   }
 
   @Test
-  public void testAbsoluteURIBuilderWithListenerForHttp() throws RestConfigException {
+  public void testAbsoluteURIBuilderWithListenerForHttp() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:9091,https://0.0.0.0:9092");
@@ -109,7 +109,7 @@ public class UriUtilsTest {
   }
 
   @Test
-  public void testAbsoluteURIBuilderWithListenerForHttps() throws RestConfigException {
+  public void testAbsoluteURIBuilderWithListenerForHttps() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:9091,https://0.0.0.0:9092");
@@ -124,7 +124,7 @@ public class UriUtilsTest {
   }
 
   @Test
-  public void testAbsoluteURIBuilderWithIPV6Listener() throws RestConfigException {
+  public void testAbsoluteURIBuilderWithIPV6Listener() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://[fe80:0:1:2:3:4:5:6]:9092");
@@ -140,7 +140,7 @@ public class UriUtilsTest {
 
 
   @Test
-  public void testAbsoluteURIBuilderWithTruncatedIPV6Listener() throws RestConfigException {
+  public void testAbsoluteURIBuilderWithTruncatedIPV6Listener() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://[fe80::1]:9092");

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -86,11 +86,11 @@ public class KafkaConsumerManagerTest {
 
 
     @Before
-    public void setUp() throws RestConfigException {
+    public void setUp() {
         setUpConsumer(setUpProperties());
     }
 
-    private void setUpConsumer(Properties properties) throws RestConfigException {
+    private void setUpConsumer(Properties properties) {
         config = new KafkaRestConfig(properties, new SystemTime());
         consumerManager = new KafkaConsumerManager(config, consumerFactory);
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST, groupName);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
@@ -32,6 +32,8 @@ import io.confluent.rest.validation.JacksonMessageBodyProvider;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
+import org.apache.kafka.common.config.ConfigException;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Before;
@@ -65,7 +67,7 @@ public class PartitionsResourceTest extends JerseyTest {
           /* producerPool= */ null,
           consumerManager,
           adminClientWrapper);
-    } catch (RestConfigException e) {
+    } catch (ConfigException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
All KafkaRestConfig constructors throw RestConfigException despite this exception only being thrown in `public KafkaRestConfig(String propsFile)`. This makes for an undesirable developer experience. 