### PR TITLE
Move MetricsReporter Config extraction to  rest-utils

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -48,8 +48,6 @@ public class KafkaRestConfig extends RestConfig {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaRestConfig.class);
   private final KafkaRestMetricsContext metricsContext;
-  public static final String METRIC_REPORTERS_PREFIX = "metric.reporters.";
-  public static final String METRICS_REPORTER_CONFIG_PREFIX = "metric.reporters.";
 
   public static final String ID_CONFIG = "id";
   private static final String ID_CONFIG_DOC =
@@ -724,10 +722,6 @@ public class KafkaRestConfig extends RestConfig {
 
   public Properties getOriginalProperties() {
     return originalProperties;
-  }
-
-  public Map<String, Object> metricsReporterConfig() {
-    return originalsWithPrefix(METRICS_REPORTER_CONFIG_PREFIX);
   }
 
   private Properties addExistingV1Properties(Properties props) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -145,6 +145,6 @@ public class KafkaRestConfigTest {
   }
 
   private String reporter_config(String suffix) {
-    return KafkaRestConfig.METRIC_REPORTERS_PREFIX + suffix;
+    return KafkaRestConfig.METRICS_REPORTER_CONFIG_PREFIX + suffix;
   }
 }


### PR DESCRIPTION
What: Move helper function and prefix to parent class. 

Why: Currently rest-utils passes all originals to the metrics reporter. KafkaRest only passes metrics configuration properties prefixed with `metric.reporters.`  We need them to handle this consistently to ensure users don't have to configure it twice. Once for rest utils and another for KafkaRest clients. Likewise we can't adopt the strategy of passing all config values to managed clients so we rely on the prefix. The prefix strategy is more in line with existing config namespacing (consumer., client., producer.) so this is the approach we moved to rest-utils. 

rest-utils pr: https://github.com/confluentinc/rest-utils/pull/190