### PR TITLE
Change resource label resource.kafka.cluster.id to resource.cluster.id

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
@@ -30,7 +30,7 @@ public final class KafkaRestMetricsContext {
   public static final String RESOURCE_LABEL_TYPE = RESOURCE_LABEL_PREFIX + "type";
   public static final String RESOURCE_LABEL_VERSION = RESOURCE_LABEL_PREFIX + "version";
   public static final String RESOURCE_LABEL_COMMIT_ID = RESOURCE_LABEL_PREFIX + "commit.id";
-  public static final String RESOURCE_LABEL_CLUSTER_ID = RESOURCE_LABEL_PREFIX + "kafka.cluster.id";
+  public static final String RESOURCE_LABEL_CLUSTER_ID = RESOURCE_LABEL_PREFIX + "cluster.id";
 
   public static final String KAFKA_REST_RESOURCE_TYPE = "kafka_rest";
   public static final String KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT = "cluster_id_unavailable";


### PR DESCRIPTION
Wrong resource label was used to identify the kafka cluster id.