### PR TITLE
METRICS-1988: add confluent-telemetry directory to kafka-rest-run-class

### DIFF
--- a/bin/kafka-rest-run-class
+++ b/bin/kafka-rest-run-class
@@ -22,7 +22,7 @@ for dir in $base_dir/kafka-rest/target/kafka-rest-*-development; do
 done
 
 # Production jars
-for library in "confluent-security/kafka-rest" "confluent-common" "rest-utils" "kafka-rest" "monitoring-interceptors"; do
+for library in "confluent-security/kafka-rest" "confluent-common" "confluent-telemetry" "rest-utils" "kafka-rest" "monitoring-interceptors"; do
   CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*
 done
 


### PR DESCRIPTION
### what
Add `share/java/confluent-telemetry` to kafka-rest's classpath.

### why
This is where we'll install the confluent-metrics jar (as part of packaging) and we need this jar for telemetry to work.