### PR TITLE
Fix KafkaRestApplication(Properties) constructor

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -50,7 +50,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
   }
 
   public KafkaRestApplication(Properties props) {
-    super(new KafkaRestConfig(props));
+    this(new KafkaRestConfig(props));
   }
 
   public KafkaRestApplication(KafkaRestConfig config) {


### PR DESCRIPTION
The original constructor fails to set restResourceExtensions causing an NPE when setting up resources. 