### PR TITLE
CLIENTS-1613: Add configuration to enable/disable V2 and V3 APIs.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -114,7 +114,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     config.register(new ConfigModule(appConfig));
     config.register(new ControllersModule());
     config.register(new ExceptionsModule());
-    config.register(new ResourcesFeature(context));
+    config.register(new ResourcesFeature(context, appConfig));
     config.register(new ResponseModule());
 
     config.register(KafkaRestCleanupFilter.class);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -665,7 +665,8 @@ public class KafkaRestConfig extends RestConfig {
         Type.BOOLEAN,
         API_V2_ENABLE_DEFAULT,
         Importance.LOW,
-        API_V2_ENABLE_DOC)
+        API_V2_ENABLE_DOC
+    )
     .define(
         API_V3_ENABLE_CONFIG,
         Type.BOOLEAN,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -336,6 +336,16 @@ public class KafkaRestConfig extends RestConfig {
           + "should be delegated to. Examples: confluent.cloud, mds-01.example.com.";
   private static final String CONFLUENT_RESOURCE_NAME_AUTHORITY_DEFAULT = "";
 
+  public static final String API_V2_ENABLE_CONFIG = "api.v2.enable";
+  private static final String API_V2_ENABLE_DOC =
+      "Whether to enable REST Proxy V2 API. Default is true.";
+  private static final boolean API_V2_ENABLE_DEFAULT = true;
+
+  public static final String API_V3_ENABLE_CONFIG = "api.v3.enable";
+  private static final String API_V3_ENABLE_DOC =
+      "Whether to enable REST Proxy V3 API. Default is true.";
+  private static final boolean API_V3_ENABLE_DEFAULT = true;
+
   private static final ConfigDef config;
 
   public static final String HTTPS = "https";
@@ -648,7 +658,20 @@ public class KafkaRestConfig extends RestConfig {
         Type.STRING,
         CONFLUENT_RESOURCE_NAME_AUTHORITY_DEFAULT,
         Importance.LOW,
-        CONFLUENT_RESOURCE_NAME_AUTHORITY_DOC);
+        CONFLUENT_RESOURCE_NAME_AUTHORITY_DOC
+    )
+    .define(
+        API_V2_ENABLE_CONFIG,
+        Type.BOOLEAN,
+        API_V2_ENABLE_DEFAULT,
+        Importance.LOW,
+        API_V2_ENABLE_DOC)
+    .define(
+        API_V3_ENABLE_CONFIG,
+        Type.BOOLEAN,
+        API_V3_ENABLE_DEFAULT,
+        Importance.LOW,
+        API_V3_ENABLE_DOC);
   }
 
   private Time time;
@@ -778,6 +801,14 @@ public class KafkaRestConfig extends RestConfig {
     addPropertiesWithPrefix("client.", adminProps);
     addPropertiesWithPrefix("admin.", adminProps);
     return adminProps;
+  }
+
+  public boolean isV2ApiEnabled() {
+    return getBoolean(API_V2_ENABLE_CONFIG);
+  }
+
+  public boolean isV3ApiEnabled() {
+    return getBoolean(API_V3_ENABLE_CONFIG);
   }
 
   public void addMetricsReporterProperties(Properties props) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/ResourcesFeature.java
@@ -15,24 +15,32 @@
 
 package io.confluent.kafkarest.resources;
 
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.kafkarest.resources.v2.V2ResourcesFeature;
 import io.confluent.kafkarest.resources.v3.V3ResourcesFeature;
-import java.util.Objects;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
 public final class ResourcesFeature implements Feature {
   private final KafkaRestContext context;
+  private final KafkaRestConfig config;
 
-  public ResourcesFeature(KafkaRestContext context) {
-    this.context = Objects.requireNonNull(context);
+  public ResourcesFeature(KafkaRestContext context, KafkaRestConfig config) {
+    this.context = requireNonNull(context);
+    this.config = requireNonNull(config);
   }
 
   @Override
   public boolean configure(FeatureContext configurable) {
-    configurable.register(new V2ResourcesFeature(context));
-    configurable.register(V3ResourcesFeature.class);
+    if (config.isV2ApiEnabled()) {
+      configurable.register(new V2ResourcesFeature(context));
+    }
+    if (config.isV3ApiEnabled()) {
+      configurable.register(V3ResourcesFeature.class);
+    }
     return true;
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/DisableV2Test.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/DisableV2Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration.v2;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.Versions;
+import io.confluent.kafkarest.integration.ClusterTestHarness;
+import java.util.Properties;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Test;
+
+public class DisableV2Test extends ClusterTestHarness {
+
+  public DisableV2Test() {
+    super(/* numBrokers= */ 1, /* withSchemaRegistry= */ false);
+  }
+
+  @Override
+  protected void overrideKafkaRestConfigs(Properties restProperties) {
+    restProperties.put(KafkaRestConfig.API_V2_ENABLE_CONFIG, false);
+  }
+
+  @Test
+  public void v2ApiIsDisabled() {
+    Response response = request("/").accept(Versions.KAFKA_V2_JSON).get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/DisableV3Test.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/DisableV3Test.java
@@ -37,7 +37,7 @@ public class DisableV3Test extends ClusterTestHarness {
   }
 
   @Test
-  public void v2ApiIsDisabled() {
+  public void v3ApiIsDisabled() {
     Response response = request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/DisableV3Test.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/DisableV3Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration.v3;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.integration.ClusterTestHarness;
+import java.util.Properties;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Test;
+
+public class DisableV3Test extends ClusterTestHarness {
+
+  public DisableV3Test() {
+    super(/* numBrokers= */ 1, /* withSchemaRegistry= */ false);
+  }
+
+  @Override
+  protected void overrideKafkaRestConfigs(Properties restProperties) {
+    restProperties.put(KafkaRestConfig.API_V3_ENABLE_CONFIG, false);
+  }
+
+  @Test
+  public void v2ApiIsDisabled() {
+    Response response = request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+}


### PR DESCRIPTION
The configurations are, respectively, `api.v2.enable` and `api.v3.enable`. Both default to true.