### PR TITLE
Enable setting cluster_id on KafkaRestMetricsContext

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -48,8 +48,9 @@ public class KafkaRestConfig extends RestConfig {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaRestConfig.class);
   private final KafkaRestMetricsContext metricsContext;
-  private static final String TELEMETRY_PREFIX = "confluent.telemetry";
   private static final String METRIC_REPORTERS_PREFIX = "metric.reporters";
+
+  public static final String TELEMETRY_PREFIX = "confluent.telemetry";
 
   public static final String ID_CONFIG = "id";
   private static final String ID_CONFIG_DOC =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -48,9 +48,7 @@ public class KafkaRestConfig extends RestConfig {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaRestConfig.class);
   private final KafkaRestMetricsContext metricsContext;
-  private static final String METRIC_REPORTERS_PREFIX = "metric.reporters";
-
-  public static final String TELEMETRY_PREFIX = "confluent.telemetry";
+  public static final String METRIC_REPORTERS_PREFIX = "metric.reporters.";
 
   public static final String ID_CONFIG = "id";
   private static final String ID_CONFIG_DOC =
@@ -780,8 +778,7 @@ public class KafkaRestConfig extends RestConfig {
   public void addMetricsReporterProperties(Properties props) {
     getMetricsContext().contextLabels()
             .forEach((label, value) -> props.put(METRICS_CONTEXT_PREFIX + label, value));
-    props.putAll(originalsWithPrefix(TELEMETRY_PREFIX, false));
-    props.putAll(originalsWithPrefix(METRIC_REPORTERS_PREFIX, false));
+    props.putAll(metricsReporterConfig());
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -49,6 +49,7 @@ public class KafkaRestConfig extends RestConfig {
   private static final Logger log = LoggerFactory.getLogger(KafkaRestConfig.class);
   private final KafkaRestMetricsContext metricsContext;
   public static final String METRIC_REPORTERS_PREFIX = "metric.reporters.";
+  public static final String METRICS_REPORTER_CONFIG_PREFIX = "metric.reporters.";
 
   public static final String ID_CONFIG = "id";
   private static final String ID_CONFIG_DOC =
@@ -699,6 +700,10 @@ public class KafkaRestConfig extends RestConfig {
 
   public Properties getOriginalProperties() {
     return originalProperties;
+  }
+
+  public Map<String, Object> metricsReporterConfig() {
+    return originalsWithPrefix(METRICS_REPORTER_CONFIG_PREFIX);
   }
 
   private Properties addExistingV1Properties(Properties props) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
@@ -26,31 +26,24 @@ public final class KafkaRestMetricsContext {
    */
   private final RestMetricsContext metricsContext;
 
-  public static final String KAFKA_REST_RESOURCE_TYPE = "kafka.rest";
   public static final String RESOURCE_LABEL_PREFIX = "resource.";
-  public static final String RESOURCE_LABEL_COMMIT_ID = RESOURCE_LABEL_PREFIX + "commit.id";
   public static final String RESOURCE_LABEL_TYPE = RESOURCE_LABEL_PREFIX + "type";
   public static final String RESOURCE_LABEL_VERSION = RESOURCE_LABEL_PREFIX + "version";
+  public static final String RESOURCE_LABEL_COMMIT_ID = RESOURCE_LABEL_PREFIX + "commit.id";
+  public static final String RESOURCE_LABEL_CLUSTER_ID = RESOURCE_LABEL_PREFIX + "kafka.cluster.id";
+
+  public static final String KAFKA_REST_RESOURCE_TYPE = "kafka_rest";
+  public static final String KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT = "cluster_id_unavailable";
 
   public KafkaRestMetricsContext(String namespace, Map<String, Object> config) {
     metricsContext = new RestMetricsContext(namespace, config);
 
-    setResourceLabel(RESOURCE_LABEL_COMMIT_ID, AppInfoParser.getCommitId());
     setResourceLabel(RESOURCE_LABEL_TYPE, KAFKA_REST_RESOURCE_TYPE);
+    setResourceLabel(RESOURCE_LABEL_CLUSTER_ID,
+            (String) config.getOrDefault("bootstrap.cluster.id",
+                    KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT));
     setResourceLabel(RESOURCE_LABEL_VERSION, AppInfoParser.getVersion());
-  }
-
-
-  /**
-   * Sets a {@link RestMetricsContext} key, value pair.
-   */
-  public void setLabel(String labelKey, String labelValue) {
-    /* Remove resource label if present */
-    if (labelKey.startsWith(RESOURCE_LABEL_PREFIX)) {
-      setResourceLabel(labelKey, labelValue);
-    }
-
-    metricsContext.setLabel(labelKey, labelValue);
+    setResourceLabel(RESOURCE_LABEL_COMMIT_ID, AppInfoParser.getCommitId());
   }
 
   /**

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
@@ -40,7 +40,7 @@ public final class KafkaRestMetricsContext {
 
     setResourceLabel(RESOURCE_LABEL_TYPE, KAFKA_REST_RESOURCE_TYPE);
     setResourceLabel(RESOURCE_LABEL_CLUSTER_ID,
-            (String) config.getOrDefault("bootstrap.cluster.id",
+            (String) config.getOrDefault(RESOURCE_LABEL_CLUSTER_ID,
                     KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT));
     setResourceLabel(RESOURCE_LABEL_VERSION, AppInfoParser.getVersion());
     setResourceLabel(RESOURCE_LABEL_COMMIT_ID, AppInfoParser.getCommitId());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -1,13 +1,29 @@
 package io.confluent.kafkarest;
 
+import static io.confluent.kafkarest.KafkaRestMetricsContext.*;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Properties;
 
+import io.confluent.rest.metrics.RestMetricsContext;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.junit.Test;
 
 public class KafkaRestConfigTest {
+
+  @Test
+  public void getMetricsContext_propagateMetricsConfigs() {
+    Properties properties = new Properties();
+    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "context_cluster_id");
+
+    RestMetricsContext config = new KafkaRestConfig(properties).getMetricsContext();
+
+    assertEquals(AppInfoParser.getCommitId(), config.getLabel(RESOURCE_LABEL_COMMIT_ID));
+    assertEquals(AppInfoParser.getVersion(), config.getLabel(RESOURCE_LABEL_VERSION));
+    assertEquals("context_cluster_id", config.getLabel(RESOURCE_LABEL_CLUSTER_ID));
+  }
 
   @Test
   public void getProducerProperties_propagatesSchemaRegistryProperties() {
@@ -16,20 +32,41 @@ public class KafkaRestConfigTest {
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
-    assertEquals("https://schemaregistry:8085", producerProperties.get("schema.registry.url"));
+    assertEquals("https://schemaregistry:8085",
+            producerProperties.get("schema.registry.url"));
+  }
+
+
+  @Test
+  public void getProducerProperties_propagateMetrics_defaultClusterId() {
+    Properties properties = new Properties();
+
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    Properties producerProperties = config.getProducerProperties();
+
+    assertEquals(KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT,
+            producerProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
 
 
   @Test
   public void getProducerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put("confluent.telemetry.bootstrap.servers", "broker1:9092");
+    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "producer_cluster_id");
+
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
-    assertEquals("broker1:9092", producerProperties.get("confluent.telemetry.bootstrap.servers"));
-    assertEquals(AppInfoParser.getCommitId(), producerProperties.get("metrics.context.resource.commit.id"));
-    assertEquals(AppInfoParser.getVersion(), producerProperties.get("metrics.context.resource.version"));
+    assertEquals("broker1:9092",
+            producerProperties.get(telemetry_config("bootstrap.servers")));
+    assertEquals(AppInfoParser.getCommitId(),
+            producerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
+    assertEquals(AppInfoParser.getVersion(),
+            producerProperties.get(context_config(RESOURCE_LABEL_VERSION)));
+    assertEquals("producer_cluster_id",
+            producerProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
 
 
@@ -40,30 +77,77 @@ public class KafkaRestConfigTest {
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties consumerProperties = config.getConsumerProperties();
-    assertEquals("https://schemaregistry:8085", consumerProperties.get("schema.registry.url"));
+    assertEquals("https://schemaregistry:8085",
+            consumerProperties.get("schema.registry.url"));
+  }
+
+  @Test
+  public void getConsumerProperties_propagateMetrics_defaultClusterId() {
+    Properties properties = new Properties();
+
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    Properties consumerProperties = config.getConsumerProperties();
+
+    assertEquals(KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT,
+            consumerProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
 
   @Test
   public void getConsumerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put("confluent.telemetry.bootstrap.servers", "broker1:9092");
+    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "consumer_cluster_id");
+
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties consumerProperties = config.getConsumerProperties();
-    assertEquals("broker1:9092", consumerProperties.get("confluent.telemetry.bootstrap.servers"));
-    assertEquals(AppInfoParser.getCommitId(), consumerProperties.get("metrics.context.resource.commit.id"));
-    assertEquals(AppInfoParser.getVersion(), consumerProperties.get("metrics.context.resource.version"));
+    assertEquals("broker1:9092",
+            consumerProperties.get(telemetry_config("bootstrap.servers")));
+    assertEquals(AppInfoParser.getCommitId(),
+            consumerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
+    assertEquals(AppInfoParser.getVersion(),
+            consumerProperties.get(context_config(RESOURCE_LABEL_VERSION)));
+    assertEquals("consumer_cluster_id",
+            consumerProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
+  }
+
+  @Test
+  public void getAdminProperties_propagateMetrics_defaultClusterId() {
+    Properties properties = new Properties();
+
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    Properties adminProperties = config.getAdminProperties();
+
+    assertEquals(KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT,
+            adminProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
 
   @Test
   public void getAdminProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put("confluent.telemetry.bootstrap.servers", "broker1:9092");
+    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "admin_cluster_id");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties adminProperties = config.getAdminProperties();
-    assertEquals("broker1:9092", adminProperties.get("confluent.telemetry.bootstrap.servers"));
-    assertEquals(AppInfoParser.getCommitId(), adminProperties.get("metrics.context.resource.commit.id"));
-    assertEquals(AppInfoParser.getVersion(), adminProperties.get("metrics.context.resource.version"));
+    assertEquals("broker1:9092",
+            adminProperties.get(telemetry_config("bootstrap.servers")));
+    assertEquals(AppInfoParser.getCommitId(),
+            adminProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
+    assertEquals(AppInfoParser.getVersion(),
+            adminProperties.get(context_config(RESOURCE_LABEL_VERSION)));
+    assertEquals("admin_cluster_id",
+            adminProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
+
+  private String telemetry_config(String suffix) {
+    return KafkaRestConfig.TELEMETRY_PREFIX + suffix;
+  }
+
+  private String context_config(String suffix) {
+    return CommonClientConfigs.METRICS_CONTEXT_PREFIX + suffix;
+  }
+
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -15,7 +15,6 @@ public class KafkaRestConfigTest {
   @Test
   public void getMetricsContext_propagateMetricsConfigs() {
     Properties properties = new Properties();
-    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "context_cluster_id");
 
     RestMetricsContext config = new KafkaRestConfig(properties).getMetricsContext();
@@ -53,14 +52,14 @@ public class KafkaRestConfigTest {
   @Test
   public void getProducerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("telemetry.bootstrap.servers"), "broker1:9092");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "producer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
     assertEquals("broker1:9092",
-            producerProperties.get(telemetry_config("bootstrap.servers")));
+            producerProperties.get(reporter_config("telemetry.bootstrap.servers")));
     assertEquals(AppInfoParser.getCommitId(),
             producerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -68,7 +67,6 @@ public class KafkaRestConfigTest {
     assertEquals("producer_cluster_id",
             producerProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
-
 
   @Test
   public void getConsumerProperties_propagatesSchemaRegistryProperties() {
@@ -96,14 +94,14 @@ public class KafkaRestConfigTest {
   @Test
   public void getConsumerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("telemetry.bootstrap.servers"), "broker1:9092");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "consumer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties consumerProperties = config.getConsumerProperties();
     assertEquals("broker1:9092",
-            consumerProperties.get(telemetry_config("bootstrap.servers")));
+            consumerProperties.get("telemetry.bootstrap.servers"));
     assertEquals(AppInfoParser.getCommitId(),
             consumerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -127,13 +125,13 @@ public class KafkaRestConfigTest {
   @Test
   public void getAdminProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(telemetry_config("bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("telemetry.bootstrap.servers"), "broker1:9092");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "admin_cluster_id");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties adminProperties = config.getAdminProperties();
     assertEquals("broker1:9092",
-            adminProperties.get(telemetry_config("bootstrap.servers")));
+            adminProperties.get("telemetry.bootstrap.servers"));
     assertEquals(AppInfoParser.getCommitId(),
             adminProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -142,12 +140,11 @@ public class KafkaRestConfigTest {
             adminProperties.get(context_config(RESOURCE_LABEL_CLUSTER_ID)));
   }
 
-  private String telemetry_config(String suffix) {
-    return KafkaRestConfig.TELEMETRY_PREFIX + suffix;
-  }
-
   private String context_config(String suffix) {
     return CommonClientConfigs.METRICS_CONTEXT_PREFIX + suffix;
   }
 
+  private String reporter_config(String suffix) {
+    return KafkaRestConfig.METRIC_REPORTERS_PREFIX + suffix;
+  }
 }


### PR DESCRIPTION
This is not explicitly added to the config def as its not intended to actually be set manually by users at this time. 