### PR TITLE
CLIENTS-1597: Add relationship reassignment and refactor reassignment resource

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -39,4 +39,8 @@
             checks="(MethodLength)"
             files="(KafkaRestConfig).java"
     />
+    <suppress
+            checks="(ParameterNumber)"
+            files="(ClusterData).java"
+    />
 </suppressions>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
@@ -54,7 +54,7 @@ public abstract class ClusterData extends Resource {
   @JsonProperty("topic_configs")
   public abstract Relationship getTopicConfigs();
 
-  @JsonProperty("reassignment")
+  @JsonProperty("partition_reassignments")
   public abstract Relationship getReassignment();
 
   public static Builder builder() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
@@ -74,7 +74,7 @@ public abstract class ClusterData extends Resource {
       @JsonProperty("acls") Relationship acls,
       @JsonProperty("brokers") Relationship brokers,
       @JsonProperty("broker_configs") Relationship brokerConfigs,
-      @JsonProperty("reassignment") Relationship reassignment,
+      @JsonProperty("partition_reassignments") Relationship reassignment,
       @JsonProperty("consumer_groups") Relationship consumerGroups,
       @JsonProperty("topics") Relationship topics,
       @JsonProperty("topic_configs") Relationship topicConfigs

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
@@ -48,6 +48,9 @@ public abstract class ClusterData extends Resource {
   @JsonProperty("topic_configs")
   public abstract Relationship getTopicConfigs();
 
+  @JsonProperty("reassignment")
+  public abstract Relationship getReassignment();
+
   public static Builder builder() {
     return new AutoValue_ClusterData.Builder().setKind("KafkaCluster");
   }
@@ -65,7 +68,8 @@ public abstract class ClusterData extends Resource {
       @JsonProperty("brokers") Relationship brokers,
       @JsonProperty("topics") Relationship topics,
       @JsonProperty("broker_configs") Relationship brokerConfigs,
-      @JsonProperty("topic_configs") Relationship topicConfigs
+      @JsonProperty("topic_configs") Relationship topicConfigs,
+      @JsonProperty("reassignment") Relationship reassignment
   ) {
     return builder()
         .setKind(kind)
@@ -76,6 +80,7 @@ public abstract class ClusterData extends Resource {
         .setTopics(topics)
         .setBrokerConfigs(brokerConfigs)
         .setTopicConfigs(topicConfigs)
+        .setReassignment(reassignment)
         .build();
   }
 
@@ -96,6 +101,8 @@ public abstract class ClusterData extends Resource {
     public abstract Builder setBrokerConfigs(Relationship brokerConfigs);
 
     public abstract Builder setTopicConfigs(Relationship topicConfigs);
+
+    public abstract Builder setReassignment(Relationship reassignment);
 
     public abstract ClusterData build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ClusterData.java
@@ -55,7 +55,7 @@ public abstract class ClusterData extends Resource {
   public abstract Relationship getTopicConfigs();
 
   @JsonProperty("partition_reassignments")
-  public abstract Relationship getReassignment();
+  public abstract Relationship getPartitionReassignments();
 
   public static Builder builder() {
     return new AutoValue_ClusterData.Builder().setKind("KafkaCluster");
@@ -74,7 +74,7 @@ public abstract class ClusterData extends Resource {
       @JsonProperty("acls") Relationship acls,
       @JsonProperty("brokers") Relationship brokers,
       @JsonProperty("broker_configs") Relationship brokerConfigs,
-      @JsonProperty("partition_reassignments") Relationship reassignment,
+      @JsonProperty("partition_reassignments") Relationship partitionReassignments,
       @JsonProperty("consumer_groups") Relationship consumerGroups,
       @JsonProperty("topics") Relationship topics,
       @JsonProperty("topic_configs") Relationship topicConfigs
@@ -90,7 +90,7 @@ public abstract class ClusterData extends Resource {
         .setConsumerGroups(consumerGroups)
         .setTopics(topics)
         .setTopicConfigs(topicConfigs)
-        .setReassignment(reassignment)
+        .setPartitionReassignments(partitionReassignments)
         .build();
   }
 
@@ -116,7 +116,7 @@ public abstract class ClusterData extends Resource {
 
     public abstract Builder setTopicConfigs(Relationship topicConfigs);
 
-    public abstract Builder setReassignment(Relationship reassignment);
+    public abstract Builder setPartitionReassignments(Relationship partitionReassignments);
 
     public abstract ClusterData build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionData.java
@@ -43,6 +43,9 @@ public abstract class PartitionData extends Resource {
   @JsonProperty("replicas")
   public abstract Relationship getReplicas();
 
+  @JsonProperty("reassignment")
+  public abstract Relationship getReassignment();
+
   public static Builder builder() {
     return new AutoValue_PartitionData.Builder().setKind("KafkaPartition");
   }
@@ -62,7 +65,8 @@ public abstract class PartitionData extends Resource {
       @JsonProperty("topic_name") String topicName,
       @JsonProperty("partition_id") int partitionId,
       @JsonProperty("leader") @Nullable Relationship leader,
-      @JsonProperty("replicas") Relationship replicas
+      @JsonProperty("replicas") Relationship replicas,
+      @JsonProperty("reassignment") Relationship reassignment
   ) {
     return builder()
         .setKind(kind)
@@ -72,6 +76,7 @@ public abstract class PartitionData extends Resource {
         .setPartitionId(partitionId)
         .setLeader(leader)
         .setReplicas(replicas)
+        .setReassignment(reassignment)
         .build();
   }
 
@@ -90,6 +95,8 @@ public abstract class PartitionData extends Resource {
     public abstract Builder setLeader(@Nullable Relationship leader);
 
     public abstract Builder setReplicas(Relationship replicas);
+
+    public abstract Builder setReassignment(Relationship reassignment);
 
     public abstract PartitionData build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -44,7 +44,7 @@ public abstract class TopicData extends Resource {
   @JsonProperty("configs")
   public abstract Relationship getConfigs();
 
-  @JsonProperty("reassignment")
+  @JsonProperty("partition_reassignments")
   public abstract Relationship getReassignment();
 
   public static Builder builder() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -45,7 +45,7 @@ public abstract class TopicData extends Resource {
   public abstract Relationship getConfigs();
 
   @JsonProperty("partition_reassignments")
-  public abstract Relationship getReassignment();
+  public abstract Relationship getPartitionReassignments();
 
   public static Builder builder() {
     return new AutoValue_TopicData.Builder().setKind("KafkaTopic");
@@ -69,7 +69,7 @@ public abstract class TopicData extends Resource {
       @JsonProperty("replication_factor") int replicationFactor,
       @JsonProperty("partitions") Relationship partitions,
       @JsonProperty("configs") Relationship configs,
-      @JsonProperty("partition_reassignments") Relationship reassignment
+      @JsonProperty("partition_reassignments") Relationship partitionReassignments
   ) {
     return builder()
         .setKind(kind)
@@ -80,7 +80,7 @@ public abstract class TopicData extends Resource {
         .setReplicationFactor(replicationFactor)
         .setPartitions(partitions)
         .setConfigs(configs)
-        .setReassignment(reassignment)
+        .setPartitionReassignments(partitionReassignments)
         .build();
   }
 
@@ -102,7 +102,7 @@ public abstract class TopicData extends Resource {
 
     public abstract Builder setConfigs(Relationship configs);
 
-    public abstract Builder setReassignment(Relationship reassignment);
+    public abstract Builder setPartitionReassignments(Relationship partitionReassignments);
 
     public abstract TopicData build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -44,6 +44,9 @@ public abstract class TopicData extends Resource {
   @JsonProperty("configs")
   public abstract Relationship getConfigs();
 
+  @JsonProperty("reassignment")
+  public abstract Relationship getReassignment();
+
   public static Builder builder() {
     return new AutoValue_TopicData.Builder().setKind("KafkaTopic");
   }
@@ -65,7 +68,8 @@ public abstract class TopicData extends Resource {
       @JsonProperty("is_internal") boolean isInternal,
       @JsonProperty("replication_factor") int replicationFactor,
       @JsonProperty("partitions") Relationship partitions,
-      @JsonProperty("configs") Relationship configs
+      @JsonProperty("configs") Relationship configs,
+      @JsonProperty("reassignment") Relationship reassignment
   ) {
     return builder()
         .setKind(kind)
@@ -76,6 +80,7 @@ public abstract class TopicData extends Resource {
         .setReplicationFactor(replicationFactor)
         .setPartitions(partitions)
         .setConfigs(configs)
+        .setReassignment(reassignment)
         .build();
   }
 
@@ -96,6 +101,8 @@ public abstract class TopicData extends Resource {
     public abstract Builder setPartitions(Relationship partitions);
 
     public abstract Builder setConfigs(Relationship configs);
+
+    public abstract Builder setReassignment(Relationship reassignment);
 
     public abstract TopicData build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -69,7 +69,7 @@ public abstract class TopicData extends Resource {
       @JsonProperty("replication_factor") int replicationFactor,
       @JsonProperty("partitions") Relationship partitions,
       @JsonProperty("configs") Relationship configs,
-      @JsonProperty("reassignment") Relationship reassignment
+      @JsonProperty("partition_reassignments") Relationship reassignment
   ) {
     return builder()
         .setKind(kind)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
@@ -115,7 +115,11 @@ public final class ClustersResource {
                     urlFactory.create("v3", "clusters", cluster.getClusterId(), "broker-configs")))
             .setTopicConfigs(
                 Resource.Relationship.create(
-                    urlFactory.create("v3", "clusters", cluster.getClusterId(), "topic-configs")));
+                    urlFactory.create("v3", "clusters", cluster.getClusterId(), "topic-configs")))
+            .setReassignment(
+                Resource.Relationship.create(
+                    urlFactory.create("v3", "clusters", cluster.getClusterId(), "topics", "-",
+                        "partitions", "-", "reassignment")));
 
     if (cluster.getController() != null) {
       clusterData.setController(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
@@ -122,7 +122,7 @@ public final class ClustersResource {
             .setTopicConfigs(
                 Resource.Relationship.create(
                     urlFactory.create("v3", "clusters", cluster.getClusterId(), "topic-configs")))
-            .setReassignment(
+            .setPartitionReassignments(
                 Resource.Relationship.create(
                     urlFactory.create("v3", "clusters", cluster.getClusterId(), "topics", "-",
                         "partitions", "-", "reassignment")));

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ListAllReassignmentsAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ListAllReassignmentsAction.java
@@ -39,7 +39,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 
-@Path("/v3/clusters/{clusterId}/topics/-/partitions/-/reassignments")
+@Path("/v3/clusters/{clusterId}/topics/-/partitions/-/reassignment")
 public final class ListAllReassignmentsAction {
 
   private final Provider<ReassignmentManager> reassignmentManager;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -142,7 +142,18 @@ public final class PartitionsResource {
                         partition.getTopicName(),
                         "partitions",
                         Integer.toString(partition.getPartitionId()),
-                        "replicas")));
+                        "replicas")))
+        .setReassignment(
+            Resource.Relationship.create(
+                urlFactory.create(
+                    "v3",
+                    "clusters",
+                    partition.getClusterId(),
+                    "topics",
+                    partition.getTopicName(),
+                    "partitions",
+                    Integer.toString(partition.getPartitionId()),
+                    "reassignment")));
 
     partition.getLeader()
         .map(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReassignmentsByTopicAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReassignmentsByTopicAction.java
@@ -39,7 +39,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 
-@Path("/v3/clusters/{clusterId}/topics/{topicName}/partitions/-/reassignments")
+@Path("/v3/clusters/{clusterId}/topics/{topicName}/partitions/-/reassignment")
 public final class SearchReassignmentsByTopicAction {
 
   private final Provider<ReassignmentManager> reassignmentManager;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -196,6 +196,17 @@ public final class TopicsResource {
                     "topics",
                     topic.getName(),
                     "configs")))
+        .setReassignment(
+            Resource.Relationship.create(
+                urlFactory.create(
+                    "v3",
+                    "clusters",
+                    topic.getClusterId(),
+                    "topics",
+                    topic.getName(),
+                    "partitions",
+                    "-",
+                    "reassignment")))
         .build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -196,7 +196,7 @@ public final class TopicsResource {
                     "topics",
                     topic.getName(),
                     "configs")))
-        .setReassignment(
+        .setPartitionReassignments(
             Resource.Relationship.create(
                 urlFactory.create(
                     "v3",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -75,6 +75,10 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                             .setTopicConfigs(
                                 Resource.Relationship.create(
                                     baseUrl + "/v3/clusters/" + clusterId + "/topic-configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    baseUrl + "/v3/clusters/" + clusterId +
+                                        "/topics/-/partitions/-/reassignment"))
                             .build()))
                 .build());
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -119,6 +119,10 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicConfigs(
                     Resource.Relationship.create(
                         baseUrl + "/v3/clusters/" + clusterId + "/topic-configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        baseUrl + "/v3/clusters/" + clusterId +
+                            "/topics/-/partitions/-/reassignment"))
                 .build());
 
     Response response =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -81,7 +81,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                             .setTopicConfigs(
                                 Resource.Relationship.create(
                                     baseUrl + "/v3/clusters/" + clusterId + "/topic-configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     baseUrl + "/v3/clusters/" + clusterId +
                                         "/topics/-/partitions/-/reassignment"))
@@ -131,7 +131,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicConfigs(
                     Resource.Relationship.create(
                         baseUrl + "/v3/clusters/" + clusterId + "/topic-configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         baseUrl + "/v3/clusters/" + clusterId +
                             "/topics/-/partitions/-/reassignment"))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/GetReassignmentActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/GetReassignmentActionIntegrationTest.java
@@ -78,7 +78,7 @@ public class GetReassignmentActionIntegrationTest extends ClusterTestHarness {
 
     Response response =
         request("/v3/clusters/foobar/topics/" + TOPIC_NAME + "/partitions/" + PARTITION_ID
-            + "/reassignments")
+            + "/reassignment")
             .accept(MediaType.APPLICATION_JSON)
             .get();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -89,7 +89,7 @@ public class GetReassignmentActionIntegrationTest extends ClusterTestHarness {
     String clusterId = getClusterId();
 
     Response response = request("/v3/clusters/" + clusterId + "/topics/foobar/partitions/"
-        + PARTITION_ID + "/reassignments")
+        + PARTITION_ID + "/reassignment")
         .accept(MediaType.APPLICATION_JSON)
         .get();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
@@ -100,7 +100,7 @@ public class GetReassignmentActionIntegrationTest extends ClusterTestHarness {
     String clusterId = getClusterId();
 
     Response response = request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME
-        + "/partitions/10/reassignments")
+        + "/partitions/10/reassignment")
         .accept(MediaType.APPLICATION_JSON)
         .get();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ListAllReassignmentsActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ListAllReassignmentsActionIntegrationTest.java
@@ -45,7 +45,7 @@ public class ListAllReassignmentsActionIntegrationTest extends ClusterTestHarnes
     alterPartitionReassignment(reassignmentMap);
 
     Response response =
-        request("/v3/clusters/" + clusterId + "/topics/-/partitions/-/reassignments")
+        request("/v3/clusters/" + clusterId + "/topics/-/partitions/-/reassignment")
             .accept(MediaType.APPLICATION_JSON)
             .get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -64,7 +64,7 @@ public class ListAllReassignmentsActionIntegrationTest extends ClusterTestHarnes
   @Test
   public void listAllReassignments_nonExistingCluster_returnsNotFound() throws Exception {
 
-    Response response = request("/v3/clusters/foobar/topics/-/partitions/-/reassignments")
+    Response response = request("/v3/clusters/foobar/topics/-/partitions/-/reassignment")
         .accept(MediaType.APPLICATION_JSON)
         .get();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/PartitionsResourceIntegrationTest.java
@@ -94,6 +94,12 @@ public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_NAME
                                         + "/partitions/0/replicas"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    baseUrl
+                                        + "/v3/clusters/" + clusterId
+                                        + "/topics/" + TOPIC_NAME
+                                        + "/partitions/0/reassignment"))
                             .build()))
                 .build());
 
@@ -160,6 +166,12 @@ public class PartitionsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + TOPIC_NAME
                             + "/partitions/0/replicas"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_NAME
+                            + "/partitions/0/reassignment"))
                 .build());
 
     Response response =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/SearchReassignmentsByTopicActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/SearchReassignmentsByTopicActionIntegrationTest.java
@@ -62,7 +62,7 @@ public class SearchReassignmentsByTopicActionIntegrationTest extends ClusterTest
     alterPartitionReassignment(reassignmentMap);
 
     Response response = request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME +
-        "/partitions/-/reassignments")
+        "/partitions/-/reassignment")
         .accept(MediaType.APPLICATION_JSON)
         .get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
@@ -80,7 +80,7 @@ public class SearchReassignmentsByTopicActionIntegrationTest extends ClusterTest
   public void searchReassignmentsByTopic_nonExistingCluster_returnsNotFound() throws Exception {
 
     Response response =
-        request("/v3/clusters/foobar/topics/topic-1/partitions/-/reassignments")
+        request("/v3/clusters/foobar/topics/topic-1/partitions/-/reassignment")
             .accept(MediaType.APPLICATION_JSON)
             .get();
 
@@ -92,7 +92,7 @@ public class SearchReassignmentsByTopicActionIntegrationTest extends ClusterTest
     String clusterId = getClusterId();
 
     Response response =
-        request("/v3/clusters/" + clusterId + "/topics/foobar/partitions/-/reassignments")
+        request("/v3/clusters/" + clusterId + "/topics/foobar/partitions/-/reassignment")
             .accept(MediaType.APPLICATION_JSON)
             .get();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -106,7 +106,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_1
                                         + "/configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     baseUrl
                                         + "/v3/clusters/" + clusterId
@@ -139,7 +139,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_2
                                         + "/configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     baseUrl
                                     + "/v3/clusters/" + clusterId
@@ -172,7 +172,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_3
                                         + "/configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     baseUrl
                                         + "/v3/clusters/" + clusterId
@@ -228,7 +228,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + TOPIC_1
                             + "/configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -292,7 +292,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + topicName
                             + "/configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -418,7 +418,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + topicName
                             + "/configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         baseUrl
                             + "/v3/clusters/" + clusterId
@@ -471,7 +471,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + topicName
                             + "/configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         baseUrl
                             + "/v3/clusters/" + clusterId

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -106,6 +106,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_1
                                         + "/configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    baseUrl
+                                        + "/v3/clusters/" + clusterId
+                                        + "/topics/" + TOPIC_1
+                                        + "/partitions/-/reassignment"))
                             .build(),
                         TopicData.builder()
                             .setMetadata(
@@ -133,6 +139,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_2
                                         + "/configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    baseUrl
+                                    + "/v3/clusters/" + clusterId
+                                    + "/topics/" + TOPIC_2
+                                    + "/partitions/-/reassignment"))
                             .build(),
                         TopicData.builder()
                             .setMetadata(
@@ -160,6 +172,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                         + "/v3/clusters/" + clusterId
                                         + "/topics/" + TOPIC_3
                                         + "/configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    baseUrl
+                                        + "/v3/clusters/" + clusterId
+                                        + "/topics/" + TOPIC_3
+                                        + "/partitions/-/reassignment"))
                             .build()))
                 .build());
 
@@ -210,6 +228,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + TOPIC_1
                             + "/configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + TOPIC_1
+                            + "/partitions/-/reassignment"))
                 .build());
 
     Response response =
@@ -268,6 +292,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + topicName
                             + "/configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/partitions/-/reassignment"))
                 .build());
 
     Response response =
@@ -388,6 +418,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + topicName
                             + "/configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/partitions/-/reassignment"))
                 .build());
 
     Response createTopicResponse =
@@ -435,6 +471,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/v3/clusters/" + clusterId
                             + "/topics/" + topicName
                             + "/configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/partitions/-/reassignment"))
                 .build());
 
     Response existingTopicResponse =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -110,7 +110,7 @@ public class ClustersResourceTest {
                             .setTopicConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topic-configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/-/partitions/-/reassignment"))
                             .build()))
@@ -158,7 +158,7 @@ public class ClustersResourceTest {
                 .setTopics(Resource.Relationship.create("/v3/clusters/cluster-1/topics"))
                 .setTopicConfigs(
                     Resource.Relationship.create("/v3/clusters/cluster-1/topic-configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create("/v3/clusters/cluster-1/topics/-/partitions"
                         + "/-/reassignment"))
                 .build());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ClustersResourceTest.java
@@ -106,6 +106,9 @@ public class ClustersResourceTest {
                             .setTopicConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topic-configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/-/partitions/-/reassignment"))
                             .build()))
                 .build());
 
@@ -148,6 +151,9 @@ public class ClustersResourceTest {
                     Resource.Relationship.create("/v3/clusters/cluster-1/broker-configs"))
                 .setTopicConfigs(
                     Resource.Relationship.create("/v3/clusters/cluster-1/topic-configs"))
+                .setReassignment(
+                    Resource.Relationship.create("/v3/clusters/cluster-1/topics/-/partitions"
+                        + "/-/reassignment"))
                 .build());
 
     assertEquals(expected, response.getValue());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/PartitionsResourceTest.java
@@ -186,6 +186,10 @@ public class PartitionsResourceTest {
                             .setReplicas(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/topic-1/partitions/0"
+                                        + "/reassignment"))
                             .build(),
                         PartitionData.builder()
                             .setMetadata(
@@ -204,6 +208,10 @@ public class PartitionsResourceTest {
                             .setReplicas(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/topic-1/partitions/1"
+                                        + "/reassignment"))
                             .build(),
                         PartitionData.builder()
                             .setMetadata(
@@ -222,6 +230,9 @@ public class PartitionsResourceTest {
                             .setReplicas(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment"))
                             .build()))
                 .build());
 
@@ -266,6 +277,9 @@ public class PartitionsResourceTest {
                 .setReplicas(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/0/replicas"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/0/reassignment"))
                 .build());
 
     assertEquals(expected, response.getValue());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -368,6 +368,10 @@ public class TopicsResourceTest {
                             .setConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-1/configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/topic-1/partitions"
+                                        + "/-/reassignment"))
                             .build(),
                         TopicData.builder()
                             .setMetadata(
@@ -385,6 +389,10 @@ public class TopicsResourceTest {
                             .setConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-2/configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/topic-2/partitions"
+                                        + "/-/reassignment"))
                             .build(),
                         TopicData.builder()
                             .setMetadata(
@@ -402,6 +410,10 @@ public class TopicsResourceTest {
                             .setConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-3/configs"))
+                            .setReassignment(
+                                Resource.Relationship.create(
+                                    "/v3/clusters/cluster-1/topics/topic-3/partitions"
+                                        + "/-/reassignment"))
                             .build()))
                 .build());
 
@@ -459,6 +471,9 @@ public class TopicsResourceTest {
                 .setConfigs(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
                 .build());
 
     assertEquals(expected, response.getValue());
@@ -530,6 +545,9 @@ public class TopicsResourceTest {
                 .setConfigs(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/configs"))
+                .setReassignment(
+                    Resource.Relationship.create(
+                        "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
                 .build());
 
     assertEquals(expected, response.getValue());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -368,7 +368,7 @@ public class TopicsResourceTest {
                             .setConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-1/partitions"
                                         + "/-/reassignment"))
@@ -389,7 +389,7 @@ public class TopicsResourceTest {
                             .setConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-2/configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-2/partitions"
                                         + "/-/reassignment"))
@@ -410,7 +410,7 @@ public class TopicsResourceTest {
                             .setConfigs(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-3/configs"))
-                            .setReassignment(
+                            .setPartitionReassignments(
                                 Resource.Relationship.create(
                                     "/v3/clusters/cluster-1/topics/topic-3/partitions"
                                         + "/-/reassignment"))
@@ -471,7 +471,7 @@ public class TopicsResourceTest {
                 .setConfigs(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
                 .build());
@@ -545,7 +545,7 @@ public class TopicsResourceTest {
                 .setConfigs(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                .setReassignment(
+                .setPartitionReassignments(
                     Resource.Relationship.create(
                         "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
                 .build());


### PR DESCRIPTION
### What
- Added relationship for reassignment to cluster, topic and partition.
- Refactor `reassignments` to `reassignment` since it is indeed a resource not a collection.

### Testing
Modified unit and integration tests.
Tested locally with `mvn test`
  