### PR TITLE
KIP-226: Add support for configs source and synonyms.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -21,6 +21,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
 import io.confluent.kafkarest.common.KafkaFutures;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.ConfigSynonym;
 import io.confluent.kafkarest.entities.TopicConfig;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +33,7 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.common.config.ConfigResource;
 
 final class TopicConfigManagerImpl implements TopicConfigManager {
@@ -54,7 +57,11 @@ final class TopicConfigManagerImpl implements TopicConfigManager {
         .thenCompose(
             topic ->
                 KafkaFutures.toCompletableFuture(
-                    adminClient.describeConfigs(singletonList(resource)).values().get(resource)))
+                    adminClient.describeConfigs(
+                        singletonList(resource),
+                        new DescribeConfigsOptions().includeSynonyms(true))
+                        .values()
+                        .get(resource)))
         .thenApply(
             config ->
                 config.entries().stream()
@@ -67,7 +74,11 @@ final class TopicConfigManagerImpl implements TopicConfigManager {
                                 entry.value(),
                                 entry.isDefault(),
                                 entry.isReadOnly(),
-                                entry.isSensitive()))
+                                entry.isSensitive(),
+                                ConfigSource.fromAdminConfigSource(entry.source()),
+                                entry.synonyms().stream()
+                                    .map(ConfigSynonym::fromAdminConfigSynonym)
+                                    .collect(Collectors.toList())))
                     .collect(Collectors.toList()));
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
@@ -88,7 +88,7 @@ public abstract class AbstractConfig {
     return isSensitive;
   }
 
-  public ConfigSource getSource() {
+  public final ConfigSource getSource() {
     return source;
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * A Kafka config.
+ */
+public abstract class AbstractConfig {
+
+  private final String clusterId;
+
+  private final String name;
+
+  @Nullable
+  private final String value;
+
+  private final boolean isDefault;
+
+  private final boolean isReadOnly;
+
+  private final boolean isSensitive;
+
+  private final ConfigSource source;
+
+  private final List<ConfigSynonym> synonyms;
+
+  AbstractConfig(
+      String clusterId,
+      String name,
+      @Nullable String value,
+      boolean isDefault,
+      boolean isReadOnly,
+      boolean isSensitive,
+      ConfigSource source,
+      List<ConfigSynonym> synonyms) {
+    this.clusterId = requireNonNull(clusterId);
+    this.name = requireNonNull(name);
+    this.value = value;
+    this.isDefault = isDefault;
+    this.isReadOnly = isReadOnly;
+    this.isSensitive = isSensitive;
+    this.source = requireNonNull(source);
+    this.synonyms = requireNonNull(synonyms);
+  }
+
+  public final String getClusterId() {
+    return clusterId;
+  }
+
+  public final String getName() {
+    return name;
+  }
+
+  @Nullable
+  public final String getValue() {
+    return value;
+  }
+
+  public final boolean isDefault() {
+    return isDefault;
+  }
+
+  public final boolean isReadOnly() {
+    return isReadOnly;
+  }
+
+  public final boolean isSensitive() {
+    return isSensitive;
+  }
+
+  public ConfigSource getSource() {
+    return source;
+  }
+
+  public final List<ConfigSynonym> getSynonyms() {
+    return unmodifiableList(synonyms);
+  }
+
+  // CHECKSTYLE:OFF:CyclomaticComplexity
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AbstractConfig that = (AbstractConfig) o;
+    return clusterId.equals(that.clusterId)
+        && name.equals(that.name)
+        && Objects.equals(value, that.value)
+        && isDefault == that.isDefault
+        && isReadOnly == that.isReadOnly
+        && isSensitive == that.isSensitive
+        && source.equals(that.source)
+        && synonyms.equals(that.synonyms);
+  }
+  // CHECKSTYLE:ON:CyclomaticComplexity
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        clusterId, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
+  }
+
+  @Override
+  public abstract String toString();
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/BrokerConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/BrokerConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.entities;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.annotation.Nullable;
@@ -22,22 +23,9 @@ import javax.annotation.Nullable;
 /**
  * A Kafka Broker Config
  */
-public final class BrokerConfig {
-
-  private final String clusterId;
+public final class BrokerConfig extends AbstractConfig {
 
   private final int brokerId;
-
-  private final String name;
-
-  @Nullable
-  private final String value;
-
-  private final boolean isDefault;
-
-  private final boolean isReadOnly;
-
-  private final boolean isSensitive;
 
   public BrokerConfig(
       String clusterId,
@@ -46,77 +34,38 @@ public final class BrokerConfig {
       @Nullable String value,
       boolean isDefault,
       boolean isReadOnly,
-      boolean isSensitive) {
-    this.clusterId = Objects.requireNonNull(clusterId);
+      boolean isSensitive,
+      ConfigSource source,
+      List<ConfigSynonym> synonyms) {
+    super(clusterId, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
     this.brokerId = brokerId;
-    this.name = Objects.requireNonNull(name);
-    this.value = value;
-    this.isDefault = isDefault;
-    this.isReadOnly = isReadOnly;
-    this.isSensitive = isSensitive;
-  }
-
-  public String getClusterId() {
-    return clusterId;
   }
 
   public int getBrokerId() {
     return brokerId;
   }
 
-  public String getName() {
-    return name;
-  }
-
-  @Nullable
-  public String getValue() {
-    return value;
-  }
-
-  public boolean isDefault() {
-    return isDefault;
-  }
-
-  public boolean isReadOnly() {
-    return isReadOnly;
-  }
-
-  public boolean isSensitive() {
-    return isSensitive;
-  }
-
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    BrokerConfig that = (BrokerConfig) o;
-    return isDefault == that.isDefault
-        && isReadOnly == that.isReadOnly
-        && isSensitive == that.isSensitive
-        && Objects.equals(clusterId, that.clusterId)
-        && brokerId == that.brokerId
-        && Objects.equals(name, that.name)
-        && Objects.equals(value, that.value);
+    return super.equals(o) && brokerId == ((BrokerConfig) o).brokerId;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(clusterId, brokerId, name, value, isDefault, isReadOnly, isSensitive);
+    return Objects.hash(super.hashCode(), brokerId);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", BrokerConfig.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + clusterId + "'")
+        .add("clusterId='" + getClusterId() + "'")
         .add("brokerId=" + brokerId)
-        .add("name='" + name + "'")
-        .add("value='" + value + "'")
-        .add("isDefault=" + isDefault)
-        .add("isSensitive=" + isSensitive)
+        .add("name='" + getName() + "'")
+        .add("value='" + getValue() + "'")
+        .add("isDefault=" + isDefault())
+        .add("isSensitive=" + isSensitive())
+        .add("source=" + getSource())
+        .add("synonyms=" + getSynonyms())
         .toString();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import org.apache.kafka.clients.admin.ConfigEntry;
+
+/**
+ * Source of a {@link AbstractConfig config} value.
+ *
+ * @see org.apache.kafka.clients.admin.ConfigEntry.ConfigSource
+ * @see <a href=
+ *      https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">
+ *      KIP-226 - Dynamic Broker Configuration</a>
+ */
+public enum ConfigSource {
+
+  /**
+   * Dynamic cluster link config that is configured for a specific link name.
+   */
+  DYNAMIC_CLUSTER_LINK_CONFIG,
+
+  /**
+   * Dynamic topic config that is configured for a specific topic.
+   */
+  DYNAMIC_TOPIC_CONFIG,
+
+  /**
+   * Dynamic broker logger config that is configured for a specific broker.
+   */
+  DYNAMIC_BROKER_LOGGER_CONFIG,
+
+  /**
+   * Dynamic broker config that is configured for a specific broker.
+   */
+  DYNAMIC_BROKER_CONFIG,
+
+  /**
+   * Dynamic broker config that is configured as default for all brokers in the cluster.
+   */
+  DYNAMIC_DEFAULT_BROKER_CONFIG,
+
+  /**
+   * Static broker config provided as broker properties at start up (e.g. server.properties file).
+   */
+  STATIC_BROKER_CONFIG,
+
+  /**
+   * Built-in default configuration for configs that have a default value.
+   */
+  DEFAULT_CONFIG,
+
+  /**
+   * Source unknown e.g. in the ConfigEntry used for alter requests where source is not set.
+   */
+  UNKNOWN;
+
+  public static ConfigSource fromAdminConfigSource(ConfigEntry.ConfigSource source) {
+    try {
+      return valueOf(source.name());
+    } catch (IllegalArgumentException e) {
+      return UNKNOWN;
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSynonym.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSynonym.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+import org.apache.kafka.clients.admin.ConfigEntry;
+
+/**
+ * Synonym of a {@link AbstractConfig config}.
+ *
+ * @see org.apache.kafka.clients.admin.ConfigEntry.ConfigSynonym
+ * @see <a href=
+ *      https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">
+ *      KIP-226 - Dynamic Broker Configuration</a>
+ */
+public final class ConfigSynonym {
+
+  private final String name;
+
+  @Nullable
+  private final String value;
+
+  private final ConfigSource source;
+
+  public ConfigSynonym(String name, @Nullable String value, ConfigSource source) {
+    this.name = requireNonNull(name);
+    this.value = value;
+    this.source = requireNonNull(source);
+  }
+
+  public static ConfigSynonym fromAdminConfigSynonym(ConfigEntry.ConfigSynonym synonym) {
+    return new ConfigSynonym(
+        synonym.name(), synonym.value(), ConfigSource.fromAdminConfigSource(synonym.source()));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getValue() {
+    return value;
+  }
+
+  public ConfigSource getSource() {
+    return source;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConfigSynonym synonym = (ConfigSynonym) o;
+    return name.equals(synonym.name)
+        && Objects.equals(value, synonym.value)
+        && source == synonym.source;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value, source);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", ConfigSynonym.class.getSimpleName() + "[", "]")
+        .add("name='" + name + "'")
+        .add("value='" + value + "'")
+        .add("source=" + source)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicConfig.java
@@ -15,6 +15,9 @@
 
 package io.confluent.kafkarest.entities;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.annotation.Nullable;
@@ -22,22 +25,9 @@ import javax.annotation.Nullable;
 /**
  * A Kafka Topic Config.
  */
-public final class TopicConfig {
-
-  private final String clusterId;
+public final class TopicConfig extends AbstractConfig {
 
   private final String topicName;
-
-  private final String name;
-
-  @Nullable
-  private final String value;
-
-  private final boolean isDefault;
-
-  private final boolean isReadOnly;
-
-  private final boolean isSensitive;
 
   public TopicConfig(
       String clusterId,
@@ -46,79 +36,38 @@ public final class TopicConfig {
       @Nullable String value,
       boolean isDefault,
       boolean isReadOnly,
-      boolean isSensitive) {
-    this.clusterId = Objects.requireNonNull(clusterId);
-    this.topicName = Objects.requireNonNull(topicName);
-    this.name = Objects.requireNonNull(name);
-    this.value = value;
-    this.isDefault = isDefault;
-    this.isReadOnly = isReadOnly;
-    this.isSensitive = isSensitive;
-  }
-
-  public String getClusterId() {
-    return clusterId;
+      boolean isSensitive,
+      ConfigSource source,
+      List<ConfigSynonym> synonyms) {
+    super(clusterId, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
+    this.topicName = requireNonNull(topicName);
   }
 
   public String getTopicName() {
     return topicName;
   }
 
-  public String getName() {
-    return name;
-  }
-
-  @Nullable
-  public String getValue() {
-    return value;
-  }
-
-  public boolean isDefault() {
-    return isDefault;
-  }
-
-  public boolean isReadOnly() {
-    return isReadOnly;
-  }
-
-  public boolean isSensitive() {
-    return isSensitive;
-  }
-
-  // CHECKSTYLE:OFF:CyclomaticComplexity
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    TopicConfig that = (TopicConfig) o;
-    return isDefault == that.isDefault
-        && isReadOnly == that.isReadOnly
-        && isSensitive == that.isSensitive
-        && Objects.equals(clusterId, that.clusterId)
-        && Objects.equals(topicName, that.topicName)
-        && Objects.equals(name, that.name)
-        && Objects.equals(value, that.value);
+    return super.equals(o) && topicName.equals(((TopicConfig) o).topicName);
   }
-  // CHECKSTYLE:ON:CyclomaticComplexity
 
   @Override
   public int hashCode() {
-    return Objects.hash(clusterId, topicName, name, value, isDefault, isSensitive);
+    return Objects.hash(super.hashCode(), topicName);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", TopicConfig.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + clusterId + "'")
-        .add("topicName='" + topicName + "'")
-        .add("name='" + name + "'")
-        .add("value='" + value + "'")
-        .add("isDefault=" + isDefault)
-        .add("isSensitive=" + isSensitive)
+        .add("clusterId='" + getClusterId() + "'")
+        .add("topicName=" + topicName)
+        .add("name='" + getName() + "'")
+        .add("value='" + getValue() + "'")
+        .add("isDefault=" + isDefault())
+        .add("isSensitive=" + isSensitive())
+        .add("source=" + getSource())
+        .add("synonyms=" + getSynonyms())
         .toString();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/BrokerConfigData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/BrokerConfigData.java
@@ -18,7 +18,8 @@ package io.confluent.kafkarest.entities.v3;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.confluent.kafkarest.entities.v3.TopicConfigData.Attributes;
+import io.confluent.kafkarest.entities.ConfigSource;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.annotation.Nullable;
@@ -37,6 +38,7 @@ public final class BrokerConfigData {
 
   private final Attributes attributes;
 
+  // CHECKSTYLE:OFF:ParameterNumber
   public BrokerConfigData(
       String id,
       ResourceLink links,
@@ -46,12 +48,24 @@ public final class BrokerConfigData {
       @Nullable String value,
       boolean isDefault,
       boolean isReadOnly,
-      boolean isSensitive) {
-
-    this(id, links,
-            new Attributes(clusterId, brokerId, name, value,
-                    isDefault, isReadOnly, isSensitive));
+      boolean isSensitive,
+      ConfigSource source,
+      List<ConfigSynonymData> synonyms) {
+    this(
+        id,
+        links,
+        new Attributes(
+            clusterId,
+            brokerId,
+            name,
+            value,
+            isDefault,
+            isReadOnly,
+            isSensitive,
+            source,
+            synonyms));
   }
+  // CHECKSTYLE:ON:ParameterNumber
 
   @JsonCreator
   public BrokerConfigData(
@@ -129,6 +143,10 @@ public final class BrokerConfigData {
 
     private final boolean isSensitive;
 
+    private final ConfigSource source;
+
+    private final List<ConfigSynonymData> synonyms;
+
     @JsonCreator
     public Attributes(
         @JsonProperty("cluster_id") String clusterId,
@@ -137,14 +155,18 @@ public final class BrokerConfigData {
         @JsonProperty("value") @Nullable String value,
         @JsonProperty("is_default") boolean isDefault,
         @JsonProperty("is_read_only") boolean isReadOnly,
-        @JsonProperty("is_sensitive") boolean isSensitive) {
-      this.clusterId = Objects.requireNonNull(clusterId);
+        @JsonProperty("is_sensitive") boolean isSensitive,
+        @JsonProperty("source") ConfigSource source,
+        @JsonProperty("synonyms") List<ConfigSynonymData> synonyms) {
+      this.clusterId = clusterId;
       this.brokerId = brokerId;
-      this.name = Objects.requireNonNull(name);
+      this.name = name;
       this.value = value;
       this.isDefault = isDefault;
       this.isReadOnly = isReadOnly;
       this.isSensitive = isSensitive;
+      this.source = source;
+      this.synonyms = synonyms;
     }
 
     @JsonProperty("cluster_id")
@@ -183,6 +205,17 @@ public final class BrokerConfigData {
       return isSensitive;
     }
 
+    @JsonProperty("source")
+    public ConfigSource getSource() {
+      return source;
+    }
+
+    @JsonProperty("synonyms")
+    public List<ConfigSynonymData> getSynonyms() {
+      return synonyms;
+    }
+
+    // CHECKSTYLE:OFF:CyclomaticComplexity
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -192,23 +225,27 @@ public final class BrokerConfigData {
         return false;
       }
       BrokerConfigData.Attributes that = (BrokerConfigData.Attributes) o;
-      return isDefault == that.isDefault
-          && isReadOnly == that.isReadOnly
-          && isSensitive == that.isSensitive
-          && Objects.equals(clusterId, that.clusterId)
+      return Objects.equals(clusterId, that.clusterId)
           && brokerId == that.brokerId
           && Objects.equals(name, that.name)
-          && Objects.equals(value, that.value);
+          && Objects.equals(value, that.value)
+          && isDefault == that.isDefault
+          && isReadOnly == that.isReadOnly
+          && isSensitive == that.isSensitive
+          && Objects.equals(source, that.source)
+          && Objects.equals(synonyms, that.synonyms);
     }
+    // CHECKSTYLE:ON:CyclomaticComplexity
 
     @Override
     public int hashCode() {
-      return Objects.hash(clusterId, brokerId, name, value, isDefault, isReadOnly, isSensitive);
+      return Objects.hash(
+          clusterId, brokerId, name, value, isDefault, isReadOnly, isSensitive, synonyms);
     }
 
     @Override
     public String toString() {
-      return new StringJoiner(", ", TopicConfigData.Attributes.class.getSimpleName() + "[", "]")
+      return new StringJoiner(", ", BrokerConfigData.Attributes.class.getSimpleName() + "[", "]")
           .add("clusterId='" + clusterId + "'")
           .add("brokerId=" + brokerId)
           .add("name='" + name + "'")
@@ -216,6 +253,8 @@ public final class BrokerConfigData {
           .add("isDefault=" + isDefault)
           .add("isReadOnly=" + isReadOnly)
           .add("isSensitive=" + isSensitive)
+          .add("source=" + source)
+          .add("synonyms=" + synonyms)
           .toString();
     }
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConfigSynonymData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConfigSynonymData.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.ConfigSynonym;
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+
+public final class ConfigSynonymData {
+
+  private final String name;
+
+  @Nullable
+  private final String value;
+
+  private final ConfigSource source;
+
+  public ConfigSynonymData(
+      @JsonProperty("name") String name,
+      @JsonProperty("value") @Nullable String value,
+      @JsonProperty("source") ConfigSource source) {
+    this.name = name;
+    this.value = value;
+    this.source = source;
+  }
+
+  public static ConfigSynonymData fromConfigSynonym(ConfigSynonym synonym) {
+    return new ConfigSynonymData(synonym.getName(), synonym.getValue(), synonym.getSource());
+  }
+
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  @JsonProperty("value")
+  @Nullable
+  public String getValue() {
+    return value;
+  }
+
+  @JsonProperty("source")
+  public ConfigSource getSource() {
+    return source;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConfigSynonymData that = (ConfigSynonymData) o;
+    return name.equals(that.name) && Objects.equals(value, that.value) && source == that.source;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getValue(), getSource());
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", ConfigSynonymData.class.getSimpleName() + "[", "]")
+        .add("name='" + name + "'")
+        .add("value='" + value + "'")
+        .add("source=" + source)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicConfigData.java
@@ -15,9 +15,13 @@
 
 package io.confluent.kafkarest.entities.v3;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafkarest.entities.ConfigSource;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.annotation.Nullable;
@@ -36,6 +40,7 @@ public final class TopicConfigData {
 
   private final Attributes attributes;
 
+  // CHECKSTYLE:OFF:ParameterNumber
   public TopicConfigData(
       String id,
       ResourceLink links,
@@ -45,11 +50,24 @@ public final class TopicConfigData {
       @Nullable String value,
       boolean isDefault,
       boolean isReadOnly,
-      boolean isSensitive) {
-    this(id, links,
-            new Attributes(clusterId, topicName, name, value,
-                    isDefault, isReadOnly, isSensitive));
+      boolean isSensitive,
+      ConfigSource source,
+      List<ConfigSynonymData> synonyms) {
+    this(
+        id,
+        links,
+        new Attributes(
+            clusterId,
+            topicName,
+            name,
+            value,
+            isDefault,
+            isReadOnly,
+            isSensitive,
+            source,
+            synonyms));
   }
+  // CHECKSTYLE:ON:ParameterNumber
 
   @JsonCreator
   public TopicConfigData(
@@ -57,8 +75,8 @@ public final class TopicConfigData {
           @JsonProperty("links") ResourceLink links,
           @JsonProperty("attributes") Attributes attributes
   ) {
-    this.id = Objects.requireNonNull(id);
-    this.links = Objects.requireNonNull(links);
+    this.id = requireNonNull(id);
+    this.links = requireNonNull(links);
     this.attributes = attributes;
   }
 
@@ -127,6 +145,10 @@ public final class TopicConfigData {
 
     private final boolean isSensitive;
 
+    private final ConfigSource source;
+
+    private final List<ConfigSynonymData> synonyms;
+
     @JsonCreator
     public Attributes(
         @JsonProperty("cluster_id") String clusterId,
@@ -135,14 +157,18 @@ public final class TopicConfigData {
         @JsonProperty("value") @Nullable String value,
         @JsonProperty("is_default") boolean isDefault,
         @JsonProperty("is_read_only") boolean isReadOnly,
-        @JsonProperty("is_sensitive") boolean isSensitive) {
-      this.clusterId = Objects.requireNonNull(clusterId);
-      this.topicName = Objects.requireNonNull(topicName);
-      this.name = Objects.requireNonNull(name);
+        @JsonProperty("is_sensitive") boolean isSensitive,
+        @JsonProperty("source") ConfigSource source,
+        @JsonProperty("synonyms") List<ConfigSynonymData> synonyms) {
+      this.clusterId = clusterId;
+      this.topicName = topicName;
+      this.name = name;
       this.value = value;
       this.isDefault = isDefault;
       this.isReadOnly = isReadOnly;
       this.isSensitive = isSensitive;
+      this.source = source;
+      this.synonyms = synonyms;
     }
 
     @JsonProperty("cluster_id")
@@ -181,6 +207,16 @@ public final class TopicConfigData {
       return isSensitive;
     }
 
+    @JsonProperty("source")
+    public ConfigSource getSource() {
+      return source;
+    }
+
+    @JsonProperty("synonyms")
+    public List<ConfigSynonymData> getSynonyms() {
+      return synonyms;
+    }
+
     // CHECKSTYLE:OFF:CyclomaticComplexity
     @Override
     public boolean equals(Object o) {
@@ -191,19 +227,22 @@ public final class TopicConfigData {
         return false;
       }
       Attributes that = (Attributes) o;
-      return isDefault == that.isDefault
-          && isReadOnly == that.isReadOnly
-          && isSensitive == that.isSensitive
-          && Objects.equals(clusterId, that.clusterId)
+      return Objects.equals(clusterId, that.clusterId)
           && Objects.equals(topicName, that.topicName)
           && Objects.equals(name, that.name)
-          && Objects.equals(value, that.value);
+          && Objects.equals(value, that.value)
+          && isDefault == that.isDefault
+          && isReadOnly == that.isReadOnly
+          && isSensitive == that.isSensitive
+          && Objects.equals(source, that.source)
+          && Objects.equals(synonyms, that.synonyms);
     }
     // CHECKSTYLE:ON:CyclomaticComplexity
 
     @Override
     public int hashCode() {
-      return Objects.hash(clusterId, topicName, name, value, isDefault, isReadOnly, isSensitive);
+      return Objects.hash(
+          clusterId, topicName, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
     }
 
     @Override
@@ -216,6 +255,8 @@ public final class TopicConfigData {
           .add("isDefault=" + isDefault)
           .add("isReadOnly=" + isReadOnly)
           .add("isSensitive=" + isSensitive)
+          .add("source=" + source)
+          .add("synonyms=" + synonyms)
           .toString();
     }
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
@@ -21,6 +21,7 @@ import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.BrokerConfigManager;
 import io.confluent.kafkarest.entities.BrokerConfig;
 import io.confluent.kafkarest.entities.v3.BrokerConfigData;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
 import io.confluent.kafkarest.entities.v3.BrokerData;
 import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
@@ -172,6 +173,10 @@ public final class BrokerConfigsResource {
         brokerConfig.getValue(),
         brokerConfig.isDefault(),
         brokerConfig.isReadOnly(),
-        brokerConfig.isSensitive());
+        brokerConfig.isSensitive(),
+        brokerConfig.getSource(),
+        brokerConfig.getSynonyms().stream()
+            .map(ConfigSynonymData::fromConfigSynonym)
+            .collect(Collectors.toList()));
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigsResource.java
@@ -22,6 +22,7 @@ import io.confluent.kafkarest.controllers.TopicConfigManager;
 import io.confluent.kafkarest.entities.TopicConfig;
 import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicConfigsResponse;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
@@ -172,6 +173,10 @@ public final class TopicConfigsResource {
         topicConfig.getValue(),
         topicConfig.isDefault(),
         topicConfig.isReadOnly(),
-        topicConfig.isSensitive());
+        topicConfig.isSensitive(),
+        topicConfig.getSource(),
+        topicConfig.getSynonyms().stream()
+            .map(ConfigSynonymData::fromConfigSynonym)
+            .collect(Collectors.toList()));
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
@@ -19,6 +19,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
@@ -28,6 +30,7 @@ import static org.junit.Assert.fail;
 
 import io.confluent.kafkarest.common.KafkaFutures;
 import io.confluent.kafkarest.entities.Cluster;
+import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.TopicConfig;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,6 +43,7 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.ConfigResource;
@@ -69,7 +73,9 @@ public class TopicConfigManagerImplTest {
           "value-1",
           /* isDefault= */ true,
           /* isReadOnly= */ false,
-          /* isSensitive= */ false);
+          /* isSensitive= */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_2 =
       new TopicConfig(
           CLUSTER_ID,
@@ -78,7 +84,9 @@ public class TopicConfigManagerImplTest {
           "value-2",
           /* isDefault= */ false,
           /* isReadOnly= */ true,
-          /* isSensitive= */ false);
+          /* isSensitive= */ false,
+          ConfigSource.UNKNOWN,
+          /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_3 =
       new TopicConfig(
           CLUSTER_ID,
@@ -87,7 +95,9 @@ public class TopicConfigManagerImplTest {
           null,
           /* isDefault= */ false,
           /* isReadOnly= */ false,
-          /* isSensitive= */ true);
+          /* isSensitive= */ true,
+          ConfigSource.UNKNOWN,
+          /* synonyms= */ emptyList());
 
   private static final Config CONFIG =
       new Config(
@@ -138,7 +148,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -158,7 +169,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -193,7 +205,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -216,7 +229,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -236,7 +250,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -273,7 +288,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -307,7 +323,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -332,7 +349,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -373,7 +391,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -407,7 +426,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(
@@ -431,7 +451,8 @@ public class TopicConfigManagerImplTest {
     expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
     expect(
         adminClient.describeConfigs(
-            singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))))
+            eq(singletonList(new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_NAME))),
+            anyObject(DescribeConfigsOptions.class)))
         .andReturn(describeConfigsResult);
     expect(describeConfigsResult.values())
         .andReturn(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokerConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokerConfigsResourceIntegrationTest.java
@@ -1,10 +1,11 @@
 package io.confluent.kafkarest.integration.v3;
 
+import static java.util.Collections.emptyList;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.v3.*;
 import io.confluent.kafkarest.integration.ClusterTestHarness;
 import javax.ws.rs.client.Entity;
@@ -14,8 +15,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public BrokerConfigsResourceIntegrationTest() {
     super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
@@ -51,7 +50,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                 "2147483647",
                 /* isDefault= */ true,
                 /* isReadOnly= */ false,
-                /* isSensitive= */ false);
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                /* synonyms= */ emptyList());
 
     BrokerConfigData expectedConfig2 =
             new BrokerConfigData(
@@ -69,7 +70,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                 "producer",
                 /* isDefault= */ true,
                 /* isReadOnly= */ false,
-                /* isSensitive= */ false);
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                /* synonyms= */ emptyList());
 
     BrokerConfigData expectedConfig3 =
             new BrokerConfigData(
@@ -87,7 +90,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                 "1",
                 /* isDefault= */ true,
                 /* isReadOnly= */ false,
-                /* isSensitive= */ false);
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                /* synonyms= */ emptyList());
 
     Response response =
         request("/v3/clusters/" + clusterId + "/brokers/" + brokerId + "/configs")
@@ -156,7 +161,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "2147483647",
                     /* isDefault= */ true,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DEFAULT_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response response =
         request(
@@ -229,7 +236,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "producer",
                     /* isDefault= */ true,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DEFAULT_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response responseBeforeUpdate =
         request(
@@ -270,7 +279,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "producer",
                     /* isDefault= */ false,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DYNAMIC_BROKER_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response responseAfterUpdate =
         request(
@@ -309,7 +320,9 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "producer",
                     /* isDefault= */ true,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DEFAULT_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response responseAfterReset =
         request(
@@ -419,6 +432,4 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
             .delete();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
-
-
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafkarest.integration.v3;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigResponse;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
 import io.confluent.kafkarest.entities.v3.TopicConfigData;
 import io.confluent.kafkarest.integration.ClusterTestHarness;
+import java.util.Arrays;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -81,7 +83,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                 /* isReadOnly= */ false,
                 /* isSensitive= */ false,
                 ConfigSource.DEFAULT_CONFIG,
-                /* synonyms= */ emptyList()));
+                singletonList(
+                    new ConfigSynonymData(
+                        "log.cleanup.policy", "delete", ConfigSource.DEFAULT_CONFIG))));
     String expectedConfig2 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigData(
@@ -101,7 +105,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                 /* isReadOnly= */ false,
                 /* isSensitive= */ false,
                 ConfigSource.DEFAULT_CONFIG,
-                /* synonyms= */ emptyList()));
+                singletonList(
+                    new ConfigSynonymData(
+                        "compression.type", "producer", ConfigSource.DEFAULT_CONFIG))));
     String expectedConfig3 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigData(
@@ -121,7 +127,11 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                 /* isReadOnly= */ false,
                 /* isSensitive= */ false,
                 ConfigSource.DEFAULT_CONFIG,
-                /* synonyms= */ emptyList()));
+                singletonList(
+                    new ConfigSynonymData(
+                        "log.cleaner.delete.retention.ms",
+                        "86400000",
+                        ConfigSource.DEFAULT_CONFIG))));
 
     Response response =
         request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configs")
@@ -164,7 +174,7 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void getTopicConfig_existingConfig_returnsConfig() throws Exception {
+  public void getTopicConfig_existingConfig_returnsConfig() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -187,7 +197,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     /* isReadOnly= */ false,
                     /* isSensitive= */ false,
                     ConfigSource.DEFAULT_CONFIG,
-                    /* synonyms= */ emptyList()));
+                    singletonList(
+                        new ConfigSynonymData(
+                            "log.cleanup.policy", "delete", ConfigSource.DEFAULT_CONFIG))));
 
     Response response =
         request(
@@ -235,7 +247,7 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void getUpdateReset_withExistingConfig() throws Exception {
+  public void getUpdateReset_withExistingConfig() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -258,7 +270,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     /* isReadOnly= */ false,
                     /* isSensitive= */ false,
                     ConfigSource.DEFAULT_CONFIG,
-                    /* synonyms= */ emptyList()));
+                    singletonList(
+                        new ConfigSynonymData(
+                            "log.cleanup.policy", "delete", ConfigSource.DEFAULT_CONFIG))));
 
     Response responseBeforeUpdate =
         request(
@@ -302,7 +316,11 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     /* isReadOnly= */ false,
                     /* isSensitive= */ false,
                     ConfigSource.DYNAMIC_TOPIC_CONFIG,
-                    /* synonyms= */ emptyList()));
+                    Arrays.asList(
+                        new ConfigSynonymData(
+                            "cleanup.policy", "compact", ConfigSource.DYNAMIC_TOPIC_CONFIG),
+                        new ConfigSynonymData(
+                            "log.cleanup.policy", "delete", ConfigSource.DEFAULT_CONFIG))));
 
     Response responseAfterUpdate =
         request(
@@ -343,7 +361,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     /* isReadOnly= */ false,
                     /* isSensitive= */ false,
                     ConfigSource.DEFAULT_CONFIG,
-                    /* synonyms= */ emptyList()));
+                    singletonList(
+                        new ConfigSynonymData(
+                            "log.cleanup.policy", "delete", ConfigSource.DEFAULT_CONFIG))));
 
     Response responseAfterReset =
         request(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
@@ -15,11 +15,13 @@
 
 package io.confluent.kafkarest.integration.v3;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigResponse;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
@@ -77,7 +79,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                 "delete",
                 /* isDefault= */ true,
                 /* isReadOnly= */ false,
-                /* isSensitive= */ false));
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                /* synonyms= */ emptyList()));
     String expectedConfig2 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigData(
@@ -95,7 +99,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                 "producer",
                 /* isDefault= */ true,
                 /* isReadOnly= */ false,
-                /* isSensitive= */ false));
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                /* synonyms= */ emptyList()));
     String expectedConfig3 =
         OBJECT_MAPPER.writeValueAsString(
             new TopicConfigData(
@@ -113,7 +119,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                 "86400000",
                 /* isDefault= */ true,
                 /* isReadOnly= */ false,
-                /* isSensitive= */ false));
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                /* synonyms= */ emptyList()));
 
     Response response =
         request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configs")
@@ -177,7 +185,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "delete",
                     /* isDefault= */ true,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DEFAULT_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response response =
         request(
@@ -246,7 +256,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "delete",
                     /* isDefault= */ true,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DEFAULT_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response responseBeforeUpdate =
         request(
@@ -288,7 +300,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "compact",
                     /* isDefault= */ false,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DYNAMIC_TOPIC_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response responseAfterUpdate =
         request(
@@ -327,7 +341,9 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                     "delete",
                     /* isDefault= */ true,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DEFAULT_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response responseAfterReset =
         request(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -15,12 +15,14 @@
 
 package io.confluent.kafkarest.integration.v3;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigResponse;
@@ -40,8 +42,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TopicsResourceIntegrationTest extends ClusterTestHarness {
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final String TOPIC_1 = "topic-1";
   private static final String TOPIC_2 = "topic-2";
@@ -419,7 +419,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                     "compact",
                     /* isDefault= */ false,
                     /* isReadOnly= */ false,
-                    /* isSensitive= */ false));
+                    /* isSensitive= */ false,
+                    ConfigSource.DYNAMIC_TOPIC_CONFIG,
+                    /* synonyms= */ emptyList()));
 
     Response existingGetTopicConfigResponse =
         request(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -15,15 +15,14 @@
 
 package io.confluent.kafkarest.integration.v3;
 
-import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicResponse;
@@ -68,7 +67,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void listTopics_existingCluster_returnsTopics() throws Exception {
+  public void listTopics_existingCluster_returnsTopics() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -154,7 +153,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void getTopic_existingClusterExistingTopic_returnsTopic() throws Exception {
+  public void getTopic_existingClusterExistingTopic_returnsTopic() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -207,7 +206,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void createTopic_nonExistingTopic_returnsCreatedTopic() throws Exception {
+  public void createTopic_nonExistingTopic_returnsCreatedTopic() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
     String topicName = "topic-4";
@@ -318,9 +317,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void
-  getTopic_nonExistingTopic_returnsEmpty_thenCreateTopicAndGetTopic_returnsCreatedTopic_thenDeleteTopicAndGetTopic_returnsEmpty
-      () throws Exception {
+  public void createAndDelete_nonExisting_returnsNotFoundCreatedAndNotFound() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
     String topicName = "topic-4";
@@ -421,7 +418,11 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                     /* isReadOnly= */ false,
                     /* isSensitive= */ false,
                     ConfigSource.DYNAMIC_TOPIC_CONFIG,
-                    /* synonyms= */ emptyList()));
+                    Arrays.asList(
+                        new ConfigSynonymData(
+                            "cleanup.policy", "compact", ConfigSource.DYNAMIC_TOPIC_CONFIG),
+                        new ConfigSynonymData(
+                            "log.cleanup.policy", "delete", ConfigSource.DEFAULT_CONFIG))));
 
     Response existingGetTopicConfigResponse =
         request(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.resources.v2;
 
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -29,6 +30,7 @@ import io.confluent.kafkarest.TestUtils;
 import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.controllers.TopicConfigManager;
 import io.confluent.kafkarest.controllers.TopicManager;
+import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
@@ -318,7 +320,9 @@ public class TopicsResourceTest
           "value-1",
           /* isDefault= */ true,
           /* isReadOnly= */ false,
-          /* isSensitive= */ false);
+          /* isSensitive= */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_2 =
       new TopicConfig(
           CLUSTER_ID,
@@ -327,7 +331,9 @@ public class TopicsResourceTest
           "value-2",
           /* isDefault= */ false,
           /* isReadOnly= */ true,
-          /* isSensitive= */ false);
+          /* isSensitive= */ false,
+          ConfigSource.DYNAMIC_TOPIC_CONFIG,
+          /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_3 =
       new TopicConfig(
           CLUSTER_ID,
@@ -336,7 +342,9 @@ public class TopicsResourceTest
           null,
           /* isDefault= */ false,
           /* isReadOnly= */ false,
-          /* isSensitive= */ true);
+          /* isSensitive= */ true,
+          ConfigSource.DYNAMIC_TOPIC_CONFIG,
+          /* synonyms= */ emptyList());
 
   @Rule
   public final EasyMockRule mocks = new EasyMockRule(this);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigsResourceTest.java
@@ -16,6 +16,7 @@
 package io.confluent.kafkarest.resources.v3;
 
 import static io.confluent.kafkarest.common.CompletableFutures.failedFuture;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -24,8 +25,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.kafkarest.controllers.TopicConfigManager;
+import io.confluent.kafkarest.entities.ConfigSource;
 import io.confluent.kafkarest.entities.TopicConfig;
 import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
 import io.confluent.kafkarest.entities.v3.GetTopicConfigResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicConfigsResponse;
 import io.confluent.kafkarest.entities.v3.ResourceLink;
@@ -36,6 +39,7 @@ import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
 import org.easymock.EasyMockRule;
 import org.easymock.Mock;
@@ -59,7 +63,9 @@ public class TopicConfigsResourceTest {
           "value-1",
           /* isDefault= */ true,
           /* isReadOnly= */ false,
-          /* isSensitive= */ false);
+          /* isSensitive= */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_2 =
       new TopicConfig(
           CLUSTER_ID,
@@ -68,7 +74,9 @@ public class TopicConfigsResourceTest {
           "value-2",
           /* isDefault= */ false,
           /* isReadOnly= */ true,
-          /* isSensitive= */ false);
+          /* isSensitive= */ false,
+          ConfigSource.DYNAMIC_TOPIC_CONFIG,
+          /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_3 =
       new TopicConfig(
           CLUSTER_ID,
@@ -77,7 +85,9 @@ public class TopicConfigsResourceTest {
           null,
           /* isDefault= */ false,
           /* isReadOnly= */ false,
-          /* isSensitive= */ true);
+          /* isSensitive= */ true,
+          ConfigSource.DYNAMIC_TOPIC_CONFIG,
+          /* synonyms= */ emptyList());
 
   @Rule
   public final EasyMockRule mocks = new EasyMockRule(this);
@@ -120,7 +130,11 @@ public class TopicConfigsResourceTest {
                     CONFIG_1.getValue(),
                     CONFIG_1.isDefault(),
                     CONFIG_1.isReadOnly(),
-                    CONFIG_1.isSensitive()),
+                    CONFIG_1.isSensitive(),
+                    CONFIG_1.getSource(),
+                    CONFIG_1.getSynonyms().stream()
+                        .map(ConfigSynonymData::fromConfigSynonym)
+                        .collect(Collectors.toList())),
                 new TopicConfigData(
                     "crn:///kafka=cluster-1/topic=topic-1/config=config-2",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/configs/config-2"),
@@ -130,7 +144,11 @@ public class TopicConfigsResourceTest {
                     CONFIG_2.getValue(),
                     CONFIG_2.isDefault(),
                     CONFIG_2.isReadOnly(),
-                    CONFIG_2.isSensitive()),
+                    CONFIG_2.isSensitive(),
+                    CONFIG_2.getSource(),
+                    CONFIG_2.getSynonyms().stream()
+                        .map(ConfigSynonymData::fromConfigSynonym)
+                        .collect(Collectors.toList())),
                 new TopicConfigData(
                     "crn:///kafka=cluster-1/topic=topic-1/config=config-3",
                     new ResourceLink("/v3/clusters/cluster-1/topics/topic-1/configs/config-3"),
@@ -140,7 +158,11 @@ public class TopicConfigsResourceTest {
                     CONFIG_3.getValue(),
                     CONFIG_3.isDefault(),
                     CONFIG_3.isReadOnly(),
-                    CONFIG_3.isSensitive())));
+                    CONFIG_3.isSensitive(),
+                    CONFIG_3.getSource(),
+                    CONFIG_3.getSynonyms().stream()
+                        .map(ConfigSynonymData::fromConfigSynonym)
+                        .collect(Collectors.toList()))));
 
     assertEquals(expected, response.getValue());
   }
@@ -179,7 +201,11 @@ public class TopicConfigsResourceTest {
                 CONFIG_1.getValue(),
                 CONFIG_1.isDefault(),
                 CONFIG_1.isReadOnly(),
-                CONFIG_1.isSensitive()));
+                CONFIG_1.isSensitive(),
+                CONFIG_1.getSource(),
+                CONFIG_1.getSynonyms().stream()
+                    .map(ConfigSynonymData::fromConfigSynonym)
+                    .collect(Collectors.toList())));
 
     assertEquals(expected, response.getValue());
   }


### PR DESCRIPTION
This PR adds two fields to broker and topic configs:

Source:

```
"source": "DYNAMIC_TOPIC_CONFIG"
```

Synonyms:

```
"synonyms": [
  {
    "name": "min.insync.replicas",
    "value": "2",
    "source": "DYNAMIC_TOPIC_CONFIG"
  },
  {
    "name": "min.insync.replicas",
    "value": "1",
    "source": "DEFAULT_CONFIG"
  }
]
```