### PR TITLE
Add Batch Alter (UPDATE/DELETE) Broker/Cluster/Topic configs.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManager.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.BrokerConfig;
 import java.util.List;
 import java.util.Optional;
@@ -45,4 +46,10 @@ public interface BrokerConfigManager {
    * Resets the Kafka {@link BrokerConfig} with the given {@code name} to its default value.
    */
   CompletableFuture<Void> resetBrokerConfig(String clusterId, int brokerId, String name);
+
+  /**
+   * Atomically alters the Kafka {@link BrokerConfig Broker Configs} according to {@code commands}.
+   */
+  CompletableFuture<Void> alterBrokerConfigs(
+      String clusterId, int brokerId, List<AlterConfigCommand> commands);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.BrokerConfig;
 import java.util.List;
 import java.util.Optional;
@@ -70,5 +71,15 @@ final class BrokerConfigManagerImpl
         new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId)),
         BrokerConfig.builder().setClusterId(clusterId).setBrokerId(brokerId),
         name);
+  }
+
+  @Override
+  public CompletableFuture<Void> alterBrokerConfigs(
+      String clusterId, int brokerId, List<AlterConfigCommand> commands) {
+    return safeAlterConfigs(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(brokerId)),
+        BrokerConfig.builder().setClusterId(clusterId).setBrokerId(brokerId),
+        commands);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManager.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.ClusterConfig;
 import java.util.List;
 import java.util.Optional;
@@ -46,4 +47,11 @@ public interface ClusterConfigManager {
    */
   CompletableFuture<Void> deleteClusterConfig(
       String clusterId, ClusterConfig.Type type, String name);
+
+  /**
+   * Atomically alters the Kafka {@link ClusterConfig Cluster Configs} according to {@code
+   * commands}.
+   */
+  CompletableFuture<Void> alterClusterConfigs(
+      String clusterId, ClusterConfig.Type type, List<AlterConfigCommand> commands);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.ClusterConfig;
 import java.util.List;
 import java.util.Optional;
@@ -68,5 +69,11 @@ final class ClusterConfigManagerImpl
     // currently of knowing which config names are valid to delete. So we skip the existence check.
     // If the config is not valid, it will fail silently.
     return unsafeResetConfig(clusterId, new ConfigResource(type.getAdminType(), ""), name);
+  }
+
+  @Override
+  public CompletableFuture<Void> alterClusterConfigs(
+      String clusterId, ClusterConfig.Type type, List<AlterConfigCommand> commands) {
+    return unsafeAlterConfigs(clusterId, new ConfigResource(type.getAdminType(), ""), commands);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManager.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.TopicConfig;
 import java.util.List;
 import java.util.Optional;
@@ -48,4 +49,10 @@ public interface TopicConfigManager {
    * Resets the Kafka {@link TopicConfig} with the given {@code name} to its default value.
    */
   CompletableFuture<Void> resetTopicConfig(String clusterId, String topicName, String name);
+
+  /**
+   * Atomically alters the Kafka {@link TopicConfig Topic Configs} according to {@code commands}.
+   */
+  CompletableFuture<Void> alterTopicConfigs(
+      String clusterId, String topicName, List<AlterConfigCommand> commands);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.TopicConfig;
 import java.util.List;
 import java.util.Optional;
@@ -69,5 +70,15 @@ final class TopicConfigManagerImpl
         new ConfigResource(ConfigResource.Type.TOPIC, topicName),
         TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
         name);
+  }
+
+  @Override
+  public CompletableFuture<Void> alterTopicConfigs(
+      String clusterId, String topicName, List<AlterConfigCommand> commands) {
+    return safeAlterConfigs(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.TOPIC, topicName),
+        TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
+        commands);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AlterConfigCommand.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AlterConfigCommand.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import com.google.auto.value.AutoValue;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+
+public abstract class AlterConfigCommand {
+
+  private AlterConfigCommand() {
+  }
+
+  public static AlterConfigCommand update(String name, @Nullable String value) {
+    return UpdateConfigCommand.create(name, value);
+  }
+
+  public static AlterConfigCommand delete(String name) {
+    return DeleteConfigCommand.create(name);
+  }
+
+  public abstract String getName();
+
+  public abstract AlterConfigOp toAlterConfigOp();
+
+  @AutoValue
+  abstract static class UpdateConfigCommand extends AlterConfigCommand {
+
+    UpdateConfigCommand() {
+    }
+
+    abstract Optional<String> getValue();
+
+    private static UpdateConfigCommand create(String name, @Nullable String value) {
+      return new AutoValue_AlterConfigCommand_UpdateConfigCommand(name, Optional.ofNullable(value));
+    }
+
+    @Override
+    public final AlterConfigOp toAlterConfigOp() {
+      return new AlterConfigOp(
+          new ConfigEntry(getName(), getValue().orElse(null)), AlterConfigOp.OpType.SET);
+    }
+  }
+
+  @AutoValue
+  abstract static class DeleteConfigCommand extends AlterConfigCommand {
+
+    DeleteConfigCommand() {
+    }
+
+    private static DeleteConfigCommand create(String name) {
+      return new AutoValue_AlterConfigCommand_DeleteConfigCommand(name);
+    }
+
+    @Override
+    public final AlterConfigOp toAlterConfigOp() {
+      return new AlterConfigOp(
+          new ConfigEntry(getName(), /* value= */ null), AlterConfigOp.OpType.DELETE);
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterBrokerConfigBatchRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterBrokerConfigBatchRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class AlterBrokerConfigBatchRequest {
+
+  AlterBrokerConfigBatchRequest() {
+  }
+
+  @JsonValue
+  public abstract AlterConfigBatchRequestData getValue();
+
+  public static AlterBrokerConfigBatchRequest create(AlterConfigBatchRequestData value) {
+    return new AutoValue_AlterBrokerConfigBatchRequest(value);
+  }
+
+  @JsonCreator
+  static AlterBrokerConfigBatchRequest fromJson(AlterConfigBatchRequestData value) {
+    return create(value);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterClusterConfigBatchRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterClusterConfigBatchRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class AlterClusterConfigBatchRequest {
+
+  AlterClusterConfigBatchRequest() {
+  }
+
+  @JsonValue
+  public abstract AlterConfigBatchRequestData getValue();
+
+  public static AlterClusterConfigBatchRequest create(AlterConfigBatchRequestData value) {
+    return new AutoValue_AlterClusterConfigBatchRequest(value);
+  }
+
+  @JsonCreator
+  static AlterClusterConfigBatchRequest fromJson(AlterConfigBatchRequestData value) {
+    return create(value);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterConfigBatchRequestData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterConfigBatchRequestData.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import static java.util.Collections.unmodifiableList;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import io.confluent.kafkarest.entities.AlterConfigCommand;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class AlterConfigBatchRequestData {
+
+  AlterConfigBatchRequestData() {
+  }
+
+  @JsonProperty("data")
+  public abstract ImmutableList<AlterEntry> getData();
+
+  public static AlterConfigBatchRequestData create(List<AlterEntry> data) {
+    return new AutoValue_AlterConfigBatchRequestData(ImmutableList.copyOf(data));
+  }
+
+  @JsonCreator
+  static AlterConfigBatchRequestData fromJson(@JsonProperty("data") List<AlterEntry> data) {
+    return create(data);
+  }
+
+  public final List<AlterConfigCommand> toAlterConfigCommands() {
+    ArrayList<AlterConfigCommand> commands = new ArrayList<>();
+    for (AlterEntry entry : getData()) {
+      switch (entry.getOperation()) {
+        case UPDATE:
+          commands.add(AlterConfigCommand.update(entry.getName(), entry.getValue().orElse(null)));
+          break;
+
+        case DELETE:
+          commands.add(AlterConfigCommand.delete(entry.getName()));
+          break;
+
+        default:
+          throw new AssertionError("unreachable");
+      }
+    }
+    return unmodifiableList(commands);
+  }
+
+  @AutoValue
+  public abstract static class AlterEntry {
+
+    @JsonProperty("name")
+    public abstract String getName();
+
+    @JsonProperty("value")
+    public abstract Optional<String> getValue();
+
+    @JsonProperty("operation")
+    public abstract AlterOperation getOperation();
+
+    public static Builder builder() {
+      return new AutoValue_AlterConfigBatchRequestData_AlterEntry.Builder()
+          .setOperation(AlterOperation.UPDATE);
+    }
+
+    @JsonCreator
+    static AlterEntry fromJson(
+        @JsonProperty("name") String name,
+        @JsonProperty("value") @Nullable String value,
+        @JsonProperty("operation") @Nullable AlterOperation operation
+    ) {
+      return builder()
+          .setName(name)
+          .setValue(value)
+          .setOperation(operation != null ? operation : AlterOperation.UPDATE)
+          .build();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder setName(String name);
+
+      public abstract Builder setValue(@Nullable String value);
+
+      public abstract Builder setOperation(AlterOperation operation);
+
+      public abstract AlterEntry build();
+    }
+  }
+
+  public enum AlterOperation {
+
+    UPDATE,
+
+    DELETE
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterTopicConfigBatchRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterTopicConfigBatchRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class AlterTopicConfigBatchRequest {
+
+  AlterTopicConfigBatchRequest() {
+  }
+
+  @JsonValue
+  public abstract AlterConfigBatchRequestData getValue();
+
+  public static AlterTopicConfigBatchRequest create(AlterConfigBatchRequestData value) {
+    return new AutoValue_AlterTopicConfigBatchRequest(value);
+  }
+
+  @JsonCreator
+  static AlterTopicConfigBatchRequest fromJson(AlterConfigBatchRequestData value) {
+    return create(value);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.controllers.BrokerConfigManager;
+import io.confluent.kafkarest.entities.v3.AlterBrokerConfigBatchRequest;
+import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+@Path("/v3/clusters/{clusterId}/brokers/{brokerId}/configs:alter")
+public final class AlterBrokerConfigBatchAction {
+
+  private final Provider<BrokerConfigManager> brokerConfigManager;
+
+  @Inject
+  public AlterBrokerConfigBatchAction(Provider<BrokerConfigManager> brokerConfigManager) {
+    this.brokerConfigManager = requireNonNull(brokerConfigManager);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public void alterBrokerConfigBatch(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("brokerId") int brokerId,
+      @Valid AlterBrokerConfigBatchRequest request
+  ) {
+    CompletableFuture<Void> response =
+        brokerConfigManager.get()
+            .alterBrokerConfigs(clusterId, brokerId, request.getValue().toAlterConfigCommands());
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchAction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.controllers.ClusterConfigManager;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.v3.AlterClusterConfigBatchRequest;
+import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+@Path("/v3/clusters/{clusterId}/{config_type}-configs:alter")
+public final class AlterClusterConfigBatchAction {
+
+  private final Provider<ClusterConfigManager> clusterConfigManager;
+
+  @Inject
+  public AlterClusterConfigBatchAction(Provider<ClusterConfigManager> clusterConfigManager) {
+    this.clusterConfigManager = requireNonNull(clusterConfigManager);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public void alterClusterConfigBatch(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("config_type") ClusterConfig.Type configType,
+      @Valid AlterClusterConfigBatchRequest request
+  ) {
+    CompletableFuture<Void> response =
+        clusterConfigManager.get()
+            .alterClusterConfigs(clusterId, configType, request.getValue().toAlterConfigCommands());
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.controllers.TopicConfigManager;
+import io.confluent.kafkarest.entities.v3.AlterTopicConfigBatchRequest;
+import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+@Path("/v3/clusters/{clusterId}/topics/{topicName}/configs:alter")
+public final class AlterTopicConfigBatchAction {
+
+  private final Provider<TopicConfigManager> topicConfigManager;
+
+  @Inject
+  public AlterTopicConfigBatchAction(Provider<TopicConfigManager> topicConfigManager) {
+    this.topicConfigManager = requireNonNull(topicConfigManager);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public void alterTopicConfigBatch(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @PathParam("topicName") String topicName,
+      @Valid AlterTopicConfigBatchRequest request
+  ) {
+    CompletableFuture<Void> response =
+        topicConfigManager.get()
+            .alterTopicConfigs(clusterId, topicName, request.getValue().toAlterConfigCommands());
+
+    AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
@@ -23,6 +23,9 @@ public final class V3ResourcesFeature implements Feature {
   @Override
   public boolean configure(FeatureContext configurable) {
     configurable.register(AclsResource.class);
+    configurable.register(AlterBrokerConfigBatchAction.class);
+    configurable.register(AlterClusterConfigBatchAction.class);
+    configurable.register(AlterTopicConfigBatchAction.class);
     configurable.register(BrokerConfigsResource.class);
     configurable.register(BrokersResource.class);
     configurable.register(ClusterConfigsResource.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokerConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokerConfigsResourceIntegrationTest.java
@@ -513,4 +513,120 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
             .delete();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
+
+  @Test
+  public void alterConfigBatch_withExistingConfig() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+    int brokerId = getBrokers().get(0).id();
+
+    Response updateResponse =
+        request(
+            "/v3/clusters/" + clusterId + "/brokers/" + brokerId + "/configs:alter")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(
+                Entity.entity(
+                    "{\"data\":["
+                        + "{\"name\": \"max.connections\",\"value\":\"1000\"},"
+                        + "{\"name\": \"compression.type\",\"value\":\"gzip\"}]}",
+                    MediaType.APPLICATION_JSON));
+    assertEquals(Status.NO_CONTENT.getStatusCode(), updateResponse.getStatus());
+
+    GetBrokerConfigResponse expectedAfterUpdate1 =
+        GetBrokerConfigResponse.create(
+            BrokerConfigData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(
+                            baseUrl
+                                + "/v3/clusters/" + clusterId
+                                + "/brokers/" + brokerId
+                                + "/configs/max.connections")
+                        .setResourceName(
+                            "crn:///kafka=" + clusterId
+                                + "/broker=" + brokerId
+                                + "/config=max.connections")
+                        .build())
+                .setClusterId(clusterId)
+                .setBrokerId(brokerId)
+                .setName("max.connections")
+                .setValue("1000")
+                .setDefault(false)
+                .setReadOnly(false)
+                .setSensitive(false)
+                .setSource(ConfigSource.DYNAMIC_BROKER_CONFIG)
+                .setSynonyms(
+                    Arrays.asList(
+                        ConfigSynonymData.builder()
+                            .setName("max.connections")
+                            .setValue("1000")
+                            .setSource(ConfigSource.DYNAMIC_BROKER_CONFIG)
+                            .build(),
+                        ConfigSynonymData.builder()
+                            .setName("max.connections")
+                            .setValue("2147483647")
+                            .setSource(ConfigSource.DEFAULT_CONFIG)
+                            .build()))
+                .build());
+    GetBrokerConfigResponse expectedAfterUpdate2 =
+        GetBrokerConfigResponse.create(
+            BrokerConfigData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(
+                            baseUrl
+                                + "/v3/clusters/" + clusterId
+                                + "/brokers/" + brokerId
+                                + "/configs/compression.type")
+                        .setResourceName(
+                            "crn:///kafka=" + clusterId
+                                + "/broker=" + brokerId
+                                + "/config=compression.type")
+                        .build())
+                .setClusterId(clusterId)
+                .setBrokerId(brokerId)
+                .setName("compression.type")
+                .setValue("gzip")
+                .setDefault(false)
+                .setReadOnly(false)
+                .setSensitive(false)
+                .setSource(ConfigSource.DYNAMIC_BROKER_CONFIG)
+                .setSynonyms(
+                    Arrays.asList(
+                        ConfigSynonymData.builder()
+                            .setName("compression.type")
+                            .setValue("gzip")
+                            .setSource(ConfigSource.DYNAMIC_BROKER_CONFIG)
+                            .build(),
+                        ConfigSynonymData.builder()
+                            .setName("compression.type")
+                            .setValue("producer")
+                            .setSource(ConfigSource.DEFAULT_CONFIG)
+                            .build()))
+                .build());
+
+    Response responseAfterUpdate1 =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/max.connections")
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
+    GetBrokerConfigResponse actualResponseAfterUpdate1 =
+        responseAfterUpdate1.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+
+    Response responseAfterUpdate2 =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/compression.type")
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
+    GetBrokerConfigResponse actualResponseAfterUpdate2 =
+        responseAfterUpdate2.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+  }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClusterConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClusterConfigsResourceIntegrationTest.java
@@ -282,4 +282,120 @@ public class ClusterConfigsResourceIntegrationTest extends ClusterTestHarness {
             .delete();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
+
+  @Test
+  public void alterConfigBatch_withExistingConfig() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+    int brokerId = getBrokers().get(0).id();
+
+    Response updateResponse =
+        request(
+            "/v3/clusters/" + clusterId + "/broker-configs:alter")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(
+                Entity.entity(
+                    "{\"data\":["
+                        + "{\"name\": \"max.connections\",\"value\":\"1000\"},"
+                        + "{\"name\": \"compression.type\",\"value\":\"gzip\"}]}",
+                    MediaType.APPLICATION_JSON));
+    assertEquals(Status.NO_CONTENT.getStatusCode(), updateResponse.getStatus());
+
+    GetBrokerConfigResponse expectedAfterUpdate1 =
+        GetBrokerConfigResponse.create(
+            BrokerConfigData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(
+                            baseUrl
+                                + "/v3/clusters/" + clusterId
+                                + "/brokers/" + brokerId
+                                + "/configs/max.connections")
+                        .setResourceName(
+                            "crn:///kafka=" + clusterId
+                                + "/broker=" + brokerId
+                                + "/config=max.connections")
+                        .build())
+                .setClusterId(clusterId)
+                .setBrokerId(brokerId)
+                .setName("max.connections")
+                .setValue("1000")
+                .setDefault(false)
+                .setReadOnly(false)
+                .setSensitive(false)
+                .setSource(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)
+                .setSynonyms(
+                    Arrays.asList(
+                        ConfigSynonymData.builder()
+                            .setName("max.connections")
+                            .setValue("1000")
+                            .setSource(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)
+                            .build(),
+                        ConfigSynonymData.builder()
+                            .setName("max.connections")
+                            .setValue("2147483647")
+                            .setSource(ConfigSource.DEFAULT_CONFIG)
+                            .build()))
+                .build());
+    GetBrokerConfigResponse expectedAfterUpdate2 =
+        GetBrokerConfigResponse.create(
+            BrokerConfigData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(
+                            baseUrl
+                                + "/v3/clusters/" + clusterId
+                                + "/brokers/" + brokerId
+                                + "/configs/compression.type")
+                        .setResourceName(
+                            "crn:///kafka=" + clusterId
+                                + "/broker=" + brokerId
+                                + "/config=compression.type")
+                        .build())
+                .setClusterId(clusterId)
+                .setBrokerId(brokerId)
+                .setName("compression.type")
+                .setValue("gzip")
+                .setDefault(false)
+                .setReadOnly(false)
+                .setSensitive(false)
+                .setSource(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)
+                .setSynonyms(
+                    Arrays.asList(
+                        ConfigSynonymData.builder()
+                            .setName("compression.type")
+                            .setValue("gzip")
+                            .setSource(ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)
+                            .build(),
+                        ConfigSynonymData.builder()
+                            .setName("compression.type")
+                            .setValue("producer")
+                            .setSource(ConfigSource.DEFAULT_CONFIG)
+                            .build()))
+                .build());
+
+    Response responseAfterUpdate1 =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/max.connections")
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
+    GetBrokerConfigResponse actualResponseAfterUpdate1 =
+        responseAfterUpdate1.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+
+    Response responseAfterUpdate2 =
+        request(
+            "/v3/clusters/" + clusterId
+                + "/brokers/" + brokerId
+                + "/configs/compression.type")
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
+    GetBrokerConfigResponse actualResponseAfterUpdate2 =
+        responseAfterUpdate2.readEntity(GetBrokerConfigResponse.class);
+    assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+  }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchActionTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static io.confluent.kafkarest.common.CompletableFutures.failedFuture;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafkarest.controllers.BrokerConfigManager;
+import io.confluent.kafkarest.entities.AlterConfigCommand;
+import io.confluent.kafkarest.entities.BrokerConfig;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.v3.AlterBrokerConfigBatchRequest;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterEntry;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterOperation;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import java.util.Arrays;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class AlterBrokerConfigBatchActionTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final int BROKER_ID = 1;
+
+  private static final BrokerConfig CONFIG_1 =
+      BrokerConfig.create(
+          CLUSTER_ID,
+          BROKER_ID,
+          "config-1",
+          "value-1",
+          /* isDefault= */ true,
+          /* isReadOnly= */ false,
+          /* isSensitive */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList());
+  private static final BrokerConfig CONFIG_2 =
+      BrokerConfig.create(
+          CLUSTER_ID,
+          BROKER_ID,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ true,
+          /* isSensitive */ false,
+          ConfigSource.STATIC_BROKER_CONFIG,
+          /* synonyms= */ emptyList());
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private BrokerConfigManager brokerConfigManager;
+
+  private AlterBrokerConfigBatchAction alterBrokerConfigBatchAction;
+
+  @Before
+  public void setUp() {
+    alterBrokerConfigBatchAction = new AlterBrokerConfigBatchAction(() -> brokerConfigManager);
+  }
+
+  @Test
+  public void alterBrokerConfigs_existingConfig_alterConfigs() {
+    expect(
+        brokerConfigManager.alterBrokerConfigs(
+            CLUSTER_ID,
+            BROKER_ID,
+            Arrays.asList(
+                AlterConfigCommand.update(CONFIG_1.getName(), "newValue"),
+                AlterConfigCommand.delete(CONFIG_2.getName()))))
+        .andReturn(completedFuture(null));
+    replay(brokerConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    alterBrokerConfigBatchAction.alterBrokerConfigBatch(
+        response,
+        CLUSTER_ID,
+        BROKER_ID,
+        AlterBrokerConfigBatchRequest.create(
+            AlterConfigBatchRequestData.create(
+                Arrays.asList(
+                    AlterEntry.builder()
+                        .setName(CONFIG_1.getName())
+                        .setValue("newValue")
+                        .build(),
+                    AlterEntry.builder()
+                        .setName(CONFIG_2.getName())
+                        .setOperation(AlterOperation.DELETE)
+                        .build()))));
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void alterBrokerConfigs_nonExistingCluster_throwsNotFound() {
+    expect(
+        brokerConfigManager.alterBrokerConfigs(
+            CLUSTER_ID,
+            BROKER_ID,
+            Arrays.asList(
+                AlterConfigCommand.update(CONFIG_1.getName(), "newValue"),
+                AlterConfigCommand.delete(CONFIG_2.getName()))))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(brokerConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    alterBrokerConfigBatchAction.alterBrokerConfigBatch(
+        response,
+        CLUSTER_ID,
+        BROKER_ID,
+        AlterBrokerConfigBatchRequest.create(
+            AlterConfigBatchRequestData.create(
+                Arrays.asList(
+                    AlterEntry.builder()
+                        .setName(CONFIG_1.getName())
+                        .setValue("newValue")
+                        .build(),
+                    AlterEntry.builder()
+                        .setName(CONFIG_2.getName())
+                        .setOperation(AlterOperation.DELETE)
+                        .build()))));
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchActionTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static io.confluent.kafkarest.common.CompletableFutures.failedFuture;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafkarest.controllers.ClusterConfigManager;
+import io.confluent.kafkarest.entities.AlterConfigCommand;
+import io.confluent.kafkarest.entities.ClusterConfig;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.v3.AlterClusterConfigBatchRequest;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterEntry;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterOperation;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import java.util.Arrays;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class AlterClusterConfigBatchActionTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+
+  private static final ClusterConfig CONFIG_1 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-1",
+          "value-1",
+          /* isDefault= */ true,
+          /* isReadOnly= */ false,
+          /* isSensitive */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+  private static final ClusterConfig CONFIG_2 =
+      ClusterConfig.create(
+          CLUSTER_ID,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ true,
+          /* isSensitive */ false,
+          ConfigSource.STATIC_BROKER_CONFIG,
+          /* synonyms= */ emptyList(),
+          ClusterConfig.Type.BROKER);
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private ClusterConfigManager clusterConfigManager;
+
+  private AlterClusterConfigBatchAction alterClusterConfigBatchAction;
+
+  @Before
+  public void setUp() {
+    alterClusterConfigBatchAction = new AlterClusterConfigBatchAction(() -> clusterConfigManager);
+  }
+
+  @Test
+  public void alterClusterConfigs_existingConfig_alterConfigs() {
+    expect(
+        clusterConfigManager.alterClusterConfigs(
+            CLUSTER_ID,
+            ClusterConfig.Type.BROKER,
+            Arrays.asList(
+                AlterConfigCommand.update(CONFIG_1.getName(), "newValue"),
+                AlterConfigCommand.delete(CONFIG_2.getName()))))
+        .andReturn(completedFuture(null));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    alterClusterConfigBatchAction.alterClusterConfigBatch(
+        response,
+        CLUSTER_ID,
+        ClusterConfig.Type.BROKER,
+        AlterClusterConfigBatchRequest.create(
+            AlterConfigBatchRequestData.create(
+                Arrays.asList(
+                    AlterEntry.builder()
+                        .setName(CONFIG_1.getName())
+                        .setValue("newValue")
+                        .build(),
+                    AlterEntry.builder()
+                        .setName(CONFIG_2.getName())
+                        .setOperation(AlterOperation.DELETE)
+                        .build()))));
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void alterClusterConfigs_nonExistingCluster_throwsNotFound() {
+    expect(
+        clusterConfigManager.alterClusterConfigs(
+            CLUSTER_ID,
+            ClusterConfig.Type.BROKER,
+            Arrays.asList(
+                AlterConfigCommand.update(CONFIG_1.getName(), "newValue"),
+                AlterConfigCommand.delete(CONFIG_2.getName()))))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(clusterConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    alterClusterConfigBatchAction.alterClusterConfigBatch(
+        response,
+        CLUSTER_ID,
+        ClusterConfig.Type.BROKER,
+        AlterClusterConfigBatchRequest.create(
+            AlterConfigBatchRequestData.create(
+                Arrays.asList(
+                    AlterEntry.builder()
+                        .setName(CONFIG_1.getName())
+                        .setValue("newValue")
+                        .build(),
+                    AlterEntry.builder()
+                        .setName(CONFIG_2.getName())
+                        .setOperation(AlterOperation.DELETE)
+                        .build()))));
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchActionTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static io.confluent.kafkarest.common.CompletableFutures.failedFuture;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafkarest.controllers.TopicConfigManager;
+import io.confluent.kafkarest.entities.AlterConfigCommand;
+import io.confluent.kafkarest.entities.ConfigSource;
+import io.confluent.kafkarest.entities.TopicConfig;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterEntry;
+import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterOperation;
+import io.confluent.kafkarest.entities.v3.AlterTopicConfigBatchRequest;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import java.util.Arrays;
+import javax.ws.rs.NotFoundException;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AlterTopicConfigBatchActionTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final String TOPIC_NAME = "topic-1";
+
+  private static final TopicConfig CONFIG_1 =
+      TopicConfig.create(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-1",
+          "value-1",
+          /* isDefault= */ true,
+          /* isReadOnly= */ false,
+          /* isSensitive= */ false,
+          ConfigSource.DEFAULT_CONFIG,
+          /* synonyms= */ emptyList());
+  private static final TopicConfig CONFIG_2 =
+      TopicConfig.create(
+          CLUSTER_ID,
+          TOPIC_NAME,
+          "config-2",
+          "value-2",
+          /* isDefault= */ false,
+          /* isReadOnly= */ true,
+          /* isSensitive= */ false,
+          ConfigSource.DYNAMIC_TOPIC_CONFIG,
+          /* synonyms= */ emptyList());
+
+  @Rule
+  public final EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private TopicConfigManager topicConfigManager;
+
+  private AlterTopicConfigBatchAction alterTopicConfigBatchAction;
+
+  @Before
+  public void setUp() {
+    alterTopicConfigBatchAction = new AlterTopicConfigBatchAction(() -> topicConfigManager);
+  }
+
+  @Test
+  public void alterTopicConfigs_existingConfig_alterConfigs() {
+    expect(
+        topicConfigManager.alterTopicConfigs(
+            CLUSTER_ID,
+            TOPIC_NAME,
+            Arrays.asList(
+                AlterConfigCommand.update(CONFIG_1.getName(), "newValue"),
+                AlterConfigCommand.delete(CONFIG_2.getName()))))
+        .andReturn(completedFuture(null));
+    replay(topicConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    alterTopicConfigBatchAction.alterTopicConfigBatch(
+        response,
+        CLUSTER_ID,
+        TOPIC_NAME,
+        AlterTopicConfigBatchRequest.create(
+            AlterConfigBatchRequestData.create(
+                Arrays.asList(
+                    AlterEntry.builder()
+                        .setName(CONFIG_1.getName())
+                        .setValue("newValue")
+                        .build(),
+                    AlterEntry.builder()
+                        .setName(CONFIG_2.getName())
+                        .setOperation(AlterOperation.DELETE)
+                        .build()))));
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+    assertTrue(response.isDone());
+  }
+
+  @Test
+  public void alterTopicConfigs_nonExistingCluster_throwsNotFound() {
+    expect(
+        topicConfigManager.alterTopicConfigs(
+            CLUSTER_ID,
+            TOPIC_NAME,
+            Arrays.asList(
+                AlterConfigCommand.update(CONFIG_1.getName(), "newValue"),
+                AlterConfigCommand.delete(CONFIG_2.getName()))))
+        .andReturn(failedFuture(new NotFoundException()));
+    replay(topicConfigManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    alterTopicConfigBatchAction.alterTopicConfigBatch(
+        response,
+        CLUSTER_ID,
+        TOPIC_NAME,
+        AlterTopicConfigBatchRequest.create(
+            AlterConfigBatchRequestData.create(
+                Arrays.asList(
+                    AlterEntry.builder()
+                        .setName(CONFIG_1.getName())
+                        .setValue("newValue")
+                        .build(),
+                    AlterEntry.builder()
+                        .setName(CONFIG_2.getName())
+                        .setOperation(AlterOperation.DELETE)
+                        .build()))));
+
+    assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+}


### PR DESCRIPTION
New APIs:

* `POST /v3/clusters/{clusterId}/broker-configs:alter`
* `POST /v3/clusters/{clusterId}/topic-configs:alter`
* `POST /v3/clusters/{clusterId}/brokers/{brokerId}/configs:alter`
* `POST /v3/clusters/{clusterId}/topics/{topicName}/configs:alter`

Request body:

```
{
  "data": [
    {
      "name": "compression.type",
      "value": "gzip",
      "operation": "UPDATE"
    },
    {
      "name": "max.connections",
      "operation": "DELETE"
    }
  ]
}
```

`operation` can be `UPDATE` and `DELETE`. It's optional and defaults to `UPDATE` if not specified. `value` defaults to `null` and is ignored if `operation` is `DELETE`.

HTTP 204 No Content is returned on success. The update is atomic: either the whole batch succeeds or fails.