### PR TITLE
Migrate internal entities to Google's Auto-Value.

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils</artifactId>
         </dependency>
@@ -149,6 +153,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>com.google.auto.value</groupId>
+                            <artifactId>auto-value</artifactId>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImpl.java
@@ -67,7 +67,7 @@ final class BrokerConfigManagerImpl implements BrokerConfigManager {
                 config.entries().stream()
                     .map(
                         entry ->
-                            new BrokerConfig(
+                            BrokerConfig.create(
                                 clusterId,
                                 brokerId,
                                 entry.name(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterManagerImpl.java
@@ -60,7 +60,7 @@ final class ClusterManagerImpl implements ClusterManager {
         adminClient.describeCluster(
             new DescribeClusterOptions().includeAuthorizedOperations(false));
 
-    return CompletableFuture.completedFuture(new Cluster.Builder())
+    return CompletableFuture.completedFuture(Cluster.builder())
         .thenCombine(
             KafkaFutures.toCompletableFuture(describeClusterResult.clusterId()),
             (clusterBuilder, clusterId) -> {
@@ -79,7 +79,7 @@ final class ClusterManagerImpl implements ClusterManager {
                 return clusterBuilder;
               }
               return clusterBuilder.setController(
-                  Broker.fromNode(clusterBuilder.getClusterId(), controller));
+                  Broker.fromNode(clusterBuilder.build().getClusterId(), controller));
             })
         .thenCombine(
             KafkaFutures.toCompletableFuture(describeClusterResult.nodes()),
@@ -90,7 +90,7 @@ final class ClusterManagerImpl implements ClusterManager {
               return clusterBuilder.addAllBrokers(
                   nodes.stream()
                       .filter(node -> node != null && !node.isEmpty())
-                      .map(node -> Broker.fromNode(clusterBuilder.getClusterId(), node))
+                      .map(node -> Broker.fromNode(clusterBuilder.build().getClusterId(), node))
                       .collect(Collectors.toList()));
             })
         .thenApply(Cluster.Builder::build);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -115,7 +115,7 @@ final class PartitionManagerImpl implements PartitionManager {
           earliestFuture.thenCombine(
               latestFuture,
               (earliest, latest) ->
-                  new Partition(
+                  Partition.create(
                       partition.getClusterId(),
                       partition.getTopicName(),
                       partition.getPartitionId(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -67,7 +67,7 @@ final class TopicConfigManagerImpl implements TopicConfigManager {
                 config.entries().stream()
                     .map(
                         entry ->
-                            new TopicConfig(
+                            TopicConfig.create(
                                 clusterId,
                                 topicName,
                                 entry.name(),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -139,7 +139,7 @@ final class TopicManagerImpl implements TopicManager {
   }
 
   private static Topic toTopic(String clusterId, TopicDescription topicDescription) {
-    return new Topic(
+    return Topic.create(
         clusterId,
         topicDescription.name(),
         topicDescription.partitions().stream()
@@ -155,7 +155,7 @@ final class TopicManagerImpl implements TopicManager {
     List<PartitionReplica> replicas = new ArrayList<>();
     for (Node replica : partitionInfo.replicas()) {
       replicas.add(
-          new PartitionReplica(
+          PartitionReplica.create(
               clusterId,
               topicName,
               partitionInfo.partition(),
@@ -163,7 +163,7 @@ final class TopicManagerImpl implements TopicManager {
               partitionInfo.leader().equals(replica),
               inSyncReplicas.contains(replica)));
     }
-    return new Partition(clusterId, topicName, partitionInfo.partition(), replicas);
+    return Partition.create(clusterId, topicName, partitionInfo.partition(), replicas);
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
@@ -15,11 +15,7 @@
 
 package io.confluent.kafkarest.entities;
 
-import static java.util.Collections.unmodifiableList;
-import static java.util.Objects.requireNonNull;
-
-import java.util.List;
-import java.util.Objects;
+import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 
 /**
@@ -27,102 +23,23 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractConfig {
 
-  private final String clusterId;
+  AbstractConfig() {
+  }
 
-  private final String name;
+  public abstract String getClusterId();
+
+  public abstract String getName();
 
   @Nullable
-  private final String value;
+  public abstract String getValue();
 
-  private final boolean isDefault;
+  public abstract boolean isDefault();
 
-  private final boolean isReadOnly;
+  public abstract boolean isReadOnly();
 
-  private final boolean isSensitive;
+  public abstract boolean isSensitive();
 
-  private final ConfigSource source;
+  public abstract ConfigSource getSource();
 
-  private final List<ConfigSynonym> synonyms;
-
-  AbstractConfig(
-      String clusterId,
-      String name,
-      @Nullable String value,
-      boolean isDefault,
-      boolean isReadOnly,
-      boolean isSensitive,
-      ConfigSource source,
-      List<ConfigSynonym> synonyms) {
-    this.clusterId = requireNonNull(clusterId);
-    this.name = requireNonNull(name);
-    this.value = value;
-    this.isDefault = isDefault;
-    this.isReadOnly = isReadOnly;
-    this.isSensitive = isSensitive;
-    this.source = requireNonNull(source);
-    this.synonyms = requireNonNull(synonyms);
-  }
-
-  public final String getClusterId() {
-    return clusterId;
-  }
-
-  public final String getName() {
-    return name;
-  }
-
-  @Nullable
-  public final String getValue() {
-    return value;
-  }
-
-  public final boolean isDefault() {
-    return isDefault;
-  }
-
-  public final boolean isReadOnly() {
-    return isReadOnly;
-  }
-
-  public final boolean isSensitive() {
-    return isSensitive;
-  }
-
-  public final ConfigSource getSource() {
-    return source;
-  }
-
-  public final List<ConfigSynonym> getSynonyms() {
-    return unmodifiableList(synonyms);
-  }
-
-  // CHECKSTYLE:OFF:CyclomaticComplexity
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    AbstractConfig that = (AbstractConfig) o;
-    return clusterId.equals(that.clusterId)
-        && name.equals(that.name)
-        && Objects.equals(value, that.value)
-        && isDefault == that.isDefault
-        && isReadOnly == that.isReadOnly
-        && isSensitive == that.isSensitive
-        && source.equals(that.source)
-        && synonyms.equals(that.synonyms);
-  }
-  // CHECKSTYLE:ON:CyclomaticComplexity
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        clusterId, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
-  }
-
-  @Override
-  public abstract String toString();
+  public abstract ImmutableList<ConfigSynonym> getSynonyms();
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Broker.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Broker.java
@@ -15,103 +15,47 @@
 
 package io.confluent.kafkarest.entities;
 
-import java.util.Objects;
-import java.util.StringJoiner;
+import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 import org.apache.kafka.common.Node;
 
 /**
  * A Kafka broker.
  */
-public final class Broker {
+@AutoValue
+public abstract class Broker {
 
-  private final String clusterId;
+  Broker() {
+  }
 
-  private final int brokerId;
+  public abstract String getClusterId();
 
-  @Nullable
-  private final String host;
-
-  @Nullable
-  private final Integer port;
+  public abstract int getBrokerId();
 
   @Nullable
-  private final String rack;
+  public abstract String getHost();
 
-  public Broker(
+  @Nullable
+  public abstract Integer getPort();
+
+  @Nullable
+  public abstract String getRack();
+
+  public static Broker create(
       String clusterId,
       int brokerId,
       @Nullable String host,
       @Nullable Integer port,
       @Nullable String rack) {
-    this.clusterId = clusterId;
-    this.brokerId = brokerId;
-    this.host = host;
-    this.port = port;
-    this.rack = rack;
-  }
-
-  public String getClusterId() {
-    return clusterId;
-  }
-
-  public int getBrokerId() {
-    return brokerId;
-  }
-
-  @Nullable
-  public String getHost() {
-    return host;
-  }
-
-  @Nullable
-  public Integer getPort() {
-    return port;
-  }
-
-  @Nullable
-  public String getRack() {
-    return rack;
+    return new AutoValue_Broker(clusterId, brokerId, host, port, rack);
   }
 
   public static Broker fromNode(String clusterId, Node node) {
-    return new Broker(
+    return create(
         clusterId,
         node.id(),
         !node.host().equals("") ? node.host() : null,
         node.port() != -1 ? node.port() : null,
         node.rack());
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Broker broker = (Broker) o;
-    return Objects.equals(clusterId, broker.clusterId)
-        && brokerId == broker.brokerId
-        && Objects.equals(host, broker.host)
-        && Objects.equals(port, broker.port)
-        && Objects.equals(rack, broker.rack);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(clusterId, brokerId, host, port, rack);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", Broker.class.getSimpleName() + "[", "]")
-        .add("clusterId=" + clusterId)
-        .add("brokerId=" + brokerId)
-        .add("host='" + host + "'")
-        .add("port=" + port)
-        .add("rack='" + rack + "'")
-        .toString();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/BrokerConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/BrokerConfig.java
@@ -15,19 +15,23 @@
 
 package io.confluent.kafkarest.entities;
 
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Objects;
-import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
  * A Kafka Broker Config
  */
-public final class BrokerConfig extends AbstractConfig {
+@AutoValue
+public abstract class BrokerConfig extends AbstractConfig {
 
-  private final int brokerId;
+  BrokerConfig() {
+  }
 
-  public BrokerConfig(
+  public abstract int getBrokerId();
+
+  public static BrokerConfig create(
       String clusterId,
       int brokerId,
       String name,
@@ -37,35 +41,15 @@ public final class BrokerConfig extends AbstractConfig {
       boolean isSensitive,
       ConfigSource source,
       List<ConfigSynonym> synonyms) {
-    super(clusterId, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
-    this.brokerId = brokerId;
-  }
-
-  public int getBrokerId() {
-    return brokerId;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    return super.equals(o) && brokerId == ((BrokerConfig) o).brokerId;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), brokerId);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", BrokerConfig.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + getClusterId() + "'")
-        .add("brokerId=" + brokerId)
-        .add("name='" + getName() + "'")
-        .add("value='" + getValue() + "'")
-        .add("isDefault=" + isDefault())
-        .add("isSensitive=" + isSensitive())
-        .add("source=" + getSource())
-        .add("synonyms=" + getSynonyms())
-        .toString();
+    return new AutoValue_BrokerConfig(
+        clusterId,
+        name,
+        value,
+        isDefault,
+        isReadOnly,
+        isSensitive,
+        source,
+        ImmutableList.copyOf(synonyms),
+        brokerId);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Cluster.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Cluster.java
@@ -15,48 +15,29 @@
 
 package io.confluent.kafkarest.entities;
 
-import static java.util.Collections.unmodifiableList;
-
-import java.util.ArrayList;
-import java.util.Collection;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Objects;
-import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
  * A Kafka cluster.
  */
-public final class Cluster {
+@AutoValue
+public abstract class Cluster {
 
-  private final String clusterId;
+  Cluster() {
+  }
+
+  public abstract String getClusterId();
 
   @Nullable
-  private final Broker controller;
+  public abstract Broker getController();
 
-  private final List<Broker> brokers;
-
-  public Cluster(String clusterId, @Nullable Broker controller, List<Broker> brokers) {
-    this.clusterId = Objects.requireNonNull(clusterId);
-    this.controller = controller;
-    this.brokers = unmodifiableList(brokers);
-  }
-
-  public String getClusterId() {
-    return clusterId;
-  }
-
-  @Nullable
-  public Broker getController() {
-    return controller;
-  }
-
-  public List<Broker> getBrokers() {
-    return brokers;
-  }
+  public abstract ImmutableList<Broker> getBrokers();
 
   public static Builder builder() {
-    return new Builder();
+    return new AutoValue_Cluster.Builder();
   }
 
   public static Cluster create(
@@ -68,69 +49,23 @@ public final class Cluster {
         .build();
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Cluster cluster = (Cluster) o;
-    return clusterId.equals(cluster.clusterId)
-        && Objects.equals(controller, cluster.controller)
-        && brokers.equals(cluster.brokers);
-  }
+  @AutoValue.Builder
+  public abstract static class Builder {
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(clusterId, controller, brokers);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", Cluster.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + clusterId + "'")
-        .add("controller=" + controller)
-        .add("brokers=" + brokers)
-        .toString();
-  }
-
-  public static final class Builder {
-
-    @Nullable
-    private String clusterId;
-
-    @Nullable
-    private Broker controller;
-
-    private final List<Broker> brokers = new ArrayList<>();
-
-    public Builder() {
+    Builder() {
     }
 
-    @Nullable
-    public String getClusterId() {
-      return clusterId;
-    }
+    public abstract Builder setClusterId(String clusterId);
 
-    public Builder setClusterId(String clusterId) {
-      this.clusterId = clusterId;
+    public abstract Builder setController(Broker controller);
+
+    abstract ImmutableList.Builder<Broker> brokersBuilder();
+
+    public final Builder addAllBrokers(Iterable<Broker> brokers) {
+      brokersBuilder().addAll(brokers);
       return this;
     }
 
-    public Builder setController(Broker controller) {
-      this.controller = controller;
-      return this;
-    }
-
-    public Builder addAllBrokers(Collection<Broker> brokers) {
-      this.brokers.addAll(brokers);
-      return this;
-    }
-
-    public Cluster build() {
-      return new Cluster(clusterId, controller, brokers);
-    }
+    public abstract Cluster build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSynonym.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSynonym.java
@@ -15,10 +15,7 @@
 
 package io.confluent.kafkarest.entities;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Objects;
-import java.util.StringJoiner;
+import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.admin.ConfigEntry;
 
@@ -30,64 +27,21 @@ import org.apache.kafka.clients.admin.ConfigEntry;
  *      https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">
  *      KIP-226 - Dynamic Broker Configuration</a>
  */
-public final class ConfigSynonym {
+@AutoValue
+public abstract class ConfigSynonym {
 
-  private final String name;
+  ConfigSynonym() {
+  }
+
+  public abstract String getName();
 
   @Nullable
-  private final String value;
+  public abstract String getValue();
 
-  private final ConfigSource source;
-
-  public ConfigSynonym(String name, @Nullable String value, ConfigSource source) {
-    this.name = requireNonNull(name);
-    this.value = value;
-    this.source = requireNonNull(source);
-  }
+  public abstract ConfigSource getSource();
 
   public static ConfigSynonym fromAdminConfigSynonym(ConfigEntry.ConfigSynonym synonym) {
-    return new ConfigSynonym(
+    return new AutoValue_ConfigSynonym(
         synonym.name(), synonym.value(), ConfigSource.fromAdminConfigSource(synonym.source()));
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  @Nullable
-  public String getValue() {
-    return value;
-  }
-
-  public ConfigSource getSource() {
-    return source;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ConfigSynonym synonym = (ConfigSynonym) o;
-    return name.equals(synonym.name)
-        && Objects.equals(value, synonym.value)
-        && source == synonym.source;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(name, value, source);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", ConfigSynonym.class.getSimpleName() + "[", "]")
-        .add("name='" + name + "'")
-        .add("value='" + value + "'")
-        .add("source=" + source)
-        .toString();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerInstanceConfig.java
@@ -15,36 +15,52 @@
 
 package io.confluent.kafkarest.entities;
 
+import com.google.auto.value.AutoValue;
 import io.confluent.kafkarest.KafkaRestConfig;
-import java.util.Objects;
 import java.util.Properties;
-import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
-public final class ConsumerInstanceConfig {
+@AutoValue
+public abstract class ConsumerInstanceConfig {
+
+  ConsumerInstanceConfig() {
+  }
 
   @Nullable
-  private final String id;
+  public abstract String getId();
 
   @Nullable
-  private final String name;
+  public abstract String getName();
 
-  private final EmbeddedFormat format;
-
-  @Nullable
-  private final String autoOffsetReset;
+  public abstract EmbeddedFormat getFormat();
 
   @Nullable
-  private final String autoCommitEnable;
+  public abstract String getAutoOffsetReset();
 
   @Nullable
-  private final Integer responseMinBytes;
+  public abstract String getAutoCommitEnable();
 
   @Nullable
-  private final Integer requestWaitMs;
+  public abstract Integer getResponseMinBytes();
 
-  public ConsumerInstanceConfig(EmbeddedFormat format) {
-    this(
+  @Nullable
+  public abstract Integer getRequestWaitMs();
+
+  public final Properties toProperties() {
+    Properties properties = new Properties();
+    if (getResponseMinBytes() != null) {
+      properties.setProperty(
+          KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, getResponseMinBytes().toString());
+    }
+    if (getRequestWaitMs() != null) {
+      properties.setProperty(
+          KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, getRequestWaitMs().toString());
+    }
+    return properties;
+  }
+
+  public static ConsumerInstanceConfig create(EmbeddedFormat format) {
+    return create(
         /* id= */ null,
         /* name= */ null,
         format,
@@ -54,7 +70,7 @@ public final class ConsumerInstanceConfig {
         /* requestWaitMs= */ null);
   }
 
-  public ConsumerInstanceConfig(
+  public static ConsumerInstanceConfig create(
       @Nullable String id,
       @Nullable String name,
       EmbeddedFormat format,
@@ -63,96 +79,7 @@ public final class ConsumerInstanceConfig {
       @Nullable Integer responseMinBytes,
       @Nullable Integer requestWaitMs
   ) {
-    this.id = id;
-    this.name = name;
-    this.format = Objects.requireNonNull(format);
-    this.responseMinBytes = responseMinBytes;
-    this.requestWaitMs = requestWaitMs;
-    this.autoOffsetReset = autoOffsetReset;
-    this.autoCommitEnable = autoCommitEnable;
-  }
-
-  @Nullable
-  public String getId() {
-    return id;
-  }
-
-  @Nullable
-  public String getName() {
-    return name;
-  }
-
-  public EmbeddedFormat getFormat() {
-    return format;
-  }
-
-  @Nullable
-  public String getAutoOffsetReset() {
-    return autoOffsetReset;
-  }
-
-  @Nullable
-  public String getAutoCommitEnable() {
-    return autoCommitEnable;
-  }
-
-  @Nullable
-  public Integer getResponseMinBytes() {
-    return this.responseMinBytes;
-  }
-
-  @Nullable
-  public Integer getRequestWaitMs() {
-    return this.requestWaitMs;
-  }
-
-  public Properties toProperties() {
-    Properties properties = new Properties();
-    if (responseMinBytes != null) {
-      properties.setProperty(
-          KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, responseMinBytes.toString());
-    }
-    if (requestWaitMs != null) {
-      properties.setProperty(
-          KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, requestWaitMs.toString());
-    }
-    return properties;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ConsumerInstanceConfig that = (ConsumerInstanceConfig) o;
-    return Objects.equals(id, that.id)
-        && Objects.equals(name, that.name)
-        && format == that.format
-        && Objects.equals(autoOffsetReset, that.autoOffsetReset)
-        && Objects.equals(autoCommitEnable, that.autoCommitEnable)
-        && Objects.equals(responseMinBytes, that.responseMinBytes)
-        && Objects.equals(requestWaitMs, that.requestWaitMs);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
+    return new AutoValue_ConsumerInstanceConfig(
         id, name, format, autoOffsetReset, autoCommitEnable, responseMinBytes, requestWaitMs);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", ConsumerInstanceConfig.class.getSimpleName() + "[", "]")
-        .add("id='" + id + "'")
-        .add("name='" + name + "'")
-        .add("format=" + format)
-        .add("autoOffsetReset='" + autoOffsetReset + "'")
-        .add("autoCommitEnable='" + autoCommitEnable + "'")
-        .add("responseMinBytes=" + responseMinBytes)
-        .add("requestWaitMs=" + requestWaitMs)
-        .toString();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerRecord.java
@@ -15,106 +15,29 @@
 
 package io.confluent.kafkarest.entities;
 
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.StringJoiner;
+import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
-public final class ConsumerRecord<K, V> {
+@AutoValue
+public abstract class ConsumerRecord<K, V> {
 
-  private final String topic;
+  ConsumerRecord() {
+  }
+
+  public abstract String getTopic();
 
   @Nullable
-  private final K key;
+  public abstract K getKey();
 
   @Nullable
-  private final V value;
+  public abstract V getValue();
 
-  private final int partition;
+  public abstract int getPartition();
 
-  private final long offset;
+  public abstract long getOffset();
 
-  public ConsumerRecord(
+  public static <K, V> ConsumerRecord<K, V> create(
       String topic, @Nullable K key, @Nullable V value, int partition, long offset) {
-    this.topic = Objects.requireNonNull(topic);
-    this.key = key;
-    this.value = value;
-    this.partition = partition;
-    this.offset = offset;
-  }
-
-  public String getTopic() {
-    return topic;
-  }
-
-  @Nullable
-  public K getKey() {
-    return key;
-  }
-
-  @Nullable
-  public V getValue() {
-    return value;
-  }
-
-  public int getPartition() {
-    return partition;
-  }
-
-  public long getOffset() {
-    return offset;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ConsumerRecord<?, ?> that = (ConsumerRecord<?, ?>) o;
-    return partition == that.partition
-           && offset == that.offset
-           && Objects.equals(topic, that.topic)
-           && genericEquals(key, that.key)
-           && genericEquals(value, that.value);
-  }
-
-  private static boolean genericEquals(Object a, Object b) {
-    // This is required because both K and V can be byte[], and comparing byte[] with Objects#equal
-    // would give the wrong result.
-    if (!(a instanceof byte[] && b instanceof byte[])) {
-      return Objects.equals(a, b);
-    }
-    return Arrays.equals((byte[]) a, (byte[]) b);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = Objects.hash(topic, partition, offset);
-    result = 31 * result + genericHashCode(key);
-    result = 31 * result + genericHashCode(value);
-    return result;
-  }
-
-  private static int genericHashCode(Object a) {
-    // This is required because both K and V can be byte[], and computing hash code of byte[] with
-    // Objects#hashCode would give the wrong result.
-    if (!(a instanceof byte[])) {
-      return Objects.hashCode(a);
-    }
-    return Arrays.hashCode((byte[]) a);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", ConsumerRecord.class.getSimpleName() + "[", "]")
-        .add("topic='" + topic + "'")
-        .add("key=" + key)
-        .add("value=" + value)
-        .add("partition=" + partition)
-        .add("offset=" + offset)
-        .toString();
+    return new AutoValue_ConsumerRecord<>(topic, key, value, partition, offset);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Partition.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Partition.java
@@ -15,36 +15,42 @@
 
 package io.confluent.kafkarest.entities;
 
-import static java.util.Objects.requireNonNull;
-
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
-public final class Partition {
+@AutoValue
+public abstract class Partition {
 
-  private final String clusterId;
+  Partition() {
+  }
 
-  private final String topicName;
+  public abstract String getClusterId();
 
-  private final int partitionId;
+  public abstract String getTopicName();
 
-  private final List<PartitionReplica> replicas;
+  public abstract int getPartitionId();
+
+  public abstract ImmutableList<PartitionReplica> getReplicas();
 
   @Nullable
-  private final Long earliestOffset;
+  public abstract Long getEarliestOffset();
 
   @Nullable
-  private final Long latestOffset;
+  public abstract Long getLatestOffset();
 
-  public Partition(
+  public final Optional<PartitionReplica> getLeader() {
+    return getReplicas().stream().filter(PartitionReplica::isLeader).findAny();
+  }
+
+  public static Partition create(
       String clusterId,
       String topicName,
       int partitionId,
       List<PartitionReplica> replicas) {
-    this(
+    return create(
         clusterId,
         topicName,
         partitionId,
@@ -53,82 +59,19 @@ public final class Partition {
         /* latestOffset= */ null);
   }
 
-  public Partition(
+  public static Partition create(
       String clusterId,
       String topicName,
       int partitionId,
       List<PartitionReplica> replicas,
       @Nullable Long earliestOffset,
       @Nullable Long latestOffset) {
-    this.clusterId = requireNonNull(clusterId);
-    this.topicName = requireNonNull(topicName);
-    this.partitionId = partitionId;
-    this.replicas = requireNonNull(replicas);
-    this.earliestOffset = earliestOffset;
-    this.latestOffset = latestOffset;
-  }
-
-  public String getClusterId() {
-    return clusterId;
-  }
-
-  public String getTopicName() {
-    return topicName;
-  }
-
-  public int getPartitionId() {
-    return partitionId;
-  }
-
-  public List<PartitionReplica> getReplicas() {
-    return replicas;
-  }
-
-  @Nullable
-  public Long getEarliestOffset() {
-    return earliestOffset;
-  }
-
-  @Nullable
-  public Long getLatestOffset() {
-    return latestOffset;
-  }
-
-  public Optional<PartitionReplica> getLeader() {
-    return replicas.stream().filter(PartitionReplica::isLeader).findAny();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Partition partition = (Partition) o;
-    return partitionId == partition.partitionId
-        && clusterId.equals(partition.clusterId)
-        && topicName.equals(partition.topicName)
-        && replicas.equals(partition.replicas)
-        && Objects.equals(earliestOffset, partition.earliestOffset)
-        && Objects.equals(latestOffset, partition.latestOffset);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(clusterId, topicName, partitionId, replicas, earliestOffset, latestOffset);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", Partition.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + clusterId + "'")
-        .add("topicName='" + topicName + "'")
-        .add("partitionId=" + partitionId)
-        .add("replicas=" + replicas)
-        .add("earliestOffset=" + earliestOffset)
-        .add("latestOffset=" + latestOffset)
-        .toString();
+    return new AutoValue_Partition(
+        clusterId,
+        topicName,
+        partitionId,
+        ImmutableList.copyOf(replicas),
+        earliestOffset,
+        latestOffset);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/PartitionReplica.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/PartitionReplica.java
@@ -15,94 +15,34 @@
 
 package io.confluent.kafkarest.entities;
 
-import java.util.Objects;
-import java.util.StringJoiner;
+import com.google.auto.value.AutoValue;
 
-public final class PartitionReplica {
+@AutoValue
+public abstract class PartitionReplica {
 
-  private final String clusterId;
+  PartitionReplica() {
+  }
 
-  private final String topicName;
+  public abstract String getClusterId();
 
-  private final int partitionId;
+  public abstract String getTopicName();
 
-  private final int brokerId;
+  public abstract int getPartitionId();
 
-  private final boolean isLeader;
+  public abstract int getBrokerId();
 
-  private final boolean isInSync;
+  public abstract boolean isLeader();
 
-  public PartitionReplica(
+  public abstract boolean isInSync();
+
+  public static PartitionReplica create(
       String clusterId,
       String topicName,
       int partitionId,
       int brokerId,
       boolean isLeader,
-      boolean isInSync
-  ) {
-    this.clusterId = Objects.requireNonNull(clusterId);
-    this.topicName = Objects.requireNonNull(topicName);
-    this.partitionId = partitionId;
-    this.brokerId = brokerId;
-    this.isLeader = isLeader;
-    this.isInSync = isInSync;
-  }
-
-  public String getClusterId() {
-    return clusterId;
-  }
-
-  public String getTopicName() {
-    return topicName;
-  }
-
-  public int getPartitionId() {
-    return partitionId;
-  }
-
-  public int getBrokerId() {
-    return brokerId;
-  }
-
-  public boolean isLeader() {
-    return isLeader;
-  }
-
-  public boolean isInSync() {
-    return isInSync;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    PartitionReplica that = (PartitionReplica) o;
-    return partitionId == that.partitionId
-        && brokerId == that.brokerId
-        && isLeader == that.isLeader
-        && isInSync == that.isInSync
-        && Objects.equals(clusterId, that.clusterId)
-        && Objects.equals(topicName, that.topicName);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(clusterId, topicName, partitionId, brokerId, isLeader, isInSync);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", PartitionReplica.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + clusterId + "'")
-        .add("topicName='" + topicName + "'")
-        .add("partitionId=" + partitionId)
-        .add("brokerId=" + brokerId)
-        .add("isLeader=" + isLeader)
-        .add("isInSync=" + isInSync)
-        .toString();
+      boolean isInSync) {
+    return new AutoValue_PartitionReplica(
+        clusterId, topicName, partitionId, brokerId, isLeader, isInSync);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ProduceRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ProduceRecord.java
@@ -15,67 +15,26 @@
 
 package io.confluent.kafkarest.entities;
 
-import java.util.Objects;
-import java.util.StringJoiner;
+import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
-public final class ProduceRecord<K, V> {
+@AutoValue
+public abstract class ProduceRecord<K, V> {
 
-  @Nullable
-  private final K key;
-
-  @Nullable
-  private final V value;
-
-  @Nullable
-  private final Integer partition;
-
-  public ProduceRecord(@Nullable K key, @Nullable V value, @Nullable Integer partition) {
-    this.key = key;
-    this.value = value;
-    this.partition = partition;
+  ProduceRecord() {
   }
 
   @Nullable
-  public K getKey() {
-    return key;
-  }
+  public abstract K getKey();
 
   @Nullable
-  public V getValue() {
-    return value;
-  }
+  public abstract V getValue();
 
   @Nullable
-  public Integer getPartition() {
-    return partition;
-  }
+  public abstract Integer getPartition();
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ProduceRecord<?, ?> that = (ProduceRecord<?, ?>) o;
-    return Objects.equals(key, that.key)
-        && Objects.equals(value, that.value)
-        && Objects.equals(partition, that.partition);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(key, value, partition);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", ProduceRecord.class.getSimpleName() + "[", "]")
-        .add("key=" + key)
-        .add("value=" + value)
-        .add("partition=" + partition)
-        .toString();
+  public static <K, V> ProduceRecord<K, V> create(
+      @Nullable K key, @Nullable V value, @Nullable Integer partition) {
+    return new AutoValue_ProduceRecord<>(key, value, partition);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ProduceRequest.java
@@ -15,28 +15,31 @@
 
 package io.confluent.kafkarest.entities;
 
+import com.google.auto.value.AutoValue;
 import java.util.List;
-import java.util.Objects;
-import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
-public final class ProduceRequest<K, V> {
+@AutoValue
+public abstract class ProduceRequest<K, V> {
 
-  private final List<ProduceRecord<K, V>> records;
+  ProduceRequest() {
+  }
 
-  @Nullable
-  private final String keySchema;
-
-  @Nullable
-  private final Integer keySchemaId;
+  public abstract List<ProduceRecord<K, V>> getRecords();
 
   @Nullable
-  private final String valueSchema;
+  public abstract String getKeySchema();
 
   @Nullable
-  private final Integer valueSchemaId;
+  public abstract Integer getKeySchemaId();
 
-  public ProduceRequest(
+  @Nullable
+  public abstract String getValueSchema();
+
+  @Nullable
+  public abstract Integer getValueSchemaId();
+
+  public static <K, V> ProduceRequest<K, V> create(
       List<ProduceRecord<K, V>> records,
       @Nullable String keySchema,
       @Nullable Integer keySchemaId,
@@ -45,66 +48,7 @@ public final class ProduceRequest<K, V> {
     if (records.isEmpty()) {
       throw new IllegalStateException();
     }
-    this.records = records;
-    this.keySchema = keySchema;
-    this.keySchemaId = keySchemaId;
-    this.valueSchema = valueSchema;
-    this.valueSchemaId = valueSchemaId;
-  }
-
-  public List<ProduceRecord<K, V>> getRecords() {
-    return records;
-  }
-
-  @Nullable
-  public String getKeySchema() {
-    return keySchema;
-  }
-
-  @Nullable
-  public Integer getKeySchemaId() {
-    return keySchemaId;
-  }
-
-  @Nullable
-  public String getValueSchema() {
-    return valueSchema;
-  }
-
-  @Nullable
-  public Integer getValueSchemaId() {
-    return valueSchemaId;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ProduceRequest<?, ?> that = (ProduceRequest<?, ?>) o;
-    return Objects.equals(records, that.records)
-        && Objects.equals(keySchema, that.keySchema)
-        && Objects.equals(keySchemaId, that.keySchemaId)
-        && Objects.equals(valueSchema, that.valueSchema)
-        && Objects.equals(valueSchemaId, that.valueSchemaId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(records, keySchema, keySchemaId, valueSchema, valueSchemaId);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", ProduceRequest.class.getSimpleName() + "[", "]")
-        .add("records=" + records)
-        .add("keySchema='" + keySchema + "'")
-        .add("keySchemaId=" + keySchemaId)
-        .add("valueSchema='" + valueSchema + "'")
-        .add("valueSchemaId=" + valueSchemaId)
-        .toString();
+    return new AutoValue_ProduceRequest<>(
+        records, keySchema, keySchemaId, valueSchema, valueSchemaId);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Topic.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Topic.java
@@ -15,87 +15,33 @@
 
 package io.confluent.kafkarest.entities;
 
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Objects;
-import java.util.StringJoiner;
 
-public final class Topic {
+@AutoValue
+public abstract class Topic {
 
-  private final String clusterId;
+  Topic() {
+  }
 
-  private final String name;
+  public abstract String getClusterId();
 
-  private final List<Partition> partitions;
+  public abstract String getName();
 
-  private final short replicationFactor;
+  public abstract ImmutableList<Partition> getPartitions();
 
-  private final boolean isInternal;
+  public abstract short getReplicationFactor();
 
-  public Topic(
+  public abstract boolean isInternal();
+
+  public static Topic create(
       String clusterId,
       String name,
       List<Partition> partitions,
       short replicationFactor,
       boolean isInternal) {
-    if (name.isEmpty()) {
-      throw new IllegalArgumentException();
-    }
-    this.clusterId = Objects.requireNonNull(clusterId);
-    this.name = name;
-    this.partitions = Objects.requireNonNull(partitions);
-    this.replicationFactor = replicationFactor;
-    this.isInternal = isInternal;
-  }
-
-  public String getClusterId() {
-    return clusterId;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public List<Partition> getPartitions() {
-    return partitions;
-  }
-
-  public short getReplicationFactor() {
-    return replicationFactor;
-  }
-
-  public boolean getIsInternal() {
-    return isInternal;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Topic topic = (Topic) o;
-    return replicationFactor == topic.replicationFactor
-        && isInternal == topic.isInternal
-        && Objects.equals(clusterId, topic.clusterId)
-        && Objects.equals(name, topic.name)
-        && Objects.equals(partitions, topic.partitions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(clusterId, name, partitions, replicationFactor, isInternal);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", Topic.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + clusterId + "'")
-        .add("name='" + name + "'")
-        .add("partitions=" + partitions)
-        .add("replicationFactor=" + replicationFactor)
-        .add("isInternal=" + isInternal)
-        .toString();
+    return new AutoValue_Topic(
+        clusterId, name, ImmutableList.copyOf(partitions), replicationFactor, isInternal);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicConfig.java
@@ -15,21 +15,23 @@
 
 package io.confluent.kafkarest.entities;
 
-import static java.util.Objects.requireNonNull;
-
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Objects;
-import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
  * A Kafka Topic Config.
  */
-public final class TopicConfig extends AbstractConfig {
+@AutoValue
+public abstract class TopicConfig extends AbstractConfig {
 
-  private final String topicName;
+  TopicConfig() {
+  }
 
-  public TopicConfig(
+  public abstract String getTopicName();
+
+  public static TopicConfig create(
       String clusterId,
       String topicName,
       String name,
@@ -39,35 +41,15 @@ public final class TopicConfig extends AbstractConfig {
       boolean isSensitive,
       ConfigSource source,
       List<ConfigSynonym> synonyms) {
-    super(clusterId, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
-    this.topicName = requireNonNull(topicName);
-  }
-
-  public String getTopicName() {
-    return topicName;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    return super.equals(o) && topicName.equals(((TopicConfig) o).topicName);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), topicName);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", TopicConfig.class.getSimpleName() + "[", "]")
-        .add("clusterId='" + getClusterId() + "'")
-        .add("topicName=" + topicName)
-        .add("name='" + getName() + "'")
-        .add("value='" + getValue() + "'")
-        .add("isDefault=" + isDefault())
-        .add("isSensitive=" + isSensitive())
-        .add("source=" + getSource())
-        .add("synonyms=" + getSynonyms())
-        .toString();
+    return new AutoValue_TopicConfig(
+        clusterId,
+        name,
+        value,
+        isDefault,
+        isReadOnly,
+        isSensitive,
+        source,
+        ImmutableList.copyOf(synonyms),
+        topicName);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicPartitionOffset.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/TopicPartitionOffset.java
@@ -15,72 +15,27 @@
 
 package io.confluent.kafkarest.entities;
 
-import java.util.Objects;
-import java.util.StringJoiner;
+import com.google.auto.value.AutoValue;
 
-public final class TopicPartitionOffset {
+@AutoValue
+public abstract class TopicPartitionOffset {
 
-  private final String topic;
+  TopicPartitionOffset() {
+  }
 
-  private final int partition;
+  public abstract String getTopic();
 
-  private final long consumed;
+  public abstract int getPartition();
 
-  private final long committed;
+  public abstract long getConsumed();
 
-  public TopicPartitionOffset(String topic, int partition, long consumed, long committed) {
+  public abstract long getCommitted();
+
+  public static TopicPartitionOffset create(
+      String topic, int partition, long consumed, long committed) {
     if (topic.isEmpty()) {
       throw new IllegalArgumentException();
     }
-    this.topic = topic;
-    this.partition = partition;
-    this.consumed = consumed;
-    this.committed = committed;
-  }
-
-  public String getTopic() {
-    return topic;
-  }
-
-  public int getPartition() {
-    return partition;
-  }
-
-  public long getConsumed() {
-    return consumed;
-  }
-
-  public long getCommitted() {
-    return committed;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    TopicPartitionOffset that = (TopicPartitionOffset) o;
-    return partition == that.partition
-        && consumed == that.consumed
-        && committed == that.committed
-        && Objects.equals(topic, that.topic);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(topic, partition, consumed, committed);
-  }
-
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", TopicPartitionOffset.class.getSimpleName() + "[", "]")
-        .add("topic='" + topic + "'")
-        .add("partition=" + partition)
-        .add("consumed=" + consumed)
-        .add("committed=" + committed)
-        .toString();
+    return new AutoValue_TopicPartitionOffset(topic, partition, consumed, committed);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/BinaryConsumerRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/BinaryConsumerRecord.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.entities.v2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.protobuf.ByteString;
 import io.confluent.kafkarest.entities.ConsumerRecord;
 import io.confluent.kafkarest.entities.EntityUtils;
 import java.util.Arrays;
@@ -91,7 +92,7 @@ public final class BinaryConsumerRecord {
   }
 
   public static BinaryConsumerRecord fromConsumerRecord(
-      ConsumerRecord<byte[], byte[]> record) {
+      ConsumerRecord<ByteString, ByteString> record) {
     if (record.getPartition() < 0) {
       throw new IllegalArgumentException();
     }
@@ -100,13 +101,13 @@ public final class BinaryConsumerRecord {
     }
     return new BinaryConsumerRecord(
         Objects.requireNonNull(record.getTopic()),
-        record.getKey(),
-        record.getValue(),
+        record.getKey() != null ? record.getKey().toByteArray() : null,
+        record.getValue() != null ? record.getValue().toByteArray() : null,
         record.getPartition(),
         record.getOffset());
   }
 
-  public ConsumerRecord<byte[], byte[]> toConsumerRecord() {
+  public ConsumerRecord<ByteString, ByteString> toConsumerRecord() {
     if (topic == null) {
       throw new IllegalStateException();
     }
@@ -116,7 +117,12 @@ public final class BinaryConsumerRecord {
     if (offset == null || offset < 0) {
       throw new IllegalStateException();
     }
-    return new ConsumerRecord<>(topic, key, value, partition, offset);
+    return ConsumerRecord.create(
+        topic,
+        key != null ? ByteString.copyFrom(key) : null,
+        value != null ? ByteString.copyFrom(value) : null,
+        partition,
+        offset);
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/BinaryPartitionProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/BinaryPartitionProduceRequest.java
@@ -68,9 +68,9 @@ public final class BinaryPartitionProduceRequest {
     if (records == null || records.isEmpty()) {
       throw new IllegalStateException();
     }
-    return new ProduceRequest<>(
+    return ProduceRequest.create(
         records.stream()
-            .map(record -> new ProduceRecord<>(record.key, record.value, null))
+            .map(record -> ProduceRecord.create(record.key, record.value, null))
             .collect(Collectors.toList()),
         /* keySchema= */ null,
         /* keySchemaId= */ null,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/BinaryTopicProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/BinaryTopicProduceRequest.java
@@ -69,9 +69,9 @@ public final class BinaryTopicProduceRequest {
     if (records == null || records.isEmpty()) {
       throw new IllegalStateException();
     }
-    return new ProduceRequest<>(
+    return ProduceRequest.create(
         records.stream()
-            .map(record -> new ProduceRecord<>(record.key, record.value, record.partition))
+            .map(record -> ProduceRecord.create(record.key, record.value, record.partition))
             .collect(Collectors.toList()),
         /* keySchema= */ null,
         /* keySchemaId= */ null,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/CreateConsumerInstanceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/CreateConsumerInstanceRequest.java
@@ -155,7 +155,7 @@ public final class CreateConsumerInstanceRequest {
   }
 
   public ConsumerInstanceConfig toConsumerInstanceConfig() {
-    return new ConsumerInstanceConfig(
+    return ConsumerInstanceConfig.create(
         id,
         name,
         format,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/JsonConsumerRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/JsonConsumerRecord.java
@@ -113,7 +113,7 @@ public final class JsonConsumerRecord {
     if (offset == null || offset < 0) {
       throw new IllegalStateException();
     }
-    return new ConsumerRecord<>(topic, key, value, partition, offset);
+    return ConsumerRecord.create(topic, key, value, partition, offset);
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/JsonPartitionProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/JsonPartitionProduceRequest.java
@@ -65,9 +65,9 @@ public final class JsonPartitionProduceRequest {
     if (records == null || records.isEmpty()) {
       throw new IllegalStateException();
     }
-    return new ProduceRequest<>(
+    return ProduceRequest.create(
         records.stream()
-            .map(record -> new ProduceRecord<>(record.key, record.value, null))
+            .map(record -> ProduceRecord.create(record.key, record.value, null))
             .collect(Collectors.toList()),
         /* keySchema= */ null,
         /* keySchemaId= */ null,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/JsonTopicProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/JsonTopicProduceRequest.java
@@ -66,9 +66,9 @@ public final class JsonTopicProduceRequest {
     if (records == null || records.isEmpty()) {
       throw new IllegalStateException();
     }
-    return new ProduceRequest<>(
+    return ProduceRequest.create(
         records.stream()
-            .map(record -> new ProduceRecord<>(record.key, record.value, record.partition))
+            .map(record -> ProduceRecord.create(record.key, record.value, record.partition))
             .collect(Collectors.toList()),
         /* keySchema= */ null,
         /* keySchemaId= */ null,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/SchemaConsumerRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/SchemaConsumerRecord.java
@@ -114,7 +114,7 @@ public final class SchemaConsumerRecord {
     if (offset == null || offset < 0) {
       throw new IllegalStateException();
     }
-    return new ConsumerRecord<>(topic, key, value, partition, offset);
+    return ConsumerRecord.create(topic, key, value, partition, offset);
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/SchemaPartitionProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/SchemaPartitionProduceRequest.java
@@ -107,9 +107,9 @@ public final class SchemaPartitionProduceRequest {
     if (records == null || records.isEmpty()) {
       throw new IllegalStateException();
     }
-    return new ProduceRequest<>(
+    return ProduceRequest.create(
         records.stream()
-            .map(record -> new ProduceRecord<>(record.key, record.value, null))
+            .map(record -> ProduceRecord.create(record.key, record.value, null))
             .collect(Collectors.toList()),
         keySchema,
         keySchemaId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/SchemaTopicProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v2/SchemaTopicProduceRequest.java
@@ -108,9 +108,9 @@ public final class SchemaTopicProduceRequest {
     if (records == null || records.isEmpty()) {
       throw new IllegalStateException();
     }
-    return new ProduceRequest<>(
+    return ProduceRequest.create(
         records.stream()
-            .map(record -> new ProduceRecord<>(record.key, record.value, record.partition))
+            .map(record -> ProduceRecord.create(record.key, record.value, record.partition))
             .collect(Collectors.toList()),
         keySchema,
         keySchemaId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -123,7 +123,7 @@ public final class TopicsResource {
 
     TopicData topicData =
         toTopicData(
-            new Topic(
+            Topic.create(
                 clusterId,
                 topicName,
                 /* partitions= */ emptyList(),
@@ -184,7 +184,7 @@ public final class TopicsResource {
             urlFactory.create("v3", "clusters", topic.getClusterId(), "topics", topic.getName())),
         topic.getClusterId(),
         topic.getName(),
-        topic.getIsInternal(),
+        topic.isInternal(),
         topic.getReplicationFactor(),
         configs,
         partitions);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/BinaryKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/BinaryKafkaConsumerState.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.v2;
 
+import com.google.protobuf.ByteString;
 import io.confluent.kafkarest.ConsumerInstanceId;
 import io.confluent.kafkarest.ConsumerRecordAndSize;
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -26,7 +27,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  * Binary implementation of KafkaConsumerState that does no decoding, returning the raw bytes
  * directly.
  */
-public class BinaryKafkaConsumerState extends KafkaConsumerState<byte[], byte[], byte[], byte[]> {
+public class BinaryKafkaConsumerState
+    extends KafkaConsumerState<byte[], byte[], ByteString, ByteString> {
 
   public BinaryKafkaConsumerState(KafkaRestConfig config,
       ConsumerInstanceId instanceId,
@@ -35,14 +37,18 @@ public class BinaryKafkaConsumerState extends KafkaConsumerState<byte[], byte[],
   }
 
   @Override
-  public ConsumerRecordAndSize<byte[], byte[]> createConsumerRecord(
+  public ConsumerRecordAndSize<ByteString, ByteString> createConsumerRecord(
       ConsumerRecord<byte[], byte[]> record) {
     long approxSize = (record.key() != null ? record.key().length : 0)
         + (record.value() != null ? record.value().length : 0);
 
-    return new ConsumerRecordAndSize<byte[], byte[]>(
-        new io.confluent.kafkarest.entities.ConsumerRecord<>(
-            record.topic(), record.key(), record.value(), record.partition(), record.offset()),
+    return new ConsumerRecordAndSize<>(
+        io.confluent.kafkarest.entities.ConsumerRecord.create(
+            record.topic(),
+            record.key() != null ? ByteString.copyFrom(record.key()) : null,
+            record.value() != null ? ByteString.copyFrom(record.value()) : null,
+            record.partition(),
+            record.offset()),
         approxSize);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/JsonKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/JsonKafkaConsumerState.java
@@ -56,7 +56,7 @@ public class JsonKafkaConsumerState extends KafkaConsumerState<byte[], byte[], O
     }
 
     return new ConsumerRecordAndSize<>(
-        new io.confluent.kafkarest.entities.ConsumerRecord<>(
+        io.confluent.kafkarest.entities.ConsumerRecord.create(
             record.topic(), key, value, record.partition(), record.offset()), approxSize);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -558,7 +558,7 @@ public class KafkaConsumerManager {
 
   private ConsumerInstanceId createAdminConsumerInstance() {
     String consumerGroup = createAdminConsumerGroup();
-    String consumerInstance = createConsumer(consumerGroup, new ConsumerInstanceConfig(
+    String consumerInstance = createConsumer(consumerGroup, ConsumerInstanceConfig.create(
         EmbeddedFormat.BINARY));
     return new ConsumerInstanceId(consumerGroup, consumerInstance);
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/SchemaKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/SchemaKafkaConsumerState.java
@@ -46,7 +46,7 @@ public final class SchemaKafkaConsumerState
     SchemaConverter.JsonNodeAndSize keyNode = schemaConverter.toJson(record.key());
     SchemaConverter.JsonNodeAndSize valueNode = schemaConverter.toJson(record.value());
     return new ConsumerRecordAndSize<>(
-        new io.confluent.kafkarest.entities.ConsumerRecord<>(
+        io.confluent.kafkarest.entities.ConsumerRecord.create(
             record.topic(),
             keyNode.getJson(),
             valueNode.getJson(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
 import io.confluent.kafkarest.entities.EntityUtils;
 import io.confluent.kafkarest.entities.ProduceRecord;
 import io.confluent.kafkarest.entities.v2.PartitionOffset;
@@ -168,6 +169,8 @@ public class TestUtils {
       return null;
     } else if (k instanceof byte[]) {
       return EntityUtils.encodeBase64Binary((byte[]) k);
+    } else if (k instanceof ByteString) {
+      return EntityUtils.encodeBase64Binary(((ByteString) k).toByteArray());
     } else if (k instanceof JsonNode) {
       return k;
     } else if (k instanceof IndexedRecord) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImplTest.java
@@ -62,10 +62,10 @@ public class BrokerConfigManagerImplTest {
   private static final int BROKER_ID = 1;
 
   private static final Cluster CLUSTER =
-      new Cluster(CLUSTER_ID, null, emptyList());
+      Cluster.create(CLUSTER_ID, null, emptyList());
 
   private static final BrokerConfig CONFIG_1 =
-      new BrokerConfig(
+      BrokerConfig.create(
           CLUSTER_ID,
           BROKER_ID,
           "config-1",
@@ -76,7 +76,7 @@ public class BrokerConfigManagerImplTest {
           ConfigSource.DEFAULT_CONFIG,
           /* synonyms= */ emptyList());
   private static final BrokerConfig CONFIG_2 =
-      new BrokerConfig(
+      BrokerConfig.create(
           CLUSTER_ID,
           BROKER_ID,
           "config-2",
@@ -87,7 +87,7 @@ public class BrokerConfigManagerImplTest {
           ConfigSource.UNKNOWN,
           /* synonyms= */ emptyList());
   private static final BrokerConfig CONFIG_3 =
-      new BrokerConfig(
+      BrokerConfig.create(
           CLUSTER_ID,
           BROKER_ID,
           "config-3",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerManagerImplTest.java
@@ -42,12 +42,12 @@ public class BrokerManagerImplTest {
 
   private static final String CLUSTER_ID = "cluster-1";
 
-  private static final Broker BROKER_1 = new Broker(CLUSTER_ID, 1, "1.0.0.1", 1, null);
-  private static final Broker BROKER_2 = new Broker(CLUSTER_ID, 2, "1.0.0.2", 2, null);
-  private static final Broker BROKER_3 = new Broker(CLUSTER_ID, 2, "1.0.0.3", 3, "rack-3");
+  private static final Broker BROKER_1 = Broker.create(CLUSTER_ID, 1, "1.0.0.1", 1, null);
+  private static final Broker BROKER_2 = Broker.create(CLUSTER_ID, 2, "1.0.0.2", 2, null);
+  private static final Broker BROKER_3 = Broker.create(CLUSTER_ID, 2, "1.0.0.3", 3, "rack-3");
 
   private static final Cluster CLUSTER =
-      new Cluster(CLUSTER_ID, BROKER_1, Arrays.asList(BROKER_1, BROKER_2, BROKER_3));
+      Cluster.create(CLUSTER_ID, BROKER_1, Arrays.asList(BROKER_1, BROKER_2, BROKER_3));
 
   @Rule
   public final EasyMockRule mocks = new EasyMockRule(this);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ClusterManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ClusterManagerImplTest.java
@@ -83,16 +83,16 @@ public class ClusterManagerImplTest {
 
     List<Cluster> expected =
         singletonList(
-            new Cluster(
+            Cluster.create(
                 CLUSTER_ID,
-                new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+                Broker.create(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
                 Arrays.asList(
-                    new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(),
-                        NODE_1.rack()),
-                    new Broker(CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(),
-                        NODE_2.rack()),
-                    new Broker(CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(),
-                        NODE_3.rack()))));
+                    Broker.create(
+                        CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+                    Broker.create(
+                        CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(), NODE_2.rack()),
+                    Broker.create(
+                        CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(), NODE_3.rack()))));
 
     assertEquals(expected, clusters);
   }
@@ -126,16 +126,16 @@ public class ClusterManagerImplTest {
 
     List<Cluster> expected =
         singletonList(
-            new Cluster(
+            Cluster.create(
                 CLUSTER_ID,
                 /* controller= */ null,
                 Arrays.asList(
-                    new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(),
-                        NODE_1.rack()),
-                    new Broker(CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(),
-                        NODE_2.rack()),
-                    new Broker(CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(),
-                        NODE_3.rack()))));
+                    Broker.create(
+                        CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+                    Broker.create(
+                        CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(), NODE_2.rack()),
+                    Broker.create(
+                        CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(), NODE_3.rack()))));
 
     assertEquals(expected, clusters);
   }
@@ -152,7 +152,7 @@ public class ClusterManagerImplTest {
     List<Cluster> clusters = clusterManager.listClusters().get();
 
     List<Cluster> expected =
-        singletonList(new Cluster(CLUSTER_ID, /* controller= */ null, emptyList()));
+        singletonList(Cluster.create(CLUSTER_ID, /* controller= */ null, emptyList()));
 
     assertEquals(expected, clusters);
   }
@@ -187,13 +187,14 @@ public class ClusterManagerImplTest {
     Cluster cluster = clusterManager.getCluster(CLUSTER_ID).get().get();
 
     Cluster expected =
-        new Cluster(
+        Cluster.create(
             CLUSTER_ID,
-            new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+            Broker.create(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
             Arrays.asList(
-                new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
-                new Broker(CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(), NODE_2.rack()),
-                new Broker(CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(), NODE_3.rack())));
+                Broker.create(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+                Broker.create(CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(), NODE_2.rack()),
+                Broker.create(
+                    CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(), NODE_3.rack())));
 
     assertEquals(expected, cluster);
   }
@@ -222,13 +223,14 @@ public class ClusterManagerImplTest {
     Cluster cluster = clusterManager.getLocalCluster().get();
 
     Cluster expected =
-        new Cluster(
+        Cluster.create(
             CLUSTER_ID,
-            new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+            Broker.create(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
             Arrays.asList(
-                new Broker(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
-                new Broker(CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(), NODE_2.rack()),
-                new Broker(CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(), NODE_3.rack())));
+                Broker.create(CLUSTER_ID, NODE_1.id(), NODE_1.host(), NODE_1.port(), NODE_1.rack()),
+                Broker.create(CLUSTER_ID, NODE_2.id(), NODE_2.host(), NODE_2.port(), NODE_2.rack()),
+                Broker.create(
+                    CLUSTER_ID, NODE_3.id(), NODE_3.host(), NODE_3.port(), NODE_3.rack())));
 
     assertEquals(expected, cluster);
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
@@ -52,26 +52,26 @@ public class PartitionManagerImplTest {
   private static final String TOPIC_NAME = "topic-1";
 
   private static final Partition PARTITION_1 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 0,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
                   /* brokerId= */ 1,
                   /* isLeader= */ true,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
                   /* brokerId= */ 2,
                   /* isLeader= */ false,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
@@ -81,26 +81,26 @@ public class PartitionManagerImplTest {
           /* earliestOffset= */ 100L,
           /* latestOffset= */ 1000L);
   private static final Partition PARTITION_2 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 1,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 1,
                   /* brokerId= */ 2,
                   /* isLeader= */ true,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 1,
                   /* brokerId= */ 3,
                   /* isLeader= */ false,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 1,
@@ -110,26 +110,26 @@ public class PartitionManagerImplTest {
           /* earliestOffset= */ 200L,
           /* latestOffset= */ 2000L);
   private static final Partition PARTITION_3 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 2,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 2,
                   /* brokerId= */ 3,
                   /* isLeader= */ true,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 2,
                   /* brokerId= */ 1,
                   /* isLeader= */ false,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 2,
@@ -140,7 +140,7 @@ public class PartitionManagerImplTest {
           /* latestOffset= */ 3000L);
 
   private static final Topic TOPIC =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           TOPIC_NAME,
           Arrays.asList(PARTITION_1, PARTITION_2, PARTITION_3),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ReplicaManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ReplicaManagerImplTest.java
@@ -63,10 +63,10 @@ public class ReplicaManagerImplTest {
   private static final int BROKER_ID_3 = 3;
 
   private static final Broker BROKER_1 =
-      new Broker(CLUSTER_ID, BROKER_ID_1, "1.2.3.4", 5, /* rack= */ null);
+      Broker.create(CLUSTER_ID, BROKER_ID_1, "1.2.3.4", 5, /* rack= */ null);
 
   private static final PartitionReplica REPLICA_1_1 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_1,
@@ -74,7 +74,7 @@ public class ReplicaManagerImplTest {
           /* isLeader= */ true,
           /* isInSync= */ false);
   private static final PartitionReplica REPLICA_1_2 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_1,
@@ -82,7 +82,7 @@ public class ReplicaManagerImplTest {
           /* isLeader= */ false,
           /* isInSync= */ true);
   private static final PartitionReplica REPLICA_1_3 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_1,
@@ -90,7 +90,7 @@ public class ReplicaManagerImplTest {
           /* isLeader= */ false,
           /* isInSync= */ false);
   private static final PartitionReplica REPLICA_2_1 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_2,
@@ -98,7 +98,7 @@ public class ReplicaManagerImplTest {
           /* isLeader= */ false,
           /* isInSync= */ false);
   private static final PartitionReplica REPLICA_2_2 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_2,
@@ -107,13 +107,13 @@ public class ReplicaManagerImplTest {
           /* isInSync= */ true);
 
   private static final Partition PARTITION_1 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_1,
           Arrays.asList(REPLICA_1_1, REPLICA_1_2, REPLICA_1_3));
   private static final Partition PARTITION_2 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID_2,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
@@ -63,10 +63,10 @@ public class TopicConfigManagerImplTest {
   private static final String TOPIC_NAME = "topic-1";
 
   private static final Cluster CLUSTER =
-      new Cluster(CLUSTER_ID, /* controller= */ null, emptyList());
+      Cluster.create(CLUSTER_ID, /* controller= */ null, emptyList());
 
   private static final TopicConfig CONFIG_1 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_NAME,
           "config-1",
@@ -77,7 +77,7 @@ public class TopicConfigManagerImplTest {
           ConfigSource.DEFAULT_CONFIG,
           /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_2 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_NAME,
           "config-2",
@@ -88,7 +88,7 @@ public class TopicConfigManagerImplTest {
           ConfigSource.UNKNOWN,
           /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_3 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_NAME,
           "config-3",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -73,7 +73,7 @@ public class TopicManagerImplTest {
   private static final Broker BROKER_3 = Broker.fromNode(CLUSTER_ID, NODE_3);
 
   private static final Cluster CLUSTER =
-      new Cluster(CLUSTER_ID, BROKER_1, Arrays.asList(BROKER_1, BROKER_2, BROKER_3));
+      Cluster.create(CLUSTER_ID, BROKER_1, Arrays.asList(BROKER_1, BROKER_2, BROKER_3));
 
   private static final List<TopicListing> TOPIC_LISTINGS =
       Arrays.asList(
@@ -121,82 +121,82 @@ public class TopicManagerImplTest {
           /* authorizedOperations= */ new HashSet<>());
 
   private static final Topic TOPIC_1 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-1",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
@@ -207,82 +207,82 @@ public class TopicManagerImplTest {
           /* isInternal= */ true);
 
   private static final Topic TOPIC_2 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-2",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ true,
                           /* isInSync= */ true))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
@@ -293,82 +293,82 @@ public class TopicManagerImplTest {
           /* isInternal= */ true);
 
   private static final Topic TOPIC_3 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-3",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ true,
                           /* isInSync= */ true))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.integration;
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
 import static io.confluent.kafkarest.TestUtils.tryReadEntityOrLog;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 import io.confluent.kafkarest.Errors;
@@ -44,24 +45,34 @@ import scala.collection.JavaConverters;
 public class MetadataAPITest extends ClusterTestHarness {
 
   private static final String topic1Name = "topic1";
-  private static final List<Partition> topic1Partitions = Arrays.asList(
-      new Partition(/* clusterId= */ "", "topic1", 0, Arrays.asList(
-          new PartitionReplica(/* clusterId= */ "", "topic1", 0, 0, true, true),
-          new PartitionReplica(/* clusterId= */ "", "topic1", 0, 1, false, false)
-      ))
-  );
-  private static final Topic topic1 = new Topic("", topic1Name, topic1Partitions, (short) 2, false);
+  private static final List<Partition> topic1Partitions =
+      singletonList(
+          Partition.create(
+              /* clusterId= */ "",
+              "topic1",
+              /* partitionId= */ 0,
+              Arrays.asList(
+                  PartitionReplica.create(/* clusterId= */ "", "topic1", 0, 0, true, true),
+                  PartitionReplica.create(/* clusterId= */ "", "topic1", 0, 1, false, false))));
+  private static final Topic topic1 =
+      Topic.create("", topic1Name, topic1Partitions, (short) 2, false);
   private static final String topic2Name = "topic2";
-  private static final List<Partition> topic2Partitions = Arrays.asList(
-      new Partition(/* clusterId= */ "", "topic2", 0, Arrays.asList(
-          new PartitionReplica(/* clusterId= */ "", "topic2", 0, 0, true, true),
-          new PartitionReplica(/* clusterId= */ "", "topic2", 0, 1, false, false)
-      )),
-      new Partition(/* clusterId= */ "", "topic2", 1, Arrays.asList(
-          new PartitionReplica(/* clusterId= */ "", "topic2", 1, 0, false, true),
-          new PartitionReplica(/* clusterId= */ "", "topic2", 1, 1, true, true)
-      ))
-  );
+  private static final List<Partition> topic2Partitions =
+      Arrays.asList(
+          Partition.create(
+              /* clusterId= */ "",
+              "topic2",
+              /* partitionId= */ 0,
+              Arrays.asList(
+                  PartitionReplica.create(/* clusterId= */ "", "topic2", 0, 0, true, true),
+                  PartitionReplica.create(/* clusterId= */ "", "topic2", 0, 1, false, false))),
+          Partition.create(
+              /* clusterId= */ "",
+              "topic2",
+              /* partitionId= */ 1,
+              Arrays.asList(
+                  PartitionReplica.create(/* clusterId= */ "", "topic2", 1, 0, false, true),
+                  PartitionReplica.create(/* clusterId= */ "", "topic2", 1, 1, true, true))));
   private static final Properties topic2Configs;
 
   static {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
@@ -47,9 +47,9 @@ public class BrokersResourceTest
     extends EmbeddedServerTestHarness<KafkaRestConfig, KafkaRestApplication> {
 
   private static final String CLUSTER_ID = "cluster-1";
-  private static final Broker BROKER_1 = new Broker(CLUSTER_ID, 1, "host1", 1, /* rack= */ null);
-  private static final Broker BROKER_2 = new Broker(CLUSTER_ID, 2, "host2", 2, /* rack= */ null);
-  private static final Broker BROKER_3 = new Broker(CLUSTER_ID, 3, "host3", 3, /* rack= */ null);
+  private static final Broker BROKER_1 = Broker.create(CLUSTER_ID, 1, "host1", 1, /* rack= */ null);
+  private static final Broker BROKER_2 = Broker.create(CLUSTER_ID, 2, "host2", 2, /* rack= */ null);
+  private static final Broker BROKER_3 = Broker.create(CLUSTER_ID, 3, "host3", 3, /* rack= */ null);
 
   @Rule
   public final EasyMockRule mocks = new EasyMockRule(this);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
@@ -55,82 +55,82 @@ public class TopicsResourceTest
   private static final String CLUSTER_ID = "cluster-1";
 
   private static final Topic TOPIC_1 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-1",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
@@ -141,82 +141,82 @@ public class TopicsResourceTest
           /* isInternal= */ true);
 
   private static final Topic TOPIC_2 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-2",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ true,
                           /* isInSync= */ true))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
@@ -227,82 +227,82 @@ public class TopicsResourceTest
           /* isInternal= */ true);
 
   private static final Topic TOPIC_3 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-3",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ true,
                           /* isInSync= */ true))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
@@ -313,7 +313,7 @@ public class TopicsResourceTest
           /* isInternal= */ false);
 
   private static final TopicConfig CONFIG_1 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_1.getName(),
           "config-1",
@@ -324,7 +324,7 @@ public class TopicsResourceTest
           ConfigSource.DEFAULT_CONFIG,
           /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_2 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_1.getName(),
           "config-2",
@@ -335,7 +335,7 @@ public class TopicsResourceTest
           ConfigSource.DYNAMIC_TOPIC_CONFIG,
           /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_3 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_1.getName(),
           "config-3",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokerConfigResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokerConfigResourceTest.java
@@ -41,7 +41,7 @@ public final class BrokerConfigResourceTest {
   private static final int BROKER_ID = 1;
 
   private static final BrokerConfig CONFIG_1 =
-      new BrokerConfig(
+      BrokerConfig.create(
           CLUSTER_ID,
           BROKER_ID,
           "config-1",
@@ -52,7 +52,7 @@ public final class BrokerConfigResourceTest {
           ConfigSource.DEFAULT_CONFIG,
           /* synonyms= */ emptyList());
   private static final BrokerConfig CONFIG_2 =
-      new BrokerConfig(
+      BrokerConfig.create(
           CLUSTER_ID,
           BROKER_ID,
           "config-2",
@@ -63,7 +63,7 @@ public final class BrokerConfigResourceTest {
           ConfigSource.STATIC_BROKER_CONFIG,
           /* synonyms= */ emptyList());
   private static final BrokerConfig CONFIG_3 =
-      new BrokerConfig(
+      BrokerConfig.create(
           CLUSTER_ID,
           BROKER_ID,
           "config-3",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/BrokersResourceTest.java
@@ -47,9 +47,9 @@ import org.junit.runners.JUnit4;
 public final class BrokersResourceTest {
 
   private static final String CLUSTER_ID = "cluster-1";
-  private static final Broker BROKER_1 = new Broker(CLUSTER_ID, 1, "broker-1", 9091, "rack-1");
-  private static final Broker BROKER_2 = new Broker(CLUSTER_ID, 2, "broker-2", 9092, null);
-  private static final Broker BROKER_3 = new Broker(CLUSTER_ID, 3, "broker-3", 9093, null);
+  private static final Broker BROKER_1 = Broker.create(CLUSTER_ID, 1, "broker-1", 9091, "rack-1");
+  private static final Broker BROKER_2 = Broker.create(CLUSTER_ID, 2, "broker-2", 9092, null);
+  private static final Broker BROKER_3 = Broker.create(CLUSTER_ID, 3, "broker-3", 9093, null);
 
   @Rule
   public final EasyMockRule mocks = new EasyMockRule(this);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -49,11 +49,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ClustersResourceTest {
 
-  private static final Broker BROKER_1 = new Broker("cluster-1", 1, "broker-1", 9091, "rack-1");
-  private static final Broker BROKER_2 = new Broker("cluster-1", 2, "broker-2", 9092, null);
-  private static final Broker BROKER_3 = new Broker("cluster-1", 3, "broker-3", 9093, null);
+  private static final Broker BROKER_1 = Broker.create("cluster-1", 1, "broker-1", 9091, "rack-1");
+  private static final Broker BROKER_2 = Broker.create("cluster-1", 2, "broker-2", 9092, null);
+  private static final Broker BROKER_3 = Broker.create("cluster-1", 3, "broker-3", 9093, null);
   private static final Cluster CLUSTER_1 =
-      new Cluster("cluster-1", BROKER_1, Arrays.asList(BROKER_1, BROKER_2, BROKER_3));
+      Cluster.create("cluster-1", BROKER_1, Arrays.asList(BROKER_1, BROKER_2, BROKER_3));
 
   @Rule
   public final EasyMockRule mocks = new EasyMockRule(this);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
@@ -51,26 +51,26 @@ public class PartitionsResourceTest {
   private static final String TOPIC_NAME = "topic-1";
 
   private static final Partition PARTITION_1 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 0,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
                   /* brokerId= */ 1,
                   /* isLeader= */ true,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
                   /* brokerId= */ 2,
                   /* isLeader= */ false,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
@@ -78,26 +78,26 @@ public class PartitionsResourceTest {
                   /* isLeader= */ false,
                   /* isInSync= */ false)));
   private static final Partition PARTITION_2 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 1,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 1,
                   /* brokerId= */ 2,
                   /* isLeader= */ true,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 1,
                   /* brokerId= */ 3,
                   /* isLeader= */ false,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 1,
@@ -105,26 +105,26 @@ public class PartitionsResourceTest {
                   /* isLeader= */ false,
                   /* isInSync= */ false)));
   private static final Partition PARTITION_3 =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 2,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 2,
                   /* brokerId= */ 3,
                   /* isLeader= */ true,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 2,
                   /* brokerId= */ 1,
                   /* isLeader= */ false,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 2,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ReplicasResourceTest.java
@@ -51,7 +51,7 @@ public class ReplicasResourceTest {
   private static final int PARTITION_ID = 0;
 
   private static final PartitionReplica REPLICA_1 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID,
@@ -59,7 +59,7 @@ public class ReplicasResourceTest {
           /* isLeader= */ true,
           /* isInSync= */ true);
   private static final PartitionReplica REPLICA_2 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID,
@@ -67,7 +67,7 @@ public class ReplicasResourceTest {
           /* isLeader= */ false,
           /* isInSync= */ true);
   private static final PartitionReplica REPLICA_3 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           PARTITION_ID,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerActionTest.java
@@ -34,7 +34,7 @@ public class SearchReplicasByBrokerActionTest {
   private static final int BROKER_ID = 1;
 
   private static final PartitionReplica REPLICA_1 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 1,
@@ -42,7 +42,7 @@ public class SearchReplicasByBrokerActionTest {
           /* isLeader= */ true,
           /* isInSync= */ true);
   private static final PartitionReplica REPLICA_2 =
-      new PartitionReplica(
+      PartitionReplica.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 2,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicConfigsResourceTest.java
@@ -56,7 +56,7 @@ public class TopicConfigsResourceTest {
   private static final String TOPIC_NAME = "topic-1";
 
   private static final TopicConfig CONFIG_1 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_NAME,
           "config-1",
@@ -67,7 +67,7 @@ public class TopicConfigsResourceTest {
           ConfigSource.DEFAULT_CONFIG,
           /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_2 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_NAME,
           "config-2",
@@ -78,7 +78,7 @@ public class TopicConfigsResourceTest {
           ConfigSource.DYNAMIC_TOPIC_CONFIG,
           /* synonyms= */ emptyList());
   private static final TopicConfig CONFIG_3 =
-      new TopicConfig(
+      TopicConfig.create(
           CLUSTER_ID,
           TOPIC_NAME,
           "config-3",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -61,82 +61,82 @@ public class TopicsResourceTest {
   private static final String CLUSTER_ID = "cluster-1";
 
   private static final Topic TOPIC_1 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-1",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-1",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-1",
                           /* partitionId= */ 2,
@@ -147,82 +147,82 @@ public class TopicsResourceTest {
           /* isInternal= */ true);
 
   private static final Topic TOPIC_2 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-2",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ true,
                           /* isInSync= */ true))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-2",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-2",
                           /* partitionId= */ 2,
@@ -233,82 +233,82 @@ public class TopicsResourceTest {
           /* isInternal= */ true);
 
   private static final Topic TOPIC_3 =
-      new Topic(
+      Topic.create(
           CLUSTER_ID,
           "topic-3",
           Arrays.asList(
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */ 0,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 2,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 0,
                           /* brokerId= */ 3,
                           /* isLeader= */ false,
                           /* isInSync= */ false))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */ 1,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 1,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 1,
                           /* brokerId= */ 3,
                           /* isLeader= */ true,
                           /* isInSync= */ true))),
-              new Partition(
+              Partition.create(
                   CLUSTER_ID,
                   "topic-3",
                   /* partitionId= */2,
                   Arrays.asList(
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
                           /* brokerId= */ 1,
                           /* isLeader= */ true,
                           /* isInSync= */ true),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,
                           /* brokerId= */ 2,
                           /* isLeader= */ false,
                           /* isInSync= */ false),
-                      new PartitionReplica(
+                      PartitionReplica.create(
                           CLUSTER_ID,
                           "topic-3",
                           /* partitionId= */ 2,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AvroRestProducerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AvroRestProducerTest.java
@@ -65,9 +65,9 @@ public class AvroRestProducerTest {
   @Test(expected= ConstraintViolationException.class)
   public void testInvalidSchema() throws Exception {
     schemaHolder =
-        new ProduceRequest<>(
+        ProduceRequest.create(
             Collections.singletonList(
-                new ProduceRecord<>(mapper.readTree("{}"), mapper.readTree("{}"), null)),
+                ProduceRecord.create(mapper.readTree("{}"), mapper.readTree("{}"), null)),
             /* keySchema= */ null,
             /* keySchemaId= */ null,
             "invalidValueSchema",
@@ -82,9 +82,9 @@ public class AvroRestProducerTest {
   @Test
   public void testInvalidData() throws Exception {
     schemaHolder =
-        new ProduceRequest<>(
+        ProduceRequest.create(
             Collections.singletonList(
-                new ProduceRecord<>(null, mapper.readTree("\"string\""), null)),
+                ProduceRecord.create(null, mapper.readTree("\"string\""), null)),
             /* keySchema= */ null,
             /* keySchemaId= */ null,
             /* valueSchema= */ "\"int\"",
@@ -128,9 +128,9 @@ public class AvroRestProducerTest {
         .andStubReturn(f);
     EasyMock.replay(producer);
     schemaHolder =
-        new ProduceRequest<>(
+        ProduceRequest.create(
             Collections.singletonList(
-                new ProduceRecord<>(null, mapper.readTree("{\"name\": \"bob\"}"), null)),
+                ProduceRecord.create(null, mapper.readTree("{\"name\": \"bob\"}"), null)),
             /* keySchema= */ null,
             /* keySchemaId= */ null,
             valueSchemaStr,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.protobuf.ByteString;
 import io.confluent.kafkarest.ConsumerReadCallback;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.SystemTime;
@@ -31,7 +32,6 @@ import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.kafkarest.entities.v2.ConsumerOffsetCommitRequest;
 import io.confluent.kafkarest.entities.v2.ConsumerSubscriptionRecord;
-import io.confluent.rest.RestConfigException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -77,7 +77,7 @@ public class KafkaConsumerManagerTest {
     // Setup holding vars for results from callback
     private boolean sawCallback = false;
     private static Exception actualException = null;
-    private static List<ConsumerRecord<byte[], byte[]>> actualRecords = null;
+    private static List<ConsumerRecord<ByteString, ByteString>> actualRecords = null;
     private static List<TopicPartitionOffset> actualOffsets = null;
 
     private Capture<Properties> capturedConsumerConfig;
@@ -166,7 +166,7 @@ public class KafkaConsumerManagerTest {
 
         EasyMock.replay(consumerFactory);
 
-        consumerManager.createConsumer(groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+        consumerManager.createConsumer(groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
         // The exclude.internal.topics setting is overridden via the constructor when the
         // ConsumerManager is created, and we can make sure it gets set properly here.
         assertEquals("false", consumerConfig.getValue().get(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG));
@@ -185,7 +185,7 @@ public class KafkaConsumerManagerTest {
 
         expectCreate(consumer);
         String cid = consumerManager.createConsumer(
-            groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+            groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
         consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
 
         readFromDefault(cid);
@@ -211,7 +211,7 @@ public class KafkaConsumerManagerTest {
         schedulePoll();
 
         String cid = consumerManager.createConsumer(
-                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+                groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
         consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
         consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
         consumer.updateBeginningOffsets(singletonMap(new TopicPartition(topicName, 0), 0L));
@@ -241,7 +241,7 @@ public class KafkaConsumerManagerTest {
         expectCreate(consumer);
 
         String cid = consumerManager.createConsumer(
-                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+                groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
         consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
         consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
         consumer.updateBeginningOffsets(singletonMap(new TopicPartition(topicName, 0), 0L));
@@ -260,7 +260,7 @@ public class KafkaConsumerManagerTest {
 
 
         sawCallback = false;
-        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = schedulePoll();
+        final List<ConsumerRecord<ByteString, ByteString>> referenceRecords = schedulePoll();
         readFromDefault(cid);
         Thread.sleep(expectedRequestTimeoutms / 2); // should return in less time
 
@@ -275,21 +275,21 @@ public class KafkaConsumerManagerTest {
      */
     @Test
     public void testConsumerMinAndMaxBytes() throws Exception {
-        ConsumerRecord<byte[], byte[]> sampleRecord = binaryConsumerRecord(0);
-        int sampleRecordSize = sampleRecord.getKey().length + sampleRecord.getValue().length;
+        ConsumerRecord<ByteString, ByteString> sampleRecord = binaryConsumerRecord(0);
+        int sampleRecordSize = sampleRecord.getKey().size() + sampleRecord.getValue().size();
         // we expect all the records from the first poll to be returned
         Properties props = setUpProperties(new Properties());
         props.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, Integer.toString(sampleRecordSize));
         props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG, Integer.toString(sampleRecordSize * 10));
         setUpConsumer(props);
 
-        final List<ConsumerRecord<byte[], byte[]>> scheduledRecords = schedulePoll();
-        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = Arrays.asList(scheduledRecords.get(0), scheduledRecords.get(1), scheduledRecords.get(2));
+        final List<ConsumerRecord<ByteString, ByteString>> scheduledRecords = schedulePoll();
+        final List<ConsumerRecord<ByteString, ByteString>> referenceRecords = Arrays.asList(scheduledRecords.get(0), scheduledRecords.get(1), scheduledRecords.get(2));
         schedulePoll(3);
 
         expectCreate(consumer);
         String cid = consumerManager.createConsumer(
-                groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+                groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
         consumerManager.subscribe(groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
         consumer.rebalance(Collections.singletonList(new TopicPartition(topicName, 0)));
         consumer.updateBeginningOffsets(singletonMap(new TopicPartition(topicName, 0), 0L));
@@ -304,17 +304,17 @@ public class KafkaConsumerManagerTest {
 
     @Test
     public void testConsumeMinBytesIsOverridablePerConsumer() throws Exception {
-        ConsumerRecord<byte[], byte[]> sampleRecord = binaryConsumerRecord(0);
-        int sampleRecordSize = sampleRecord.getKey().length + sampleRecord.getValue().length;
+        ConsumerRecord<ByteString, ByteString> sampleRecord = binaryConsumerRecord(0);
+        int sampleRecordSize = sampleRecord.getKey().size() + sampleRecord.getValue().size();
         Properties props = setUpProperties(new Properties());
         props.setProperty(KafkaRestConfig.PROXY_FETCH_MIN_BYTES_CONFIG, Integer.toString(sampleRecordSize * 5));
         props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG, Integer.toString(sampleRecordSize * 6));
         setUpConsumer(props);
 
-        final List<ConsumerRecord<byte[], byte[]>> scheduledRecords = schedulePoll();
+        final List<ConsumerRecord<ByteString, ByteString>> scheduledRecords = schedulePoll();
         // global settings would make the consumer call poll twice and get more than 3 records,
         // overridden settings should make him poll once since the min bytes will be reached
-        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = Arrays.asList(scheduledRecords.get(0),
+        final List<ConsumerRecord<ByteString, ByteString>> referenceRecords = Arrays.asList(scheduledRecords.get(0),
                 scheduledRecords.get(1),
                 scheduledRecords.get(2));
         schedulePoll(3);
@@ -322,7 +322,7 @@ public class KafkaConsumerManagerTest {
         expectCreate(consumer);
         // we expect three records to be returned since the setting is overridden and poll() wont be called a second time
         ConsumerInstanceConfig config =
-            new ConsumerInstanceConfig(
+            ConsumerInstanceConfig.create(
                 /* id= */ null,
                 /* name= */ null,
                 EmbeddedFormat.BINARY,
@@ -346,7 +346,7 @@ public class KafkaConsumerManagerTest {
 
     @Test
     public void testConsumerNormalOps() throws InterruptedException, ExecutionException {
-        final List<ConsumerRecord<byte[], byte[]>> referenceRecords = bootstrapConsumer(consumer);
+        final List<ConsumerRecord<ByteString, ByteString>> referenceRecords = bootstrapConsumer(consumer);
 
         sawCallback = false;
         actualException = null;
@@ -385,10 +385,10 @@ public class KafkaConsumerManagerTest {
     public void testBackoffMsControlsPollCalls() throws Exception {
         bootstrapConsumer(consumer);
         consumerManager.readRecords(groupName, consumer.cid(), BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
-                new ConsumerReadCallback<byte[], byte[]>() {
+                new ConsumerReadCallback<ByteString, ByteString>() {
                     @Override
                     public void onCompletion(
-                        List<ConsumerRecord<byte[], byte[]>> records, Exception e) {
+                        List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
                         actualException = e;
                         actualRecords = records;
                         sawCallback = true;
@@ -412,10 +412,10 @@ public class KafkaConsumerManagerTest {
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST, groupName);
         bootstrapConsumer(consumer);
         consumerManager.readRecords(groupName, consumer.cid(), BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
-                new ConsumerReadCallback<byte[], byte[]>() {
+                new ConsumerReadCallback<ByteString, ByteString>() {
                     @Override
                     public void onCompletion(
-                        List<ConsumerRecord<byte[], byte[]>> records, Exception e) {
+                        List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
                         actualException = e;
                         actualRecords = records;
                         sawCallback = true;
@@ -438,10 +438,10 @@ public class KafkaConsumerManagerTest {
         KafkaConsumerState state = consumerManager.getConsumerInstance(groupName, consumer.cid());
         long initialExpiration = state.expiration;
         consumerManager.readRecords(groupName, consumer.cid(), BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
-                new ConsumerReadCallback<byte[], byte[]>() {
+                new ConsumerReadCallback<ByteString, ByteString>() {
                     @Override
                     public void onCompletion(
-                        List<ConsumerRecord<byte[], byte[]>> records, Exception e) {
+                        List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
                         actualException = e;
                         actualRecords = records;
                         sawCallback = true;
@@ -489,9 +489,9 @@ public class KafkaConsumerManagerTest {
         bootstrapConsumer(consumer2, false);
         bootstrapConsumer(consumer3, false);
 
-        ConsumerReadCallback callback = new ConsumerReadCallback<byte[], byte[]>() {
+        ConsumerReadCallback callback = new ConsumerReadCallback<ByteString, ByteString>() {
             @Override
-            public void onCompletion(List<ConsumerRecord<byte[], byte[]>> records, Exception e) {
+            public void onCompletion(List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
                 actualException = e;
                 actualRecords = records;
                 sawCallback = true;
@@ -516,19 +516,19 @@ public class KafkaConsumerManagerTest {
         }
     }
 
-    private List<ConsumerRecord<byte[], byte[]>> bootstrapConsumer(final MockConsumer<byte[], byte[]> consumer) {
+    private List<ConsumerRecord<ByteString, ByteString>> bootstrapConsumer(final MockConsumer<byte[], byte[]> consumer) {
         return bootstrapConsumer(consumer, true);
     }
 
     /**
      * Subscribes a consumer to a topic and schedules a poll task
      */
-    private List<ConsumerRecord<byte[], byte[]>> bootstrapConsumer(final MockConsumer<byte[], byte[]> consumer, boolean toExpectCreate) {
-        List<ConsumerRecord<byte[], byte[]>> referenceRecords =
+    private List<ConsumerRecord<ByteString, ByteString>> bootstrapConsumer(final MockConsumer<byte[], byte[]> consumer, boolean toExpectCreate) {
+        List<ConsumerRecord<ByteString, ByteString>> referenceRecords =
             Arrays.asList(
-                new ConsumerRecord<>(topicName, "k1".getBytes(), "v1".getBytes(), 0, 0),
-                new ConsumerRecord<>(topicName, "k2".getBytes(), "v2".getBytes(), 0, 1),
-                new ConsumerRecord<>(topicName, "k3".getBytes(), "v3".getBytes(), 0, 2));
+                ConsumerRecord.create(topicName, ByteString.copyFromUtf8("k1"), ByteString.copyFromUtf8("v1"), 0, 0),
+                ConsumerRecord.create(topicName, ByteString.copyFromUtf8("k2"), ByteString.copyFromUtf8("v2"), 0, 1),
+                ConsumerRecord.create(topicName, ByteString.copyFromUtf8("k3"), ByteString.copyFromUtf8("v3"), 0, 2));
 
         if (toExpectCreate)
             expectCreate(consumer);
@@ -542,7 +542,7 @@ public class KafkaConsumerManagerTest {
         });
 
         String cid = consumerManager.createConsumer(
-                consumer.groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+                consumer.groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
 
         consumer.cid(cid);
         consumerManager.subscribe(consumer.groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
@@ -554,10 +554,10 @@ public class KafkaConsumerManagerTest {
 
     private void readFromDefault(String cid) throws InterruptedException, ExecutionException {
         consumerManager.readRecords(groupName, cid, BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
-            new ConsumerReadCallback<byte[], byte[]>() {
+            new ConsumerReadCallback<ByteString, ByteString>() {
               @Override
               public void onCompletion(
-                  List<ConsumerRecord<byte[], byte[]>> records, Exception e) {
+                  List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
                 actualException = e;
                 actualRecords = records;
                 sawCallback = true;
@@ -565,11 +565,11 @@ public class KafkaConsumerManagerTest {
             });
     }
 
-    private List<ConsumerRecord<byte[], byte[]>> schedulePoll() {
+    private List<ConsumerRecord<ByteString, ByteString>> schedulePoll() {
         return schedulePoll(0);
     }
 
-    private List<ConsumerRecord<byte[], byte[]>> schedulePoll(final int fromOffset) {
+    private List<ConsumerRecord<ByteString, ByteString>> schedulePoll(final int fromOffset) {
         consumer.schedulePollTask(new Runnable() {
           @Override
           public void run() {
@@ -579,17 +579,17 @@ public class KafkaConsumerManagerTest {
           }
         });
         return Arrays.asList(
-            (ConsumerRecord<byte[], byte[]>) binaryConsumerRecord(fromOffset),
+            binaryConsumerRecord(fromOffset),
             binaryConsumerRecord(fromOffset + 1),
             binaryConsumerRecord(fromOffset + 2)
         );
     }
 
-    private ConsumerRecord<byte[], byte[]> binaryConsumerRecord(int offset) {
-        return new ConsumerRecord<>(
+    private ConsumerRecord<ByteString, ByteString> binaryConsumerRecord(int offset) {
+        return ConsumerRecord.create(
                 topicName,
-                String.format("k%d", offset).getBytes(),
-                String.format("v%d", offset).getBytes(),
+                ByteString.copyFromUtf8(String.format("k%d", offset)),
+                ByteString.copyFromUtf8(String.format("v%d", offset)),
                 0,
                 offset
         );

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.ByteString;
 import io.confluent.kafkarest.ConsumerReadCallback;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.Time;
@@ -129,7 +130,7 @@ public class LoadTest {
         void verifyRead() {
             assertTrue("Callback failed to fire", sawCallback);
             assertNull("There shouldn't be an exception in callback", actualException);
-            List<ConsumerRecord<byte[], byte[]>> expectedRecords = referenceRecords();
+            List<ConsumerRecord<ByteString, ByteString>> expectedRecords = referenceRecords();
             assertEquals("Records returned not as expected", expectedRecords, actualRecords);
 
             lock.lock();
@@ -142,14 +143,14 @@ public class LoadTest {
             }
         }
 
-        private List<ConsumerRecord<byte[], byte[]>> referenceRecords() {
+        private List<ConsumerRecord<ByteString, ByteString>> referenceRecords() {
             return Arrays.asList(
-                new ConsumerRecord<>(
-                    topicName, "k1".getBytes(), "v1".getBytes(), 0, latestOffset - 3),
-                new ConsumerRecord<>(
-                    topicName, "k2".getBytes(), "v2".getBytes(), 0, latestOffset - 2),
-                new ConsumerRecord<>(
-                    topicName, "k3".getBytes(), "v3".getBytes(), 0, latestOffset - 1));
+                ConsumerRecord.create(
+                    topicName, ByteString.copyFromUtf8("k1"), ByteString.copyFromUtf8("v1"), 0, latestOffset - 3),
+                ConsumerRecord.create(
+                    topicName, ByteString.copyFromUtf8("k2"), ByteString.copyFromUtf8("v2"), 0, latestOffset - 2),
+                ConsumerRecord.create(
+                    topicName, ByteString.copyFromUtf8("k3"), ByteString.copyFromUtf8("v3"), 0, latestOffset - 1));
         }
 
         private void schedulePoll() {
@@ -211,7 +212,7 @@ public class LoadTest {
 
     private void bootstrapConsumer(final MockConsumer<byte[], byte[]> consumer) {
         String cid = consumerManager.createConsumer(
-                consumer.groupName, new ConsumerInstanceConfig(EmbeddedFormat.BINARY));
+                consumer.groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
 
         consumer.cid(cid);
         consumerManager.subscribe(consumer.groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
@@ -47,26 +47,26 @@ public class PartitionsResourceTest extends JerseyTest {
   private static final String TOPIC_NAME = "topic-1";
 
   private static final Partition PARTITION =
-      new Partition(
+      Partition.create(
           CLUSTER_ID,
           TOPIC_NAME,
           /* partitionId= */ 0,
           Arrays.asList(
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
                   /* brokerId= */ 1,
                   /* isLeader= */ true,
                   /* isInSync= */ true),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,
                   /* brokerId= */ 2,
                   /* isLeader= */ false,
                   /* isInSync= */ false),
-              new PartitionReplica(
+              PartitionReplica.create(
                   CLUSTER_ID,
                   TOPIC_NAME,
                   /* partitionId= */ 0,

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,16 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.auto.value</groupId>
+                <artifactId>auto-value-annotations</artifactId>
+                <version>1.6.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -70,6 +80,19 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>${exec-maven-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <annotationProcessorPaths>
+                            <annotationProcessorPath>
+                                <groupId>com.google.auto.value</groupId>
+                                <artifactId>auto-value</artifactId>
+                                <version>1.6.2</version>
+                            </annotationProcessorPath>
+                        </annotationProcessorPaths>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The amount of boilerplate code I had to write in my last PR (https://github.com/confluentinc/kafka-rest/pull/677) to add two fields in a response, was just too much. Enough is enough, so I migrated our internal entities to use Google's Auto-Value, that auto-generates a lot of this boilerplate automatically.