### PR TITLE
CLIENTS-1659: Remove V1 API Kafka core dependency and associated Zookeeper Client configs

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -150,7 +150,7 @@
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>${maven-assembly.version}</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/assembly/development.xml</descriptor>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -34,11 +34,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${kafka.scala.version}</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
         </dependency>
@@ -102,6 +97,12 @@
             <scope>test</scope>
         </dependency>
         <!-- End workaround -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -93,13 +93,11 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
       ProducerPool producerPool,
       KafkaConsumerManager kafkaConsumerManager
   ) {
-    if (StringUtil.isBlank(appConfig.getString(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG))
-        && StringUtil.isBlank(appConfig.getString(KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG))) {
-      throw new RuntimeException("Atleast one of " + KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG + " "
-                                 + "or "
-                                    + KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG
-                                    + " needs to be configured");
+    /* TODO: Update EmbeddedServerTestHarness to allow required BOOTSTRAP_SERVERS_CONFIG */
+    if (StringUtil.isBlank(appConfig.getString(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG))) {
+      throw new RuntimeException(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG + " must be configured");
     }
+
     KafkaRestContextProvider.initialize(config, appConfig, producerPool,
         kafkaConsumerManager);
     ContextInvocationHandler contextInvocationHandler = new ContextInvocationHandler();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -93,7 +93,6 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
       ProducerPool producerPool,
       KafkaConsumerManager kafkaConsumerManager
   ) {
-    /* TODO: Update EmbeddedServerTestHarness to allow required BOOTSTRAP_SERVERS_CONFIG */
     if (StringUtil.isBlank(appConfig.getString(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG))) {
       throw new RuntimeException(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG + " must be configured");
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -87,25 +87,6 @@ public class KafkaRestConfig extends RestConfig {
       + " The value of -1 denotes unbounded thread creation";
   public static final String CONSUMER_MAX_THREADS_DEFAULT = "50";
 
-  public static final String ZOOKEEPER_CONNECT_CONFIG = "zookeeper.connect";
-  private static final String ZOOKEEPER_CONNECT_DOC =
-      "NOTE: Only required when using v1 Consumer API's. Specifies the ZooKeeper connection "
-      + "string in the form "
-      + "hostname:port where host and port are the host and port of a ZooKeeper server. To allow "
-      + "connecting "
-      + "through other ZooKeeper nodes when that ZooKeeper machine is down you can also specify "
-      + "multiple hosts "
-      + "in the form hostname1:port1,hostname2:port2,hostname3:port3.\n"
-      + "\n"
-      + "The server may also have a ZooKeeper chroot path as part of it's ZooKeeper connection "
-      + "string which puts "
-      + "its data under some path in the global ZooKeeper namespace. If so the consumer should "
-      + "use the same "
-      + "chroot path in its connection string. For example to give a chroot path of /chroot/path "
-      + "you would give "
-      + "the connection string as hostname1:port1,hostname2:port2,hostname3:port3/chroot/path. ";
-  public static final String ZOOKEEPER_CONNECT_DEFAULT = "";
-
   public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
   private static final String BOOTSTRAP_SERVERS_DOC =
       "A list of host/port pairs to use for establishing the initial connection to the Kafka "
@@ -202,18 +183,12 @@ public class KafkaRestConfig extends RestConfig {
 
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.rest";
 
-  /**
-   * <code>client.zk.session.timeout.ms</code>
-   */
-  public static final String KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_CONFIG
-      = "client.zk.session.timeout.ms";
   public static final String KAFKACLIENT_TIMEOUT_CONFIG = "client.timeout.ms";
   /**
    * <code>client.init.timeout.ms</code>
    */
   public static final String KAFKACLIENT_INIT_TIMEOUT_CONFIG = "client.init.timeout.ms";
 
-  public static final String ZOOKEEPER_SET_ACL_CONFIG = "zookeeper.set.acl";
   public static final String KAFKACLIENT_SECURITY_PROTOCOL_CONFIG =
       "client.security.protocol";
   public static final String KAFKACLIENT_SSL_TRUSTSTORE_LOCATION_CONFIG =
@@ -258,19 +233,11 @@ public class KafkaRestConfig extends RestConfig {
       "client.sasl.kerberos.ticket.renew.window.factor";
   public static final String KAFKA_REST_RESOURCE_EXTENSION_CONFIG =
       "kafka.rest.resource.extension.class";
-  protected static final String KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_DOC =
-      "Zookeeper session timeout";
   protected static final String KAFKACLIENT_INIT_TIMEOUT_DOC =
       "The timeout for initialization of the Kafka store, including creation of the Kafka topic "
       + "that stores schema data.";
   protected static final String KAFKACLIENT_TIMEOUT_DOC =
       "The timeout for an operation on the Kafka store";
-  protected static final String
-      ZOOKEEPER_SET_ACL_DOC =
-      "Whether or not to set an ACL in ZooKeeper when znodes are created and ZooKeeper SASL "
-      + "authentication is "
-      + "configured. IMPORTANT: if set to `true`, the SASL principal must be the same as the "
-      + "Kafka brokers.";
   protected static final String KAFKACLIENT_SECURITY_PROTOCOL_DOC =
       "The security protocol to use when connecting with Kafka, the underlying persistent storage. "
       + "Values can be `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.";
@@ -327,8 +294,6 @@ public class KafkaRestConfig extends RestConfig {
       + " <code>RestResourceExtension</code> allows you to inject user defined resources "
       + " like filters to Rest Proxy. Typically used to add custom capability like logging, "
       + " security, etc.";
-  private static final boolean ZOOKEEPER_SET_ACL_DEFAULT = false;
-
   public static final String CRN_AUTHORITY_CONFIG =
       "confluent.resource.name.authority";
   private static final String CONFLUENT_RESOURCE_NAME_AUTHORITY_DOC =
@@ -389,13 +354,6 @@ public class KafkaRestConfig extends RestConfig {
         CONSUMER_MAX_THREADS_DEFAULT,
         Importance.MEDIUM,
         CONSUMER_MAX_THREADS_DOC
-    )
-    .define(
-        ZOOKEEPER_CONNECT_CONFIG,
-        Type.STRING,
-        ZOOKEEPER_CONNECT_DEFAULT,
-        Importance.HIGH,
-        ZOOKEEPER_CONNECT_DOC
     )
     .define(
         BOOTSTRAP_SERVERS_CONFIG,
@@ -474,14 +432,6 @@ public class KafkaRestConfig extends RestConfig {
         SIMPLE_CONSUMER_POOL_TIMEOUT_MS_DEFAULT,
         Importance.LOW,
         SIMPLE_CONSUMER_POOL_TIMEOUT_MS_DOC
-    )
-    .define(
-        KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_CONFIG,
-        Type.INT,
-        30000,
-        Range.atLeast(0),
-        Importance.LOW,
-        KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_DOC
     )
     .define(
         KAFKACLIENT_INIT_TIMEOUT_CONFIG,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/RestConfigUtils.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/RestConfigUtils.java
@@ -16,64 +16,11 @@
 package io.confluent.kafkarest;
 
 import static io.confluent.kafkarest.KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG;
-
-import java.util.List;
-
-import kafka.cluster.Broker;
-import kafka.cluster.EndPoint;
-import kafka.zk.KafkaZkClient;
-import kafka.zookeeper.ZooKeeperClient;
-import org.apache.kafka.common.security.JaasUtils;
-import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
-import org.eclipse.jetty.util.StringUtil;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
 
 public class RestConfigUtils {
 
   public static String bootstrapBrokers(KafkaRestConfig config) {
-    int zkSessionTimeoutMs = config.getInt(KAFKACLIENT_ZK_SESSION_TIMEOUT_MS_CONFIG);
-
-    String bootstrapServersConfig = config.getString(BOOTSTRAP_SERVERS_CONFIG);
-    if (StringUtil.isNotBlank(bootstrapServersConfig)) {
-      return bootstrapServersConfig;
-    }
-    KafkaZkClient zkClient = null;
-    try {
-      org.apache.kafka.common.utils.Time time = Time.SYSTEM;
-
-      zkClient = new KafkaZkClient(
-          new ZooKeeperClient(config.getString(ZOOKEEPER_CONNECT_CONFIG), zkSessionTimeoutMs,
-              zkSessionTimeoutMs, Integer.MAX_VALUE, time,
-              "testMetricGroup", "testMetricGroupType"),
-          JaasUtils.isZkSaslEnabled(),
-          time);
-      return getBootstrapBrokers(zkClient);
-    } finally {
-      if (zkClient != null) {
-        zkClient.close();
-      }
-    }
+    return config.getString(BOOTSTRAP_SERVERS_CONFIG);
   }
 
-  private static String getBootstrapBrokers(KafkaZkClient zkClient) {
-    Seq<Broker> brokerSeq = zkClient.getAllBrokersInCluster();
-
-    List<Broker> brokers = JavaConverters.seqAsJavaList(brokerSeq);
-    String bootstrapBrokers = "";
-    for (int i = 0; i < brokers.size(); i++) {
-      for (EndPoint ep : JavaConverters.asJavaCollection(brokers.get(i).endPoints())) {
-        if (bootstrapBrokers.length() > 0) {
-          bootstrapBrokers += ",";
-        }
-        String hostport =
-            ep.host() == null ? ":" + ep.port() : Utils.formatAddress(ep.host(), ep.port());
-        bootstrapBrokers += ep.securityProtocol() + "://" + hostport;
-      }
-    }
-    return bootstrapBrokers;
-  }
 }


### PR DESCRIPTION
We should only depend on the kafka-clients jar.