### PR TITLE
SEC-1034: log4j migration to confluent repackaged version

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -67,6 +67,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <version>${confluent-log4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>


### PR DESCRIPTION
- Confluent repackaged version fixes CVE-2019-17571
- `common/pom.xml` excludes default log4j as a transitive dependency, and the repackaged version must be explicitly added.

Ref: https://github.com/confluentinc/common/pull/270