### PR TITLE
Propagate Confluent Telemetry Reporter configuration properties to managed clients.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -809,9 +809,15 @@ public class KafkaRestConfig extends RestConfig {
   }
 
   public void addTelemetryReporterProperties(Properties props) {
+    addMetricsReporters(props);
     getMetricsContext().contextLabels()
             .forEach((label, value) -> props.put(METRICS_CONTEXT_PREFIX + label, value));
     props.putAll(originalsWithPrefix(TELEMETRY_PREFIX, false));
+  }
+
+  private void addMetricsReporters(Properties props) {
+    props.put(METRICS_REPORTER_CLASSES_CONFIG,
+            this.getList(METRICS_REPORTER_CLASSES_CONFIG));
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -47,7 +47,9 @@ import static org.apache.kafka.clients.CommonClientConfigs.METRICS_CONTEXT_PREFI
 public class KafkaRestConfig extends RestConfig {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaRestConfig.class);
+
   private final KafkaRestMetricsContext metricsContext;
+  public static final String TELEMETRY_PREFIX = "confluent.telemetry.";
 
   public static final String ID_CONFIG = "id";
   private static final String ID_CONFIG_DOC =
@@ -758,7 +760,7 @@ public class KafkaRestConfig extends RestConfig {
     Properties producerProps = new Properties();
     /* Propagate MetricsContext labels to managed components
     / as prefixed configuration properties. */
-    addMetricsReporterProperties(producerProps);
+    addTelemetryReporterProperties(producerProps);
     //add properties for V1 version of configuration parameters for backward compability
     //since producers need to support V1 with configuration change
     addExistingV1Properties(producerProps);
@@ -776,7 +778,7 @@ public class KafkaRestConfig extends RestConfig {
     Properties consumerProps = new Properties();
     /* Propagate MetricsContext labels to managed components
     / as prefixed configuration properties. */
-    addMetricsReporterProperties(consumerProps);
+    addTelemetryReporterProperties(consumerProps);
     //copy cover the properties with prefixes "client." and  "consumer."
     addPropertiesWithPrefix("client.", consumerProps);
     addPropertiesWithPrefix("consumer.", consumerProps);
@@ -791,7 +793,7 @@ public class KafkaRestConfig extends RestConfig {
     Properties adminProps = new Properties();
     /* Propagate MetricsContext labels to managed components
        as prefixed configuration properties. */
-    addMetricsReporterProperties(adminProps);
+    addTelemetryReporterProperties(adminProps);
     //copy cover the properties with prefixes "client." and  "admin."
     addPropertiesWithPrefix("client.", adminProps);
     addPropertiesWithPrefix("admin.", adminProps);
@@ -806,10 +808,10 @@ public class KafkaRestConfig extends RestConfig {
     return getBoolean(API_V3_ENABLE_CONFIG);
   }
 
-  public void addMetricsReporterProperties(Properties props) {
+  public void addTelemetryReporterProperties(Properties props) {
     getMetricsContext().contextLabels()
             .forEach((label, value) -> props.put(METRICS_CONTEXT_PREFIX + label, value));
-    props.putAll(metricsReporterConfig());
+    props.putAll(originalsWithPrefix(TELEMETRY_PREFIX, false));
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -52,14 +52,14 @@ public class KafkaRestConfigTest {
   @Test
   public void getProducerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(reporter_config("telemetry.bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("api.key"), "my_api_key");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "producer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
-    assertEquals("broker1:9092",
-            producerProperties.get(reporter_config("telemetry.bootstrap.servers")));
+    assertEquals("my_api_key",
+            producerProperties.get(reporter_config("api.key")));
     assertEquals(AppInfoParser.getCommitId(),
             producerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -94,14 +94,14 @@ public class KafkaRestConfigTest {
   @Test
   public void getConsumerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(reporter_config("bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("api.key"), "my_api_key");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "consumer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties consumerProperties = config.getConsumerProperties();
-    assertEquals("broker1:9092",
-            consumerProperties.get("confluent.telemetry.bootstrap.servers"));
+    assertEquals("my_api_key",
+            consumerProperties.get("confluent.telemetry.api.key"));
     assertEquals(AppInfoParser.getCommitId(),
             consumerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -125,13 +125,13 @@ public class KafkaRestConfigTest {
   @Test
   public void getAdminProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(reporter_config("bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("api.key"), "my_api_key");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "admin_cluster_id");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties adminProperties = config.getAdminProperties();
-    assertEquals("broker1:9092",
-            adminProperties.get("confluent.telemetry.bootstrap.servers"));
+    assertEquals("my_api_key",
+            adminProperties.get("confluent.telemetry.api.key"));
     assertEquals(AppInfoParser.getCommitId(),
             adminProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -1,11 +1,16 @@
 package io.confluent.kafkarest;
 
-import static io.confluent.kafkarest.KafkaRestMetricsContext.*;
+import static io.confluent.kafkarest.KafkaRestMetricsContext.KAFKA_REST_RESOURCE_CLUSTER_ID_DEFAULT;
+import static io.confluent.kafkarest.KafkaRestConfig.METRICS_REPORTER_CLASSES_CONFIG;
+import static io.confluent.kafkarest.KafkaRestMetricsContext.RESOURCE_LABEL_CLUSTER_ID;
+import static io.confluent.kafkarest.KafkaRestMetricsContext.RESOURCE_LABEL_COMMIT_ID;
+import static io.confluent.kafkarest.KafkaRestMetricsContext.RESOURCE_LABEL_VERSION;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Properties;
-
 import io.confluent.rest.metrics.RestMetricsContext;
+
+import java.util.Arrays;
+import java.util.Properties;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.junit.Test;
@@ -52,12 +57,16 @@ public class KafkaRestConfigTest {
   @Test
   public void getProducerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
+    properties.put(METRICS_REPORTER_CLASSES_CONFIG,
+            "metrics.reporter.1, metrics.reporter.2, metrics.reporter.3");
     properties.put(reporter_config("api.key"), "my_api_key");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "producer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
+    assertEquals(producerProperties.get(METRICS_REPORTER_CLASSES_CONFIG),
+            "metrics.reporter.1, metrics.reporter.2, metrics.reporter.3");
     assertEquals("my_api_key",
             producerProperties.get(reporter_config("api.key")));
     assertEquals(AppInfoParser.getCommitId(),
@@ -94,12 +103,18 @@ public class KafkaRestConfigTest {
   @Test
   public void getConsumerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
+    properties.put(METRICS_REPORTER_CLASSES_CONFIG,
+            "metrics.reporter.1, metrics.reporter.2, metrics.reporter.3");
     properties.put(reporter_config("api.key"), "my_api_key");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "consumer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties consumerProperties = config.getConsumerProperties();
+    assertEquals(consumerProperties.get(METRICS_REPORTER_CLASSES_CONFIG),
+            Arrays.asList("metrics.reporter.1",
+                    "metrics.reporter.2",
+                    "metrics.reporter.3"));
     assertEquals("my_api_key",
             consumerProperties.get("confluent.telemetry.api.key"));
     assertEquals(AppInfoParser.getCommitId(),
@@ -125,11 +140,17 @@ public class KafkaRestConfigTest {
   @Test
   public void getAdminProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
+    properties.put(METRICS_REPORTER_CLASSES_CONFIG,
+            "metrics.reporter.1, metrics.reporter.2, metrics.reporter.3");
     properties.put(reporter_config("api.key"), "my_api_key");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "admin_cluster_id");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties adminProperties = config.getAdminProperties();
+    assertEquals(adminProperties.get(METRICS_REPORTER_CLASSES_CONFIG),
+            Arrays.asList("metrics.reporter.1",
+                    "metrics.reporter.2",
+                    "metrics.reporter.3"));
     assertEquals("my_api_key",
             adminProperties.get("confluent.telemetry.api.key"));
     assertEquals(AppInfoParser.getCommitId(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -94,14 +94,14 @@ public class KafkaRestConfigTest {
   @Test
   public void getConsumerProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(reporter_config("telemetry.bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("bootstrap.servers"), "broker1:9092");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "consumer_cluster_id");
 
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties consumerProperties = config.getConsumerProperties();
     assertEquals("broker1:9092",
-            consumerProperties.get("telemetry.bootstrap.servers"));
+            consumerProperties.get("confluent.telemetry.bootstrap.servers"));
     assertEquals(AppInfoParser.getCommitId(),
             consumerProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -125,13 +125,13 @@ public class KafkaRestConfigTest {
   @Test
   public void getAdminProperties_propagateMetricsProperties() {
     Properties properties = new Properties();
-    properties.put(reporter_config("telemetry.bootstrap.servers"), "broker1:9092");
+    properties.put(reporter_config("bootstrap.servers"), "broker1:9092");
     properties.put(context_config(RESOURCE_LABEL_CLUSTER_ID), "admin_cluster_id");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties adminProperties = config.getAdminProperties();
     assertEquals("broker1:9092",
-            adminProperties.get("telemetry.bootstrap.servers"));
+            adminProperties.get("confluent.telemetry.bootstrap.servers"));
     assertEquals(AppInfoParser.getCommitId(),
             adminProperties.get(context_config(RESOURCE_LABEL_COMMIT_ID)));
     assertEquals(AppInfoParser.getVersion(),
@@ -145,6 +145,6 @@ public class KafkaRestConfigTest {
   }
 
   private String reporter_config(String suffix) {
-    return KafkaRestConfig.METRICS_REPORTER_CONFIG_PREFIX + suffix;
+    return KafkaRestConfig.TELEMETRY_PREFIX + suffix;
   }
 }


### PR DESCRIPTION
KafkaRest managed clients should inherit the KafkaRestApplication's metrics reporter configs when not configured as a client override. 

There is a new metrics reporter, ConfluentTelemetryReporter, who's configurations need to be propagated as well. 

This PR addresses both concerns.