### PR TITLE
CLIENTS-1599: Add constructor accepting path to KafkaRestApplication.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -59,7 +59,11 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
   }
 
   public KafkaRestApplication(KafkaRestConfig config) {
-    super(config);
+    this(config, /* path= */ "");
+  }
+
+  public KafkaRestApplication(KafkaRestConfig config, String path) {
+    super(config, path);
 
     restResourceExtensions = config.getConfiguredInstances(
         KafkaRestConfig.KAFKA_REST_RESOURCE_EXTENSION_CONFIG,


### PR DESCRIPTION
What: KafkaHttpServlet was an abstraction created when we intended to write applications for the Kafka HTTP server inside the ce-kafka repository. Since that's not the case anymore, this abstraction is no longer needed.

Why: KafkaHttpServlet wraps rest-utils Application, only exposing the minimum necessary from Application's extensive public API. Whenever we need something extra, we have to first expose it. It turns out that to be able to enable the Telemetry Reporter for (Embedded) REST Proxy, we need to make extensive non-trivial modifications to KafkaHttpServlet. All this is work is not needed if we just don't wrap application anymore.