### PR TITLE
Fix REST Proxy injection-based authentication.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -94,7 +94,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
             contextInvocationHandler
         );
 
-    config.register(new BackendsModule(context));
+    config.register(new BackendsModule());
     config.register(new ConfigModule(appConfig));
     config.register(new ControllersModule());
     config.register(new ExceptionsModule());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/backends/BackendsModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/backends/BackendsModule.java
@@ -15,9 +15,7 @@
 
 package io.confluent.kafkarest.backends;
 
-import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.kafkarest.backends.kafka.KafkaModule;
-import java.util.Objects;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 /**
@@ -25,14 +23,8 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
  */
 public final class BackendsModule extends AbstractBinder {
 
-  private final KafkaRestContext context;
-
-  public BackendsModule(KafkaRestContext context) {
-    this.context = Objects.requireNonNull(context);
-  }
-
   @Override
   protected void configure() {
-    install(new KafkaModule(context));
+    install(new KafkaModule());
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/BrokersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/BrokersResource.java
@@ -26,6 +26,7 @@ import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -41,10 +42,10 @@ import javax.ws.rs.container.Suspended;
 @Consumes()
 public final class BrokersResource {
 
-  private final BrokerManager brokerManager;
+  private final Provider<BrokerManager> brokerManager;
 
   @Inject
-  BrokersResource(BrokerManager brokerManager) {
+  BrokersResource(Provider<BrokerManager> brokerManager) {
     this.brokerManager = requireNonNull(brokerManager);
   }
 
@@ -52,7 +53,8 @@ public final class BrokersResource {
   @PerformanceMetric("brokers.list+v2")
   public void list(@Suspended AsyncResponse asyncResponse) {
     CompletableFuture<BrokerList> response =
-        brokerManager.listLocalBrokers()
+        brokerManager.get()
+            .listLocalBrokers()
             .thenApply(
                 brokers ->
                     new BrokerList(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -53,13 +54,13 @@ import javax.ws.rs.core.Response.Status;
 @Path("/v3/clusters/{clusterId}/brokers/{brokerId}/configs")
 public final class BrokerConfigsResource {
 
-  private final BrokerConfigManager brokerConfigManager;
+  private final Provider<BrokerConfigManager> brokerConfigManager;
   private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
   public BrokerConfigsResource(
-      BrokerConfigManager brokerConfigManager,
+      Provider<BrokerConfigManager> brokerConfigManager,
       CrnFactory crnFactory,
       UrlFactory urlFactory) {
     this.brokerConfigManager = requireNonNull(brokerConfigManager);
@@ -74,7 +75,8 @@ public final class BrokerConfigsResource {
       @PathParam("clusterId") String clusterId,
       @PathParam("brokerId") int brokerId) {
     CompletableFuture<ListBrokerConfigsResponse> response =
-        brokerConfigManager.listBrokerConfigs(clusterId, brokerId)
+        brokerConfigManager.get()
+            .listBrokerConfigs(clusterId, brokerId)
             .thenApply(
                 configs ->
                     new ListBrokerConfigsResponse(
@@ -100,7 +102,8 @@ public final class BrokerConfigsResource {
       @PathParam("name") String name
   ) {
     CompletableFuture<GetBrokerConfigResponse> response =
-        brokerConfigManager.getBrokerConfig(clusterId, brokerId, name)
+        brokerConfigManager.get()
+            .getBrokerConfig(clusterId, brokerId, name)
             .thenApply(broker -> broker.orElseThrow(NotFoundException::new))
             .thenApply(broker -> new GetBrokerConfigResponse(toBrokerConfigData(broker)));
 
@@ -121,7 +124,7 @@ public final class BrokerConfigsResource {
     String newValue = request.getData().getAttributes().getValue();
 
     CompletableFuture<Void> response =
-        brokerConfigManager.updateBrokerConfig(clusterId, brokerId, name, newValue);
+        brokerConfigManager.get().updateBrokerConfig(clusterId, brokerId, name, newValue);
 
     AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
         .entity(response)
@@ -138,7 +141,7 @@ public final class BrokerConfigsResource {
       @PathParam("name") String name
   ) {
     CompletableFuture<Void> response =
-        brokerConfigManager.resetBrokerConfig(clusterId, brokerId, name);
+        brokerConfigManager.get().resetBrokerConfig(clusterId, brokerId, name);
 
     AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
         .entity(response)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
@@ -33,6 +33,7 @@ import io.confluent.kafkarest.response.UrlFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
@@ -44,13 +45,13 @@ import javax.ws.rs.container.Suspended;
 @Path("/v3/clusters/{clusterId}/brokers")
 public final class BrokersResource {
 
-  private final BrokerManager brokerManager;
+  private final Provider<BrokerManager> brokerManager;
   private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
   public BrokersResource(
-      BrokerManager brokerManager, CrnFactory crnFactory, UrlFactory urlFactory) {
+      Provider<BrokerManager> brokerManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.brokerManager = requireNonNull(brokerManager);
     this.crnFactory = requireNonNull(crnFactory);
     this.urlFactory = requireNonNull(urlFactory);
@@ -61,7 +62,8 @@ public final class BrokersResource {
   public void listBrokers(
       @Suspended AsyncResponse asyncResponse, @PathParam("clusterId") String clusterId) {
     CompletableFuture<ListBrokersResponse> response =
-        brokerManager.listBrokers(clusterId)
+        brokerManager.get()
+            .listBrokers(clusterId)
             .thenApply(
                 brokers ->
                     new ListBrokersResponse(
@@ -82,7 +84,8 @@ public final class BrokersResource {
       @PathParam("brokerId") Integer brokerId
   ) {
     CompletableFuture<GetBrokerResponse> response =
-        brokerManager.getBroker(clusterId, brokerId)
+        brokerManager.get()
+            .getBroker(clusterId, brokerId)
             .thenApply(broker -> broker.orElseThrow(NotFoundException::new))
             .thenApply(broker -> new GetBrokerResponse(toBrokerData(broker)));
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -34,6 +34,7 @@ import io.confluent.kafkarest.response.UrlFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
@@ -45,13 +46,13 @@ import javax.ws.rs.container.Suspended;
 @Path("/v3/clusters/{clusterId}/topics/{topicName}/partitions")
 public final class PartitionsResource {
 
-  private final PartitionManager partitionManager;
+  private final Provider<PartitionManager> partitionManager;
   private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
   public PartitionsResource(
-      PartitionManager partitionManager, CrnFactory crnFactory, UrlFactory urlFactory) {
+      Provider<PartitionManager> partitionManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.partitionManager = requireNonNull(partitionManager);
     this.crnFactory = requireNonNull(crnFactory);
     this.urlFactory = requireNonNull(urlFactory);
@@ -64,7 +65,8 @@ public final class PartitionsResource {
       @PathParam("clusterId") String clusterId,
       @PathParam("topicName") String topicName) {
     CompletableFuture<ListPartitionsResponse> response =
-        partitionManager.listPartitions(clusterId, topicName)
+        partitionManager.get()
+            .listPartitions(clusterId, topicName)
             .thenApply(
                 partitions ->
                     new ListPartitionsResponse(
@@ -88,7 +90,8 @@ public final class PartitionsResource {
       @PathParam("topicName") String topicName,
       @PathParam("partitionId") Integer partitionId) {
     CompletableFuture<GetPartitionResponse> response =
-        partitionManager.getPartition(clusterId, topicName, partitionId)
+        partitionManager.get()
+            .getPartition(clusterId, topicName, partitionId)
             .thenApply(partition -> partition.orElseThrow(NotFoundException::new))
             .thenApply(partition -> new GetPartitionResponse(toPartitionData(partition)));
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.response.UrlFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
@@ -40,13 +41,13 @@ import javax.ws.rs.container.Suspended;
 @Path("/v3/clusters/{clusterId}/topics/{topicName}/partitions/{partitionId}/replicas")
 public final class ReplicasResource {
 
-  private final ReplicaManager replicaManager;
+  private final Provider<ReplicaManager> replicaManager;
   private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
   public ReplicasResource(
-      ReplicaManager replicaManager, CrnFactory crnFactory, UrlFactory urlFactory) {
+      Provider<ReplicaManager> replicaManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.replicaManager = requireNonNull(replicaManager);
     this.crnFactory = requireNonNull(crnFactory);
     this.urlFactory = requireNonNull(urlFactory);
@@ -61,7 +62,8 @@ public final class ReplicasResource {
       @PathParam("partitionId") Integer partitionId
   ) {
     CompletableFuture<ListReplicasResponse> response =
-        replicaManager.listReplicas(clusterId, topicName, partitionId)
+        replicaManager.get()
+            .listReplicas(clusterId, topicName, partitionId)
             .thenApply(
                 replicas ->
                     new ListReplicasResponse(
@@ -94,7 +96,8 @@ public final class ReplicasResource {
       @PathParam("brokerId") Integer brokerId
   ) {
     CompletableFuture<GetReplicaResponse> response =
-        replicaManager.getReplica(clusterId, topicName, partitionId, brokerId)
+        replicaManager.get()
+            .getReplica(clusterId, topicName, partitionId, brokerId)
             .thenApply(replica -> replica.orElseThrow(NotFoundException::new))
             .thenApply(replica ->
                 new GetReplicaResponse(ReplicaData.create(crnFactory, urlFactory, replica)));

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerAction.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.response.UrlFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -40,13 +41,13 @@ import javax.ws.rs.container.Suspended;
 @Path("/v3/clusters/{clusterId}/brokers/{brokerId}/partition-replicas")
 public final class SearchReplicasByBrokerAction {
 
-  private final ReplicaManager replicaManager;
+  private final Provider<ReplicaManager> replicaManager;
   private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
   public SearchReplicasByBrokerAction(
-      ReplicaManager replicaManager, CrnFactory crnFactory, UrlFactory urlFactory) {
+      Provider<ReplicaManager> replicaManager, CrnFactory crnFactory, UrlFactory urlFactory) {
     this.replicaManager = requireNonNull(replicaManager);
     this.crnFactory = requireNonNull(crnFactory);
     this.urlFactory = requireNonNull(urlFactory);
@@ -59,7 +60,8 @@ public final class SearchReplicasByBrokerAction {
       @PathParam("clusterId") String clusterId,
       @PathParam("brokerId") Integer brokerId) {
     CompletableFuture<ListReplicasResponse> response =
-        replicaManager.searchReplicasByBrokerId(clusterId, brokerId)
+        replicaManager.get()
+            .searchReplicasByBrokerId(clusterId, brokerId)
             .thenApply(
                 replicas ->
                     new ListReplicasResponse(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
@@ -63,7 +63,7 @@ public class BrokersResourceTest
 
   @Before
   public void setUp() throws Exception {
-    addResource(new BrokersResource(brokerManager));
+    addResource(new BrokersResource(() -> brokerManager));
     super.setUp();
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
@@ -354,7 +354,7 @@ public class TopicsResourceTest
   @Before
   @Override
   public void setUp() throws Exception {
-    addResource(new TopicsResource(topicManager, topicConfigManager));
+    addResource(new TopicsResource(() -> topicManager, () -> topicConfigManager));
     super.setUp();
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokerConfigResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokerConfigResourceTest.java
@@ -76,7 +76,7 @@ public final class BrokerConfigResourceTest {
   public void setUp() {
     brokerConfigsResource =
         new BrokerConfigsResource(
-            brokerConfigManager,
+            () -> brokerConfigManager,
             new CrnFactoryImpl(/* crnAuthorityConfig= */""),
             new FakeUrlFactory());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
@@ -63,7 +63,8 @@ public final class BrokersResourceTest {
   public void setUp() {
     brokersResource =
         new BrokersResource(
-            brokerManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
+            () -> brokerManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
+            new FakeUrlFactory());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -67,7 +67,8 @@ public class ClustersResourceTest {
   public void setUp() {
     clustersResource =
         new ClustersResource(
-            clusterManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
+            () -> clusterManager,
+            new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
@@ -144,7 +144,7 @@ public class PartitionsResourceTest {
   public void setUp() {
     partitionsResource =
         new PartitionsResource(
-            partitionManager,
+            () -> partitionManager,
             new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
             new FakeUrlFactory());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
@@ -87,7 +87,8 @@ public class ReplicasResourceTest {
   public void setUp() {
     replicasResource =
         new ReplicasResource(
-            replicaManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
+            () -> replicaManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
+            new FakeUrlFactory());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerActionTest.java
@@ -62,7 +62,8 @@ public class SearchReplicasByBrokerActionTest {
   public void setUp() {
     searchReplicasByBrokerAction =
         new SearchReplicasByBrokerAction(
-            replicaManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
+            () -> replicaManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
+            new FakeUrlFactory());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigsResourceTest.java
@@ -91,7 +91,7 @@ public class TopicConfigsResourceTest {
   public void setUp() {
     topicConfigsResource =
         new TopicConfigsResource(
-            topicConfigManager,
+            () -> topicConfigManager,
             new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
             new FakeUrlFactory());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -330,7 +330,8 @@ public class TopicsResourceTest {
   public void setUp() {
     topicsResource =
         new TopicsResource(
-            topicManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""), new FakeUrlFactory());
+            () -> topicManager, new CrnFactoryImpl(/* crnAuthorityConfig= */ ""),
+            new FakeUrlFactory());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
@@ -83,7 +83,7 @@ public class PartitionsResourceTest extends JerseyTest {
   protected Application configure() {
     partitionManager = createMock(PartitionManager.class);
     ResourceConfig application = new ResourceConfig();
-    application.register(new PartitionsResource(partitionManager));
+    application.register(new PartitionsResource(() -> partitionManager));
     application.register(new JacksonMessageBodyProvider());
     return application;
   }


### PR DESCRIPTION
Background: Confluent security plugins for REST Proxy perform authentication in a Post-Match Filter. Upon successful authentication, it sets up AdminClient connection accordingly. Later on, we bind Admin to this AdminClient instance created during authentication, and this instance is what is injected in the controllers/resources.

The problem: JSR 339/JAX-RS 2.0 specification, Section 3.7.2, Step 3 [1], specifies that the resource instance must be created in the Resource Match phase, which happens before the Post-Match Filter phase (see Appendix C). Therefore, at the time the Admin is injected in the resources, AdminClient has not been properly set yet. A default unauthenticated instance is injected instead.

The solution: A possible solution would be to move the authentication to the Pre-Match Filter phase. Unfortunately that is undesirable for a few reasons (for example, without matched resource information, it can't properly negotiate the content-type of the response in case of an authentication error). The solution implemented here instead is to inject a Provider of Admin, instead of Admin itself. By the time we call `get()` in the provider (Method Invocation phase, see Appendix C), authentication has already happened, and the correct AdminClient instance is acquired.

[1] https://download.oracle.com/otn-pub/jcp/jaxrs-2_0_rev_A-mrel-spec/jsr339-jaxrs-2.0-final-spec.pdf