### PR TITLE
KIP-226: Add cluster-wide dynamic default configs.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -19,6 +19,7 @@ import io.confluent.kafkarest.backends.BackendsModule;
 import io.confluent.kafkarest.config.ConfigModule;
 import io.confluent.kafkarest.controllers.ControllersModule;
 import io.confluent.kafkarest.exceptions.ExceptionsModule;
+import io.confluent.kafkarest.extension.ClusterConfigTypeConverterProvider;
 import io.confluent.kafkarest.extension.ContextInvocationHandler;
 import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.extension.KafkaRestCleanupFilter;
@@ -110,6 +111,8 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     config.register(new ResponseModule());
 
     config.register(KafkaRestCleanupFilter.class);
+
+    config.register(ClusterConfigTypeConverterProvider.class);
     config.register(InstantConverterProvider.class);
 
     for (RestResourceExtension restResourceExtension : restResourceExtensions) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
@@ -86,6 +86,9 @@ abstract class AbstractConfigManager<
         .thenApply(configs -> findEntityByKey(configs, AbstractConfig::getName, name));
   }
 
+  /**
+   * Updates the config {@code name} value to {@code newValue}, checking if the config exists first.
+   */
   final CompletableFuture<Void> safeUpdateConfig(
       String clusterId, ConfigResource resourceId, B prototype, String name, String newValue) {
     return getConfig(clusterId, resourceId, prototype, name)
@@ -101,6 +104,10 @@ abstract class AbstractConfigManager<
         .thenCompose(config -> updateConfig(resourceId, name, newValue));
   }
 
+  /**
+   * Updates the config {@code name} value to {@code newValue}, without checking if the config
+   * exists first.
+   */
   final CompletableFuture<Void> unsafeUpdateConfig(
       String clusterId, ConfigResource resourceId, String name, String newValue) {
     return clusterManager.getCluster(clusterId)
@@ -120,6 +127,9 @@ abstract class AbstractConfigManager<
             .get(resourceId));
   }
 
+  /**
+   * Resets the config {@code name} to its default value, checking if the config exists first.
+   */
   final CompletableFuture<Void> safeResetConfig(
       String clusterId, ConfigResource resourceId, B prototype, String name) {
     return getConfig(clusterId, resourceId, prototype, name)
@@ -135,6 +145,10 @@ abstract class AbstractConfigManager<
         .thenCompose(config -> resetConfig(resourceId, name));
   }
 
+  /**
+   * Resets the config {@code name} to its default value, without checking if the config exists
+   * first.
+   */
   final CompletableFuture<Void> unsafeResetConfig(
       String clusterId, ConfigResource resourceId, String name) {
     return clusterManager.getCluster(clusterId)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static io.confluent.kafkarest.controllers.Entities.checkEntityExists;
+import static io.confluent.kafkarest.controllers.Entities.findEntityByKey;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.common.KafkaFutures;
+import io.confluent.kafkarest.entities.AbstractConfig;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.ConfigSynonym;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsOptions;
+import org.apache.kafka.common.config.ConfigResource;
+
+/**
+ * An abstract base class for managers of subtypes of {@link AbstractConfig}.
+ */
+abstract class AbstractConfigManager<
+    T extends AbstractConfig, B extends AbstractConfig.Builder<T, B>> {
+
+  private final Admin adminClient;
+  private final ClusterManager clusterManager;
+
+  AbstractConfigManager(Admin adminClient, ClusterManager clusterManager) {
+    this.adminClient = requireNonNull(adminClient);
+    this.clusterManager = requireNonNull(clusterManager);
+  }
+
+  final CompletableFuture<List<T>> listConfigs(
+      String clusterId, ConfigResource resourceId, B prototype) {
+    return clusterManager.getCluster(clusterId)
+        .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))
+        .thenCompose(
+            cluster ->
+                KafkaFutures.toCompletableFuture(
+                    adminClient.describeConfigs(
+                        singletonList(resourceId),
+                        new DescribeConfigsOptions().includeSynonyms(true))
+                        .values()
+                        .get(resourceId)))
+        .thenApply(
+            response ->
+                response.entries().stream()
+                    .map(
+                        entry ->
+                            prototype.setName(entry.name())
+                                .setValue(entry.value())
+                                .setDefault(entry.isDefault())
+                                .setReadOnly(entry.isReadOnly())
+                                .setSensitive(entry.isSensitive())
+                                .setSource(ConfigSource.fromAdminConfigSource(entry.source()))
+                                .setSynonyms(
+                                    entry.synonyms().stream()
+                                        .map(ConfigSynonym::fromAdminConfigSynonym)
+                                        .collect(Collectors.toList()))
+                                .build())
+                    .collect(Collectors.toList()));
+  }
+
+  final CompletableFuture<Optional<T>> getConfig(
+      String clusterId, ConfigResource resourceId, B prototype, String name) {
+    return listConfigs(clusterId, resourceId, prototype)
+        .thenApply(configs -> findEntityByKey(configs, AbstractConfig::getName, name));
+  }
+
+  final CompletableFuture<Void> safeUpdateConfig(
+      String clusterId, ConfigResource resourceId, B prototype, String name, String newValue) {
+    return getConfig(clusterId, resourceId, prototype, name)
+        .thenApply(
+            config ->
+                checkEntityExists(
+                    config,
+                    "Config %s cannot be found for %s %s in cluster %s.",
+                    name,
+                    resourceId.type(),
+                    resourceId.name(),
+                    clusterId))
+        .thenCompose(config -> updateConfig(resourceId, name, newValue));
+  }
+
+  final CompletableFuture<Void> unsafeUpdateConfig(
+      String clusterId, ConfigResource resourceId, String name, String newValue) {
+    return clusterManager.getCluster(clusterId)
+        .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))
+        .thenCompose(cluster -> updateConfig(resourceId, name, newValue));
+  }
+
+  private CompletableFuture<Void> updateConfig(
+      ConfigResource resourceId, String name, String newValue) {
+    return KafkaFutures.toCompletableFuture(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                resourceId,
+                singletonList(
+                    new AlterConfigOp(new ConfigEntry(name, newValue), AlterConfigOp.OpType.SET))))
+            .values()
+            .get(resourceId));
+  }
+
+  final CompletableFuture<Void> safeResetConfig(
+      String clusterId, ConfigResource resourceId, B prototype, String name) {
+    return getConfig(clusterId, resourceId, prototype, name)
+        .thenApply(
+            config ->
+                checkEntityExists(
+                    config,
+                    "Config %s cannot be found for %s %s in cluster %s.",
+                    name,
+                    resourceId.type(),
+                    resourceId.name(),
+                    clusterId))
+        .thenCompose(config -> resetConfig(resourceId, name));
+  }
+
+  final CompletableFuture<Void> unsafeResetConfig(
+      String clusterId, ConfigResource resourceId, String name) {
+    return clusterManager.getCluster(clusterId)
+        .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))
+        .thenCompose(cluster -> resetConfig(resourceId, name));
+  }
+
+  private CompletableFuture<Void> resetConfig(ConfigResource resourceId, String name) {
+    return KafkaFutures.toCompletableFuture(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                resourceId,
+                singletonList(
+                    new AlterConfigOp(
+                        new ConfigEntry(name, /* value= */ null),
+                        AlterConfigOp.OpType.DELETE))))
+            .values()
+            .get(resourceId));
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import io.confluent.kafkarest.entities.ClusterConfig;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public interface ClusterConfigManager {
+
+  /**
+   * Returns the list of Kafka {@link ClusterConfig ClusterConfigs}.
+   */
+  CompletableFuture<List<ClusterConfig>> listClusterConfigs(
+      String clusterId, ClusterConfig.Type type);
+
+  /**
+   * Returns the Kafka {@link ClusterConfig} with the given {@code name}.
+   */
+  CompletableFuture<Optional<ClusterConfig>> getClusterConfig(
+      String clusterId, ClusterConfig.Type type, String name);
+
+  /**
+   * Creates or updates the Kafka {@link ClusterConfig} with the given {@code name} with the given
+   * {@code newValue}.
+   */
+  CompletableFuture<Void> upsertClusterConfig(
+      String clusterId, ClusterConfig.Type type, String name, String newValue);
+
+  /**
+   * Resets the Kafka {@link ClusterConfig} with the given {@code name} to its default value.
+   */
+  CompletableFuture<Void> deleteClusterConfig(
+      String clusterId, ClusterConfig.Type type, String name);
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImpl.java
@@ -54,6 +54,9 @@ final class ClusterConfigManagerImpl
   @Override
   public CompletableFuture<Void> upsertClusterConfig(
       String clusterId, ClusterConfig.Type type, String name, String newValue) {
+    // Since listing cluster configs will only return the ones dynamically created, there's no way
+    // currently of knowing which config names are valid to create/update. So we skip the existence
+    // check. If the config is not valid, it will fail silently.
     return unsafeUpdateConfig(
         clusterId, new ConfigResource(type.getAdminType(), ""), name, newValue);
   }
@@ -61,6 +64,9 @@ final class ClusterConfigManagerImpl
   @Override
   public CompletableFuture<Void> deleteClusterConfig(
       String clusterId, ClusterConfig.Type type, String name) {
+    // Since listing cluster configs will only return the ones dynamically created, there's no way
+    // currently of knowing which config names are valid to delete. So we skip the existence check.
+    // If the config is not valid, it will fail silently.
     return unsafeResetConfig(clusterId, new ConfigResource(type.getAdminType(), ""), name);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import io.confluent.kafkarest.entities.ClusterConfig;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.config.ConfigResource;
+
+final class ClusterConfigManagerImpl
+    extends AbstractConfigManager<ClusterConfig, ClusterConfig.Builder>
+    implements ClusterConfigManager {
+
+  @Inject
+  ClusterConfigManagerImpl(Admin adminClient, ClusterManager clusterManager) {
+    super(adminClient, clusterManager);
+  }
+
+  @Override
+  public CompletableFuture<List<ClusterConfig>> listClusterConfigs(
+      String clusterId, ClusterConfig.Type type) {
+    return listConfigs(
+        clusterId,
+        new ConfigResource(type.getAdminType(), ""),
+        ClusterConfig.builder().setClusterId(clusterId).setType(type));
+  }
+
+  @Override
+  public CompletableFuture<Optional<ClusterConfig>> getClusterConfig(
+      String clusterId, ClusterConfig.Type type, String name) {
+    return getConfig(
+        clusterId,
+        new ConfigResource(type.getAdminType(), ""),
+        ClusterConfig.builder().setClusterId(clusterId).setType(type),
+        name);
+  }
+
+  @Override
+  public CompletableFuture<Void> upsertClusterConfig(
+      String clusterId, ClusterConfig.Type type, String name, String newValue) {
+    return unsafeUpdateConfig(
+        clusterId, new ConfigResource(type.getAdminType(), ""), name, newValue);
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteClusterConfig(
+      String clusterId, ClusterConfig.Type type, String name) {
+    return unsafeResetConfig(clusterId, new ConfigResource(type.getAdminType(), ""), name);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -25,6 +25,7 @@ public final class ControllersModule extends AbstractBinder {
   protected void configure() {
     bind(BrokerConfigManagerImpl.class).to(BrokerConfigManager.class);
     bind(BrokerManagerImpl.class).to(BrokerManager.class);
+    bind(ClusterConfigManagerImpl.class).to(ClusterConfigManager.class);
     bind(ClusterManagerImpl.class).to(ClusterManager.class);
     bind(PartitionManagerImpl.class).to(PartitionManager.class);
     bind(ReplicaManagerImpl.class).to(ReplicaManager.class);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -15,132 +15,59 @@
 
 package io.confluent.kafkarest.controllers;
 
-import static io.confluent.kafkarest.controllers.Entities.checkEntityExists;
-import static io.confluent.kafkarest.controllers.Entities.findEntityByKey;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
-
-import io.confluent.kafkarest.common.KafkaFutures;
-import io.confluent.kafkarest.entities.ConfigSource;
-import io.confluent.kafkarest.entities.ConfigSynonym;
 import io.confluent.kafkarest.entities.TopicConfig;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.common.config.ConfigResource;
 
-final class TopicConfigManagerImpl implements TopicConfigManager {
-
-  private final Admin adminClient;
-  private final ClusterManager clusterManager;
+final class TopicConfigManagerImpl
+    extends AbstractConfigManager<TopicConfig, TopicConfig.Builder> implements TopicConfigManager {
 
   @Inject
   TopicConfigManagerImpl(Admin adminClient, ClusterManager clusterManager) {
-    this.adminClient = Objects.requireNonNull(adminClient);
-    this.clusterManager = Objects.requireNonNull(clusterManager);
+    super(adminClient, clusterManager);
   }
 
   @Override
   public CompletableFuture<List<TopicConfig>> listTopicConfigs(
       String clusterId, String topicName) {
-    ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-
-    return clusterManager.getCluster(clusterId)
-        .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))
-        .thenCompose(
-            topic ->
-                KafkaFutures.toCompletableFuture(
-                    adminClient.describeConfigs(
-                        singletonList(resource),
-                        new DescribeConfigsOptions().includeSynonyms(true))
-                        .values()
-                        .get(resource)))
-        .thenApply(
-            config ->
-                config.entries().stream()
-                    .map(
-                        entry ->
-                            TopicConfig.create(
-                                clusterId,
-                                topicName,
-                                entry.name(),
-                                entry.value(),
-                                entry.isDefault(),
-                                entry.isReadOnly(),
-                                entry.isSensitive(),
-                                ConfigSource.fromAdminConfigSource(entry.source()),
-                                entry.synonyms().stream()
-                                    .map(ConfigSynonym::fromAdminConfigSynonym)
-                                    .collect(Collectors.toList())))
-                    .collect(Collectors.toList()));
+    return listConfigs(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.TOPIC, topicName),
+        TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName));
   }
 
   @Override
   public CompletableFuture<Optional<TopicConfig>> getTopicConfig(
       String clusterId, String topicName, String name) {
-    return listTopicConfigs(clusterId, topicName)
-        .thenApply(configs -> findEntityByKey(configs, TopicConfig::getName, name));
+    return getConfig(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.TOPIC, topicName),
+        TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
+        name);
   }
 
   @Override
   public CompletableFuture<Void> updateTopicConfig(
       String clusterId, String topicName, String name, String newValue) {
-    ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-
-    return getTopicConfig(clusterId, topicName, name)
-        .thenApply(
-            config ->
-                checkEntityExists(
-                    config,
-                    "Config %s cannot be found for topic %s in cluster %s.",
-                    name,
-                    topicName,
-                    clusterId))
-        .thenCompose(
-            topic ->
-                KafkaFutures.toCompletableFuture(
-                    adminClient.incrementalAlterConfigs(
-                        singletonMap(
-                            resource,
-                            singletonList(
-                                new AlterConfigOp(
-                                    new ConfigEntry(name, newValue), AlterConfigOp.OpType.SET))))
-                        .values()
-                        .get(resource)));
+    return safeUpdateConfig(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.TOPIC, topicName),
+        TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
+        name,
+        newValue);
   }
 
   @Override
   public CompletableFuture<Void> resetTopicConfig(
       String clusterId, String topicName, String name) {
-    ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-
-    return getTopicConfig(clusterId, topicName, name)
-        .thenApply(
-            config ->
-                checkEntityExists(
-                    config,
-                    "Config %s cannot be found for topic %s in cluster %s.",
-                    name,
-                    topicName,
-                    clusterId))
-        .thenCompose(
-            topic ->
-                KafkaFutures.toCompletableFuture(
-                    adminClient.incrementalAlterConfigs(
-                        singletonMap(
-                            resource,
-                            singletonList(
-                                new AlterConfigOp(
-                                    new ConfigEntry(name, /* value= */ null),
-                                    AlterConfigOp.OpType.DELETE))))
-                        .values()
-                        .get(resource)));
+    return safeResetConfig(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.TOPIC, topicName),
+        TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
+        name);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AbstractConfig.java
@@ -16,6 +16,7 @@
 package io.confluent.kafkarest.entities;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -42,4 +43,28 @@ public abstract class AbstractConfig {
   public abstract ConfigSource getSource();
 
   public abstract ImmutableList<ConfigSynonym> getSynonyms();
+
+  /**
+   * A builder for {@link AbstractConfig}.
+   */
+  public abstract static class Builder<T extends AbstractConfig, B extends Builder<T, B>> {
+
+    public abstract B setClusterId(String clusterId);
+
+    public abstract B setName(String name);
+
+    public abstract B setValue(@Nullable String value);
+
+    public abstract B setDefault(boolean isDefault);
+
+    public abstract B setReadOnly(boolean isReadOnly);
+
+    public abstract B setSensitive(boolean isSensitive);
+
+    public abstract B setSource(ConfigSource source);
+
+    public abstract B setSynonyms(List<ConfigSynonym> synonyms);
+
+    public abstract T build();
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/BrokerConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/BrokerConfig.java
@@ -16,12 +16,11 @@
 package io.confluent.kafkarest.entities;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * A Kafka Broker Config
+ * A Kafka broker config
  */
 @AutoValue
 public abstract class BrokerConfig extends AbstractConfig {
@@ -30,6 +29,10 @@ public abstract class BrokerConfig extends AbstractConfig {
   }
 
   public abstract int getBrokerId();
+
+  public static Builder builder() {
+    return new AutoValue_BrokerConfig.Builder();
+  }
 
   public static BrokerConfig create(
       String clusterId,
@@ -41,15 +44,28 @@ public abstract class BrokerConfig extends AbstractConfig {
       boolean isSensitive,
       ConfigSource source,
       List<ConfigSynonym> synonyms) {
-    return new AutoValue_BrokerConfig(
-        clusterId,
-        name,
-        value,
-        isDefault,
-        isReadOnly,
-        isSensitive,
-        source,
-        ImmutableList.copyOf(synonyms),
-        brokerId);
+    return builder()
+        .setClusterId(clusterId)
+        .setName(name)
+        .setValue(value)
+        .setDefault(isDefault)
+        .setReadOnly(isReadOnly)
+        .setSensitive(isSensitive)
+        .setSource(source)
+        .setSynonyms(synonyms)
+        .setBrokerId(brokerId)
+        .build();
+  }
+
+  /**
+   * A builder for {@link BrokerConfig}.
+   */
+  @AutoValue.Builder
+  public abstract static class Builder extends AbstractConfig.Builder<BrokerConfig, Builder> {
+
+    Builder() {
+    }
+
+    public abstract Builder setBrokerId(int brokerId);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ClusterConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ClusterConfig.java
@@ -18,32 +18,33 @@ package io.confluent.kafkarest.entities;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.kafka.common.config.ConfigResource;
 
 /**
- * A Kafka topic config.
+ * A Kafka cluster-wide dynamic default config.
  */
 @AutoValue
-public abstract class TopicConfig extends AbstractConfig {
+public abstract class ClusterConfig extends AbstractConfig {
 
-  TopicConfig() {
+  ClusterConfig() {
   }
 
-  public abstract String getTopicName();
+  public abstract Type getType();
 
-  public static Builder builder() {
-    return new AutoValue_TopicConfig.Builder();
+  public static ClusterConfig.Builder builder() {
+    return new AutoValue_ClusterConfig.Builder();
   }
 
-  public static TopicConfig create(
+  public static ClusterConfig create(
       String clusterId,
-      String topicName,
       String name,
       @Nullable String value,
       boolean isDefault,
       boolean isReadOnly,
       boolean isSensitive,
       ConfigSource source,
-      List<ConfigSynonym> synonyms) {
+      List<ConfigSynonym> synonyms,
+      Type type) {
     return builder()
         .setClusterId(clusterId)
         .setName(name)
@@ -53,19 +54,45 @@ public abstract class TopicConfig extends AbstractConfig {
         .setSensitive(isSensitive)
         .setSource(source)
         .setSynonyms(synonyms)
-        .setTopicName(topicName)
+        .setType(type)
         .build();
   }
 
   /**
-   * A builder for {@link TopicConfig}.
+   * A builder for {@link ClusterConfig}.
    */
   @AutoValue.Builder
-  public abstract static class Builder extends AbstractConfig.Builder<TopicConfig, Builder> {
+  public abstract static class Builder extends AbstractConfig.Builder<ClusterConfig, Builder> {
 
     Builder() {
     }
 
-    public abstract Builder setTopicName(String topicName);
+    public abstract Builder setType(Type type);
+  }
+
+  /**
+   * The type of the {@link ClusterConfig}.
+   */
+  public enum Type {
+
+    /**
+     * A cluster-wide dynamic default broker config.
+     */
+    BROKER(ConfigResource.Type.BROKER),
+
+    /**
+     * A cluster-wide dynamic default topic config.
+     */
+    TOPIC(ConfigResource.Type.TOPIC);
+
+    private final ConfigResource.Type adminType;
+
+    Type(ConfigResource.Type adminType) {
+      this.adminType = adminType;
+    }
+
+    public ConfigResource.Type getAdminType() {
+      return adminType;
+    }
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterConfigData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterConfigData.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.ClusterConfig.Type;
+import io.confluent.kafkarest.entities.ConfigSource;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+
+/**
+ * A cluster config resource type.
+ */
+@JsonIgnoreProperties(value = {"type"}, allowGetters = true)
+public final class ClusterConfigData {
+
+  private final String id;
+
+  private final ResourceLink links;
+
+  private final Attributes attributes;
+
+  // CHECKSTYLE:OFF:ParameterNumber
+  public ClusterConfigData(
+      String id,
+      ResourceLink links,
+      String clusterId,
+      ClusterConfig.Type type,
+      String name,
+      @Nullable String value,
+      boolean isDefault,
+      boolean isReadOnly,
+      boolean isSensitive,
+      ConfigSource source,
+      List<ConfigSynonymData> synonyms) {
+    this(
+        id,
+        links,
+        new Attributes(
+            clusterId,
+            type,
+            name,
+            value,
+            isDefault,
+            isReadOnly,
+            isSensitive,
+            source,
+            synonyms));
+  }
+  // CHECKSTYLE:ON:ParameterNumber
+
+  @JsonCreator
+  public ClusterConfigData(
+      @JsonProperty("id") String id,
+      @JsonProperty("links") ResourceLink links,
+      @JsonProperty("attributes") Attributes attributes
+  ) {
+    this.id = requireNonNull(id);
+    this.links = requireNonNull(links);
+    this.attributes = attributes;
+  }
+
+  public static String getElementType(ClusterConfig.Type type) {
+    return String.format("%s-config", type.name().toLowerCase());
+  }
+
+  @JsonProperty("type")
+  public String getType() {
+    return "KafkaClusterConfig";
+  }
+
+  @JsonProperty("id")
+  public String getId() {
+    return id;
+  }
+
+  @JsonProperty("links")
+  public ResourceLink getLinks() {
+    return links;
+  }
+
+  @JsonProperty("attributes")
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClusterConfigData that = (ClusterConfigData) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(links, that.links)
+        && Objects.equals(attributes, that.attributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, links, attributes);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", ClusterConfigData.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'")
+        .add("links=" + links)
+        .add("attributes=" + attributes)
+        .toString();
+  }
+
+  public static final class Attributes {
+
+    private final String clusterId;
+
+    private final ClusterConfig.Type configType;
+
+    private final String name;
+
+    @Nullable
+    private final String value;
+
+    private final boolean isDefault;
+
+    private final boolean isReadOnly;
+
+    private final boolean isSensitive;
+
+    private final ConfigSource source;
+
+    private final List<ConfigSynonymData> synonyms;
+
+    @JsonCreator
+    public Attributes(
+        @JsonProperty("cluster_id") String clusterId,
+        @JsonProperty("config_type") ClusterConfig.Type configType,
+        @JsonProperty("name") String name,
+        @JsonProperty("value") @Nullable String value,
+        @JsonProperty("is_default") boolean isDefault,
+        @JsonProperty("is_read_only") boolean isReadOnly,
+        @JsonProperty("is_sensitive") boolean isSensitive,
+        @JsonProperty("source") ConfigSource source,
+        @JsonProperty("synonyms") List<ConfigSynonymData> synonyms) {
+      this.clusterId = clusterId;
+      this.configType = configType;
+      this.name = name;
+      this.value = value;
+      this.isDefault = isDefault;
+      this.isReadOnly = isReadOnly;
+      this.isSensitive = isSensitive;
+      this.source = source;
+      this.synonyms = synonyms;
+    }
+
+    @JsonProperty("cluster_id")
+    public String getClusterId() {
+      return clusterId;
+    }
+
+    @JsonProperty("config_type")
+    public Type getConfigType() {
+      return configType;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+      return name;
+    }
+
+    @JsonProperty("value")
+    @Nullable
+    public String getValue() {
+      return value;
+    }
+
+    @JsonProperty("is_default")
+    public boolean isDefault() {
+      return isDefault;
+    }
+
+    @JsonProperty("is_read_only")
+    public boolean isReadOnly() {
+      return isReadOnly;
+    }
+
+    @JsonProperty("is_sensitive")
+    public boolean isSensitive() {
+      return isSensitive;
+    }
+
+    @JsonProperty("source")
+    public ConfigSource getSource() {
+      return source;
+    }
+
+    @JsonProperty("synonyms")
+    public List<ConfigSynonymData> getSynonyms() {
+      return synonyms;
+    }
+
+    // CHECKSTYLE:OFF:CyclomaticComplexity
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Attributes that = (Attributes) o;
+      return Objects.equals(clusterId, that.clusterId)
+          && Objects.equals(configType, that.configType)
+          && Objects.equals(name, that.name)
+          && Objects.equals(value, that.value)
+          && isDefault == that.isDefault
+          && isReadOnly == that.isReadOnly
+          && isSensitive == that.isSensitive
+          && Objects.equals(source, that.source)
+          && Objects.equals(synonyms, that.synonyms);
+    }
+    // CHECKSTYLE:ON:CyclomaticComplexity
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          clusterId, configType, name, value, isDefault, isReadOnly, isSensitive, source, synonyms);
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(", ", Attributes.class.getSimpleName() + "[", "]")
+          .add("clusterId='" + clusterId + "'")
+          .add("configType='" + configType + "'")
+          .add("name='" + name + "'")
+          .add("value='" + value + "'")
+          .add("isDefault=" + isDefault)
+          .add("isReadOnly=" + isReadOnly)
+          .add("isSensitive=" + isSensitive)
+          .add("source=" + source)
+          .add("synonyms=" + synonyms)
+          .toString();
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetClusterConfigResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetClusterConfigResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Response body for {@code GET /v3/clusters/<clusterId>/<config_type>-configs/<name>} requests.
+ */
+public final class GetClusterConfigResponse {
+
+  private final ClusterConfigData data;
+
+  @JsonCreator
+  public GetClusterConfigResponse(@JsonProperty("data") ClusterConfigData data) {
+    this.data = requireNonNull(data);
+  }
+
+  @JsonProperty
+  public ClusterConfigData getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    GetClusterConfigResponse that = (GetClusterConfigResponse) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", GetClusterConfigResponse.class.getSimpleName() + "[", "]")
+        .add("data=" + data)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListClusterConfigsResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ListClusterConfigsResponse.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Response body for {@code GET /v3/clusters/<clusterId>/<config_type>-configs} requests.
+ */
+public final class ListClusterConfigsResponse {
+
+  private final CollectionLink links;
+
+  private final List<ClusterConfigData> data;
+
+  @JsonCreator
+  public ListClusterConfigsResponse(
+      @JsonProperty("links") CollectionLink links,
+      @JsonProperty("data") List<ClusterConfigData> data
+  ) {
+    this.links = requireNonNull(links);
+    this.data = requireNonNull(data);
+  }
+
+  @JsonProperty("links")
+  public CollectionLink getLinks() {
+    return links;
+  }
+
+  @JsonProperty("data")
+  public List<ClusterConfigData> getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ListClusterConfigsResponse that = (ListClusterConfigsResponse) o;
+    return Objects.equals(links, that.links) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(links, data);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", ListClusterConfigsResponse.class.getSimpleName() + "[", "]")
+        .add("links=" + links)
+        .add("data=" + data)
+        .toString();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/UpdateClusterConfigRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/UpdateClusterConfigRequest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Request body for {@code PUT /v3/clusters?/<clusterId>/<config_type>-configs/<name>} requests.
+ */
+public final class UpdateClusterConfigRequest {
+
+  @NotNull
+  @Nullable
+  private final Data data;
+
+  @JsonCreator
+  public UpdateClusterConfigRequest(@JsonProperty("data") @Nullable Data data) {
+    this.data = data;
+  }
+
+  @Nullable
+  public Data getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UpdateClusterConfigRequest that = (UpdateClusterConfigRequest) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", UpdateClusterConfigRequest.class.getSimpleName() + "[", "]")
+        .add("data=" + data)
+        .toString();
+  }
+
+  public static final class Data {
+
+    @NotNull
+    @Nullable
+    private final Attributes attributes;
+
+    @JsonCreator
+    public Data(@JsonProperty("attributes") @Nullable Attributes attributes) {
+      this.attributes = attributes;
+    }
+
+    @Nullable
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Data data = (Data) o;
+      return Objects.equals(attributes, data.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(attributes);
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(
+          ", ", UpdateClusterConfigRequest.Data.class.getSimpleName() + "[", "]")
+          .add("attributes=" + attributes)
+          .toString();
+    }
+
+    public static final class Attributes {
+
+      @Nullable
+      private final String value;
+
+      @JsonCreator
+      public Attributes(@JsonProperty("value") @Nullable String value) {
+        this.value = value;
+      }
+
+      @Nullable
+      public String getValue() {
+        return value;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (this == o) {
+          return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+          return false;
+        }
+        Attributes that = (Attributes) o;
+        return Objects.equals(value, that.value);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(value);
+      }
+
+      @Override
+      public String toString() {
+        return new StringJoiner(", ", Attributes.class.getSimpleName() + "[", "]")
+            .add("value='" + value + "'")
+            .toString();
+      }
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/extension/ClusterConfigTypeConverterProvider.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/extension/ClusterConfigTypeConverterProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.extension;
+
+import io.confluent.kafkarest.entities.ClusterConfig;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+
+public final class ClusterConfigTypeConverterProvider implements ParamConverterProvider {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ParamConverter<T> getConverter(
+      Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (!rawType.equals(ClusterConfig.Type.class)) {
+      return null;
+    }
+    return (ParamConverter<T>) ClusterConfigTypeConverter.INSTANCE;
+  }
+
+  private enum ClusterConfigTypeConverter implements ParamConverter<ClusterConfig.Type> {
+    INSTANCE;
+
+    @Override
+    public ClusterConfig.Type fromString(String value) {
+      if (value == null) {
+        return null;
+      }
+      return ClusterConfig.Type.valueOf(value.toUpperCase());
+    }
+
+    @Override
+    public String toString(ClusterConfig.Type value) {
+      return value.toString().toLowerCase();
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClusterConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClusterConfigsResource.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.controllers.ClusterConfigManager;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.v3.ClusterConfigData;
+import io.confluent.kafkarest.entities.v3.ClusterData;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
+import io.confluent.kafkarest.entities.v3.GetClusterConfigResponse;
+import io.confluent.kafkarest.entities.v3.ListClusterConfigsResponse;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.UpdateClusterConfigRequest;
+import io.confluent.kafkarest.resources.AsyncResponses;
+import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.kafkarest.response.CrnFactory;
+import io.confluent.kafkarest.response.UrlFactory;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+@Path("/v3/clusters/{clusterId}/{config_type}-configs")
+public final class ClusterConfigsResource {
+
+  private final Provider<ClusterConfigManager> clusterConfigManager;
+  private final CrnFactory crnFactory;
+  private final UrlFactory urlFactory;
+
+  @Inject
+  public ClusterConfigsResource(
+      Provider<ClusterConfigManager> clusterConfigManager,
+      CrnFactory crnFactory,
+      UrlFactory urlFactory
+  ) {
+    this.clusterConfigManager = requireNonNull(clusterConfigManager);
+    this.crnFactory = requireNonNull(crnFactory);
+    this.urlFactory = requireNonNull(urlFactory);
+  }
+
+  @GET
+  @Produces(Versions.JSON_API)
+  public void listClusterConfigs(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("config_type") ClusterConfig.Type configType
+  ) {
+    CompletableFuture<ListClusterConfigsResponse> response =
+        clusterConfigManager.get().listClusterConfigs(clusterId, configType)
+            .thenApply(
+                configs ->
+                    new ListClusterConfigsResponse(
+                        new CollectionLink(
+                            urlFactory.create(
+                                "v3",
+                                "clusters",
+                                clusterId,
+                                String.format("%s-configs", configType.name().toLowerCase())),
+                            /* next= */ null),
+                        configs.stream()
+                            .sorted(
+                                Comparator.comparing(ClusterConfig::getType)
+                                    .thenComparing(ClusterConfig::getName))
+                            .map(this::toClusterConfigData)
+                            .collect(Collectors.toList())));
+
+    AsyncResponses.asyncResume(asyncResponse, response);
+  }
+
+  @GET
+  @Path("/{name}")
+  @Produces(Versions.JSON_API)
+  public void getClusterConfig(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("config_type") ClusterConfig.Type configType,
+      @PathParam("name") String name
+  ) {
+    CompletableFuture<GetClusterConfigResponse> response =
+        clusterConfigManager.get()
+            .getClusterConfig(clusterId, configType, name)
+            .thenApply(config -> config.orElseThrow(NotFoundException::new))
+            .thenApply(config -> new GetClusterConfigResponse(toClusterConfigData(config)));
+
+    AsyncResponses.asyncResume(asyncResponse, response);
+  }
+
+  @PUT
+  @Path("/{name}")
+  @Consumes(Versions.JSON_API)
+  @Produces(Versions.JSON_API)
+  public void upsertClusterConfig(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("config_type") ClusterConfig.Type configType,
+      @PathParam("name") String name,
+      @Valid UpdateClusterConfigRequest request
+  ) {
+    String newValue = request.getData().getAttributes().getValue();
+
+    CompletableFuture<Void> response =
+        clusterConfigManager.get().upsertClusterConfig(clusterId, configType, name, newValue);
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+
+  @DELETE
+  @Path("/{name}")
+  @Produces(Versions.JSON_API)
+  public void deleteClusterConfig(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("config_type") ClusterConfig.Type configType,
+      @PathParam("name") String name
+  ) {
+    CompletableFuture<Void> response =
+        clusterConfigManager.get().deleteClusterConfig(clusterId, configType, name);
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+
+  private ClusterConfigData toClusterConfigData(ClusterConfig clusterConfig) {
+    return new ClusterConfigData(
+        crnFactory.create(
+            ClusterData.ELEMENT_TYPE,
+            clusterConfig.getClusterId(),
+            ClusterConfigData.getElementType(clusterConfig.getType()),
+            clusterConfig.getName()),
+        new ResourceLink(
+            urlFactory.create(
+                "v3",
+                "clusters",
+                clusterConfig.getClusterId(),
+                String.format("%s-configs", clusterConfig.getType().name().toLowerCase()),
+                clusterConfig.getName())),
+        clusterConfig.getClusterId(),
+        clusterConfig.getType(),
+        clusterConfig.getName(),
+        clusterConfig.getValue(),
+        clusterConfig.isDefault(),
+        clusterConfig.isReadOnly(),
+        clusterConfig.isSensitive(),
+        clusterConfig.getSource(),
+        clusterConfig.getSynonyms().stream()
+            .map(ConfigSynonymData::fromConfigSynonym)
+            .collect(Collectors.toList()));
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
@@ -22,8 +22,9 @@ public final class V3ResourcesFeature implements Feature {
 
   @Override
   public boolean configure(FeatureContext configurable) {
-    configurable.register(BrokersResource.class);
     configurable.register(BrokerConfigsResource.class);
+    configurable.register(BrokersResource.class);
+    configurable.register(ClusterConfigsResource.class);
     configurable.register(ClustersResource.class);
     configurable.register(PartitionsResource.class);
     configurable.register(ReplicasResource.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImplTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.fail;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import io.confluent.kafkarest.common.KafkaFutures;
+import io.confluent.kafkarest.entities.Cluster;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.ConfigSource;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import javax.ws.rs.NotFoundException;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.AlterConfigsResult;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsOptions;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.ConfigResource;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ClusterConfigManagerImplTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+
+  private static final Cluster CLUSTER =
+      Cluster.create(CLUSTER_ID, null, emptyList());
+
+  private static final ClusterConfig CONFIG_1 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-1",
+          "value-1",
+          /* isDefault= */ false,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ false,
+          ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+  private static final ClusterConfig CONFIG_2 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ false,
+          ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+  private static final ClusterConfig CONFIG_3 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-3",
+          /* value= */ null,
+          /* isDefault= */ false,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ true,
+          ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+
+  private static final Config CONFIG =
+      new Config(
+          Arrays.asList(
+              new OpenConfigEntry(
+                  CONFIG_1.getName(),
+                  CONFIG_1.getValue(),
+                  ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+                  CONFIG_1.isDefault(),
+                  CONFIG_1.isSensitive(),
+                  CONFIG_1.isReadOnly()),
+              new OpenConfigEntry(
+                  CONFIG_2.getName(),
+                  CONFIG_2.getValue(),
+                  ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+                  CONFIG_2.isDefault(),
+                  CONFIG_2.isSensitive(),
+                  CONFIG_2.isReadOnly()),
+              new OpenConfigEntry(
+                  CONFIG_3.getName(),
+                  CONFIG_3.getValue(),
+                  ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+                  CONFIG_3.isDefault(),
+                  CONFIG_3.isSensitive(),
+                  CONFIG_3.isReadOnly())));
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private Admin adminClient;
+
+  @Mock
+  private ClusterManager clusterManager;
+
+  @Mock
+  private DescribeConfigsResult describeConfigsResult;
+
+  @Mock
+  private AlterConfigsResult alterConfigsResult;
+
+  private ClusterConfigManagerImpl clusterConfigManager;
+
+  @Before
+  public void setUp() {
+    clusterConfigManager = new ClusterConfigManagerImpl(adminClient, clusterManager);
+  }
+
+  @Test
+  public void listClusterConfigs_existingCluster_returnsConfigs() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.describeConfigs(
+            eq(singletonList(new ConfigResource(ConfigResource.Type.BROKER, ""))),
+            anyObject(DescribeConfigsOptions.class)))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(adminClient, clusterManager, describeConfigsResult);
+
+    List<ClusterConfig> configs =
+        clusterConfigManager.listClusterConfigs(CLUSTER_ID, ClusterConfig.Type.BROKER).get();
+
+    assertEquals(
+        new HashSet<>(Arrays.asList(CONFIG_1, CONFIG_2, CONFIG_3)), new HashSet<>(configs));
+  }
+
+  @Test
+  public void listClusterConfigs_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.describeConfigs(
+            eq(singletonList(new ConfigResource(ConfigResource.Type.BROKER, ""))),
+            anyObject(DescribeConfigsOptions.class)))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFutures.failedFuture(new NotFoundException("Cluster not found."))));
+    replay(clusterManager, adminClient, describeConfigsResult);
+
+    try {
+      clusterConfigManager.listClusterConfigs(CLUSTER_ID, ClusterConfig.Type.BROKER).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void getClusterConfig_existingConfig_returnsConfig() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(adminClient.describeConfigs(
+        eq(singletonList(new ConfigResource(ConfigResource.Type.BROKER, ""))),
+        anyObject(DescribeConfigsOptions.class)))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(adminClient, clusterManager, describeConfigsResult);
+
+    ClusterConfig config =
+        clusterConfigManager.getClusterConfig(
+            CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName())
+            .get()
+            .get();
+
+    assertEquals(CONFIG_1, config);
+  }
+
+  @Test
+  public void getClusterConfig_nonExistingConfig_returnsEmpty() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.describeConfigs(
+            eq(singletonList(
+                new ConfigResource(ConfigResource.Type.BROKER, ""))),
+            anyObject(DescribeConfigsOptions.class)))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFuture.completedFuture(CONFIG)));
+    replay(adminClient, clusterManager, describeConfigsResult);
+
+    Optional<ClusterConfig> config =
+        clusterConfigManager.getClusterConfig(CLUSTER_ID, ClusterConfig.Type.BROKER, "foobar")
+            .get();
+
+    assertFalse(config.isPresent());
+  }
+
+  @Test
+  public void getClusterConfig_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.describeConfigs(
+            eq(singletonList(
+                new ConfigResource(ConfigResource.Type.BROKER, ""))),
+            anyObject(DescribeConfigsOptions.class)))
+        .andReturn(describeConfigsResult);
+    expect(describeConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFutures.failedFuture(new NotFoundException("Cluster not found."))));
+    replay(clusterManager, adminClient, describeConfigsResult);
+
+    try {
+      clusterConfigManager.getClusterConfig(
+          CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void updateClusterConfig_existingConfig_updatesConfigs() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                singletonList(
+                    new AlterConfigOp(
+                        new ConfigEntry(CONFIG_1.getName(), "new-value"),
+                        AlterConfigOp.OpType.SET)))))
+        .andReturn(alterConfigsResult);
+    expect(alterConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFuture.completedFuture(null)));
+    replay(clusterManager, adminClient, alterConfigsResult);
+
+    clusterConfigManager.upsertClusterConfig(
+        CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName(), "new-value").get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void updateClusterConfig_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.empty()));
+    replay(clusterManager);
+
+    try {
+      clusterConfigManager.upsertClusterConfig(
+          CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName(), "new-value").get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(clusterManager);
+  }
+
+  @Test
+  public void resetClusterConfig_existingConfig_resetsConfig() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.incrementalAlterConfigs(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                singletonList(
+                    new AlterConfigOp(
+                        new ConfigEntry(CONFIG_1.getName(), /* value= */ null),
+                        AlterConfigOp.OpType.DELETE)))))
+        .andReturn(alterConfigsResult);
+    expect(alterConfigsResult.values())
+        .andReturn(
+            singletonMap(
+                new ConfigResource(ConfigResource.Type.BROKER, ""),
+                KafkaFuture.completedFuture(null)));
+    replay(clusterManager, adminClient, alterConfigsResult);
+
+    clusterConfigManager.deleteClusterConfig(
+        CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName()).get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void resetClusterConfig_nonExistingCluster_throwsNotFound() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.empty()));
+    replay(clusterManager);
+
+    try {
+      clusterConfigManager.deleteClusterConfig(
+          CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName()).get();
+      fail();
+    } catch (ExecutionException e) {
+      assertEquals(NotFoundException.class, e.getCause().getClass());
+    }
+
+    verify(clusterManager);
+  }
+
+  private static final class OpenConfigEntry extends ConfigEntry {
+
+    private final ConfigEntry.ConfigSource source;
+
+    public OpenConfigEntry(
+        String name,
+        String value,
+        ConfigEntry.ConfigSource source,
+        boolean isDefault,
+        boolean isReadOnly,
+        boolean isSensitive) {
+      super(name, value, isDefault, isReadOnly, isSensitive);
+      this.source = requireNonNull(source);
+    }
+
+    @Override
+    public ConfigSource source() {
+      return source;
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClusterConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClusterConfigsResourceIntegrationTest.java
@@ -1,0 +1,250 @@
+package io.confluent.kafkarest.integration.v3;
+
+import static java.util.Collections.singletonList;
+import static junit.framework.TestCase.assertEquals;
+
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.v3.BrokerConfigData;
+import io.confluent.kafkarest.entities.v3.ClusterConfigData;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
+import io.confluent.kafkarest.entities.v3.GetBrokerConfigResponse;
+import io.confluent.kafkarest.entities.v3.GetClusterConfigResponse;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.integration.ClusterTestHarness;
+import java.util.Arrays;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterConfigsResourceIntegrationTest extends ClusterTestHarness {
+
+  public ClusterConfigsResourceIntegrationTest() {
+    super(/* numClusters= */ 3, /* withSchemaRegistry= */ false);
+  }
+
+  @Test
+  public void listClusterConfigs_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/broker-configs")
+            .accept(Versions.JSON_API)
+            .get();
+    Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getClusterConfig_nonExistingConfig_throwsNotFound() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/broker-configs/foobar")
+            .accept(Versions.JSON_API)
+            .get();
+    Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getClusterConfig_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/broker-configs/max.connections")
+            .accept(Versions.JSON_API)
+            .get();
+    Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void updateAndReset_existingConfig_returnsDefaultUpdatedAndDefaultAgain() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+    int brokerId = getBrokers().get(0).id();
+
+    Response responseBeforeUpdate =
+        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), responseBeforeUpdate.getStatus());
+
+    GetBrokerConfigResponse expectedBrokerBeforeUpdate =
+        new GetBrokerConfigResponse(
+            new BrokerConfigData(
+                "crn:///kafka=" + clusterId
+                    + "/broker=" + brokerId
+                    + "/config=compression.type",
+                new ResourceLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/brokers/" + brokerId
+                        + "/configs/compression.type"),
+                clusterId,
+                brokerId,
+                "compression.type",
+                "producer",
+                /* isDefault= */ true,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                singletonList(
+                    new ConfigSynonymData(
+                        "compression.type", "producer", ConfigSource.DEFAULT_CONFIG))));
+
+    Response brokerResponseBeforeUpdate =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/compression.type")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), brokerResponseBeforeUpdate.getStatus());
+
+    GetBrokerConfigResponse actualBrokerBeforeUpdate =
+        brokerResponseBeforeUpdate.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedBrokerBeforeUpdate, actualBrokerBeforeUpdate);
+
+    Response updateResponse =
+        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"gzip\"}}}", Versions.JSON_API));
+    assertEquals(Status.NO_CONTENT.getStatusCode(), updateResponse.getStatus());
+
+    GetClusterConfigResponse expectedAfterUpdate =
+        new GetClusterConfigResponse(
+            new ClusterConfigData(
+                "crn:///kafka=" + clusterId + "/broker-config=compression.type",
+                new ResourceLink(
+                    baseUrl + "/v3/clusters/" + clusterId + "/broker-configs/compression.type"),
+                clusterId,
+                ClusterConfig.Type.BROKER,
+                "compression.type",
+                "gzip",
+                /* isDefault= */ false,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false,
+                ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+                singletonList(
+                    new ConfigSynonymData(
+                        "compression.type",
+                        "gzip",
+                        ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG))));
+
+    Response responseAfterUpdate =
+        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
+
+    GetClusterConfigResponse actualAfterUpdate =
+        responseAfterUpdate.readEntity(GetClusterConfigResponse.class);
+    assertEquals(expectedAfterUpdate, actualAfterUpdate);
+
+    GetBrokerConfigResponse expectedBrokerAfterUpdate =
+        new GetBrokerConfigResponse(
+            new BrokerConfigData(
+                "crn:///kafka=" + clusterId
+                    + "/broker=" + brokerId
+                    + "/config=compression.type",
+                new ResourceLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/brokers/" + brokerId
+                        + "/configs/compression.type"),
+                clusterId,
+                brokerId,
+                "compression.type",
+                "gzip",
+                /* isDefault= */ false,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false,
+                ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
+                Arrays.asList(
+                    new ConfigSynonymData(
+                        "compression.type", "gzip", ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG),
+                    new ConfigSynonymData(
+                        "compression.type", "producer", ConfigSource.DEFAULT_CONFIG))));
+
+    Response responseBrokerAfterUpdate =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/compression.type")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseBrokerAfterUpdate.getStatus());
+
+    GetBrokerConfigResponse actualBrokerAfterUpdate =
+        responseBrokerAfterUpdate.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedBrokerAfterUpdate, actualBrokerAfterUpdate);
+
+    Response resetResponse =
+        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NO_CONTENT.getStatusCode(), resetResponse.getStatus());
+
+    Response responseAfterReset =
+        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), responseAfterReset.getStatus());
+
+    GetBrokerConfigResponse expectedBrokerAfterReset =
+        new GetBrokerConfigResponse(
+            new BrokerConfigData(
+                "crn:///kafka=" + clusterId
+                    + "/broker=" + brokerId
+                    + "/config=compression.type",
+                new ResourceLink(
+                    baseUrl
+                        + "/v3/clusters/" + clusterId
+                        + "/brokers/" + brokerId
+                        + "/configs/compression.type"),
+                clusterId,
+                brokerId,
+                "compression.type",
+                "producer",
+                /* isDefault= */ true,
+                /* isReadOnly= */ false,
+                /* isSensitive= */ false,
+                ConfigSource.DEFAULT_CONFIG,
+                singletonList(
+                    new ConfigSynonymData(
+                        "compression.type", "producer", ConfigSource.DEFAULT_CONFIG))));
+
+    Response brokerResponseAfterReset =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/compression.type")
+            .accept(Versions.JSON_API)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), brokerResponseAfterReset.getStatus());
+
+    GetBrokerConfigResponse actualBrokerAfterReset =
+        brokerResponseAfterReset.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedBrokerAfterReset, actualBrokerAfterReset);
+  }
+
+  @Test
+  public void updateClusterConfig_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .put(
+                Entity.entity(
+                    "{\"data\":{\"attributes\":{\"value\":\"producer\"}}}", Versions.JSON_API));
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void resetClusterConfig_nonExistingCluster_throwsNotFound() {
+    Response response =
+        request("/v3/clusters/foobar/broker-configs/compression.type")
+            .accept(Versions.JSON_API)
+            .delete();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClusterConfigResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClusterConfigResourceTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static io.confluent.kafkarest.common.CompletableFutures.failedFuture;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafkarest.controllers.ClusterConfigManager;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.v3.ClusterConfigData;
+import io.confluent.kafkarest.entities.v3.CollectionLink;
+import io.confluent.kafkarest.entities.v3.ConfigSynonymData;
+import io.confluent.kafkarest.entities.v3.GetClusterConfigResponse;
+import io.confluent.kafkarest.entities.v3.ListClusterConfigsResponse;
+import io.confluent.kafkarest.entities.v3.ResourceLink;
+import io.confluent.kafkarest.entities.v3.UpdateClusterConfigRequest;
+import io.confluent.kafkarest.response.CrnFactoryImpl;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.kafkarest.response.FakeUrlFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ClusterConfigResourceTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+
+  private static final ClusterConfig CONFIG_1 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-1",
+          "value-1",
+          /* isDefault= */ true,
+          /* isReadOnly= */ false,
+          /* isSensitive */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+  private static final ClusterConfig CONFIG_2 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ true,
+          /* isSensitive */ false,
+          ConfigSource.STATIC_BROKER_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+  private static final ClusterConfig CONFIG_3 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-3",
+          "value-3",
+          /* isDefault= */ false,
+          /* isReadOnly= */ false,
+          /* isSensitive */ true,
+          ConfigSource.DYNAMIC_BROKER_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private ClusterConfigManager clusterConfigManager;
+
+  private ClusterConfigsResource clusterConfigsResource;
+
+  @Before
+  public void setUp() {
+    clusterConfigsResource =
+        new ClusterConfigsResource(
+            () -> clusterConfigManager,
+            new CrnFactoryImpl(/* crnAuthorityConfig= */""),
+            new FakeUrlFactory());
+  }
+
+  @Test
+  public void listClusterConfigs_existingCluster_returnsConfigs() {
+    expect(clusterConfigManager.listClusterConfigs(CLUSTER_ID, ClusterConfig.Type.BROKER))
+        .andReturn(
+            completedFuture(Arrays.asList(CONFIG_1, CONFIG_2, CONFIG_3)));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.listClusterConfigs(response, CLUSTER_ID, ClusterConfig.Type.BROKER);
+
+    ListClusterConfigsResponse expected =
+        new ListClusterConfigsResponse(
+            new CollectionLink(
+                "/v3/clusters/cluster-1/broker-configs", null),
+            Arrays.asList(
+                new ClusterConfigData(
+                    "crn:///kafka=cluster-1/broker-config=config-1",
+                    new ResourceLink("/v3/clusters/cluster-1/broker-configs/config-1"),
+                    CLUSTER_ID,
+                    ClusterConfig.Type.BROKER,
+                    CONFIG_1.getName(),
+                    CONFIG_1.getValue(),
+                    CONFIG_1.isDefault(),
+                    CONFIG_1.isReadOnly(),
+                    CONFIG_1.isSensitive(),
+                    CONFIG_1.getSource(),
+                    CONFIG_1.getSynonyms().stream()
+                        .map(ConfigSynonymData::fromConfigSynonym)
+                        .collect(Collectors.toList())),
+                new ClusterConfigData(
+                    "crn:///kafka=cluster-1/broker-config=config-2",
+                    new ResourceLink("/v3/clusters/cluster-1/broker-configs/config-2"),
+                    CLUSTER_ID,
+                    ClusterConfig.Type.BROKER,
+                    CONFIG_2.getName(),
+                    CONFIG_2.getValue(),
+                    CONFIG_2.isDefault(),
+                    CONFIG_2.isReadOnly(),
+                    CONFIG_2.isSensitive(),
+                    CONFIG_2.getSource(),
+                    CONFIG_2.getSynonyms().stream()
+                        .map(ConfigSynonymData::fromConfigSynonym)
+                        .collect(Collectors.toList())),
+                new ClusterConfigData(
+                    "crn:///kafka=cluster-1/broker-config=config-3",
+                    new ResourceLink("/v3/clusters/cluster-1/broker-configs/config-3"),
+                    CLUSTER_ID,
+                    ClusterConfig.Type.BROKER,
+                    CONFIG_3.getName(),
+                    CONFIG_3.getValue(),
+                    CONFIG_3.isDefault(),
+                    CONFIG_3.isReadOnly(),
+                    CONFIG_3.isSensitive(),
+                    CONFIG_3.getSource(),
+                    CONFIG_3.getSynonyms().stream()
+                        .map(ConfigSynonymData::fromConfigSynonym)
+                        .collect(Collectors.toList()))));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void listClusterConfigs_nonExistingCluster_throwsNotFound() {
+    expect(clusterConfigManager.listClusterConfigs(CLUSTER_ID, ClusterConfig.Type.BROKER))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.listClusterConfigs(response, CLUSTER_ID, ClusterConfig.Type.BROKER);
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void getClusterConfig_existingConfig_returnsConfig() {
+    expect(clusterConfigManager.getClusterConfig(
+        CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName()))
+        .andReturn(completedFuture(Optional.of(CONFIG_1)));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.getClusterConfig(
+        response, CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName());
+    GetClusterConfigResponse expected =
+        new GetClusterConfigResponse(
+            new ClusterConfigData(
+                "crn:///kafka=cluster-1/broker-config=config-1",
+                new ResourceLink("/v3/clusters/cluster-1/broker-configs/config-1"),
+                CLUSTER_ID,
+                ClusterConfig.Type.BROKER,
+                CONFIG_1.getName(),
+                CONFIG_1.getValue(),
+                CONFIG_1.isDefault(),
+                CONFIG_1.isReadOnly(),
+                CONFIG_1.isSensitive(),
+                CONFIG_1.getSource(),
+                CONFIG_1.getSynonyms().stream()
+                    .map(ConfigSynonymData::fromConfigSynonym)
+                    .collect(Collectors.toList())));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void getClusterConfig_nonExistingConfig_throwsNotFound() {
+    expect(clusterConfigManager.getClusterConfig(
+        CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.getClusterConfig(
+        response, CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void getClusterConfig_nonExistingCluster_throwsNotFound() {
+    expect(clusterConfigManager.getClusterConfig(
+        CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.getClusterConfig(
+        response, CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void updateClusterConfig_existingConfig_updatesConfig() {
+    expect(
+        clusterConfigManager.upsertClusterConfig(
+            CLUSTER_ID,
+            ClusterConfig.Type.BROKER,
+            CONFIG_1.getName(),
+            "new-value"))
+        .andReturn(completedFuture(null));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.upsertClusterConfig(
+        response,
+        CLUSTER_ID,
+        ClusterConfig.Type.BROKER,
+        CONFIG_1.getName(),
+        new UpdateClusterConfigRequest(
+            new UpdateClusterConfigRequest.Data(
+                new UpdateClusterConfigRequest.Data.Attributes("new-value"))));
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void updateConfig_nonExistingCluster_throwsNotFound() {
+    expect(
+        clusterConfigManager.upsertClusterConfig(
+            CLUSTER_ID,
+            ClusterConfig.Type.BROKER,
+            CONFIG_1.getName(),
+            "new-value"))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.upsertClusterConfig(
+        response,
+        CLUSTER_ID,
+        ClusterConfig.Type.BROKER,
+        CONFIG_1.getName(),
+        new UpdateClusterConfigRequest(
+            new UpdateClusterConfigRequest.Data(
+                new UpdateClusterConfigRequest.Data.Attributes("new-value"))));
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void resetClusterConfig_existingConfig_resetsConfig() {
+    expect(
+        clusterConfigManager.deleteClusterConfig(
+            CLUSTER_ID,
+            ClusterConfig.Type.BROKER,
+            CONFIG_1.getName()))
+        .andReturn(completedFuture(null));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.deleteClusterConfig(
+        response, CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName());
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void resetClusterConfig_nonExistingCluster_throwsNotFound() {
+    expect(
+        clusterConfigManager.deleteClusterConfig(
+            CLUSTER_ID,
+            ClusterConfig.Type.BROKER,
+            CONFIG_1.getName()))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    clusterConfigsResource.deleteClusterConfig(
+        response, CLUSTER_ID, ClusterConfig.Type.BROKER, CONFIG_1.getName());
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+}


### PR DESCRIPTION
This PR adds 8 new endpoints:

* List current cluster-wide dynamic default configs:

Request:

```
GET /v3/clusters/{clusterId}/broker-configs

and

GET /v3/clusters/{clusterId}/topic-configs
```

Example response (note only the dynamic default configs are returned, instead of all configs):

```
HTTP 200 OK

{
  "links": {
    "self": "http://localhost:9391/v3/clusters/60huKN8RTdW40AAchhHJIw/broker-configs",
    "next": null
  },
  "data": [
    {
      "id": "crn:///kafka=60huKN8RTdW40AAchhHJIw/broker-config=compression.type",
      "links": {
        "self": "http://localhost:9391/v3/clusters/60huKN8RTdW40AAchhHJIw/broker-configs/compression.type"
      },
      "attributes": {
        "cluster_id": "60huKN8RTdW40AAchhHJIw",
        "config_type": "BROKER",
        "name": "compression.type",
        "value": "gzip",
        "is_default": false,
        "is_read_only": false,
        "is_sensitive": false,
        "source": "DYNAMIC_DEFAULT_BROKER_CONFIG",
        "synonyms": [
          {
            "name": "compression.type",
            "value": "gzip",
            "source": "DYNAMIC_DEFAULT_BROKER_CONFIG"
          }
        ]
      },
      "type": "KafkaClusterConfig"
    }
  ]
}
```

* Get a cluster-wide dynamic default config.

Request:

```
GET /v3/clusters/{clusterId}/broker-configs/{name}

and

GET /v3/clusters/{clusterId}/topic-configs/{name}
```

Example response:

```
HTTP 200 OK

{
  "data": {
    "id": "crn:///kafka=60huKN8RTdW40AAchhHJIw/broker-config=compression.type",
    "links": {
      "self": "http://localhost:9391/v3/clusters/60huKN8RTdW40AAchhHJIw/broker-configs/compression.type"
    },
    "attributes": {
      "cluster_id": "60huKN8RTdW40AAchhHJIw",
      "config_type": "BROKER",
      "name": "compression.type",
      "value": "gzip",
      "is_default": false,
      "is_read_only": false,
      "is_sensitive": false,
      "source": "DYNAMIC_DEFAULT_BROKER_CONFIG",
      "synonyms": [
        {
          "name": "compression.type",
          "value": "gzip",
          "source": "DYNAMIC_DEFAULT_BROKER_CONFIG"
        }
      ]
    },
    "type": "KafkaClusterConfig"
  }
}
```

Create or update a cluster-wide dynamic default config:

Request:

```
PUT /v3/clusters/{clusterId}/broker-configs/{name}

{
    "data": {
        "attributes": {
            "value": "my-new-value"
	}
    }
}

and

PUT /v3/clusters/{clusterId}/topic-configs/{name}

{
    "data": {
        "attributes": {
            "value": "my-new-value"
	}
    }
}
```

Example response:

```
HTTP 204 No Content
```

* Delete a cluster-wide dynamic default config:

Request:

```
DELETE /v3/clusters/{clusterId}/broker-configs/{name}

and

DELETE /v3/clusters/{clusterId}/topic-configs/{name}
```

Example response:

```
HTTP 204 No Content
```