### PR TITLE
#538 - LOG_DIR not set causing FileNotFoundException

### DIFF
--- a/bin/kafka-rest-run-class
+++ b/bin/kafka-rest-run-class
@@ -39,6 +39,11 @@ if [ "x$KAFKAREST_LOG4J_OPTS" = "x" ]; then
   fi
 fi
 
+# Log directory to use
+if [ "x$LOG_DIR" = "x" ]; then
+  LOG_DIR="$base_dir/logs"
+fi
+
 if [[ -n $LOG_DIR ]]; then
     [[ -d $LOG_DIR ]] || mkdir -p "$LOG_DIR"
     KAFKAREST_LOG4J_OPTS="-Dkafka-rest.log.dir=$LOG_DIR ${KAFKAREST_LOG4J_OPTS}"


### PR DESCRIPTION
Noticed that this same `LOG_DIR` not set causing `FileNotFoundException` behavior was still happening in the latest 5.5.x version of Rest Proxy.

Created a simple PR to correctly set the base log directory for the logs.
