### PR TITLE
SEC-1307: Backport "log4j replacement with confluent repackaged version"

### DIFF
--- a/kafka-rest-scala-consumer/pom.xml
+++ b/kafka-rest-scala-consumer/pom.xml
@@ -45,7 +45,13 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${log4j.version}</version>
         </dependency>
-        <!--
+         <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <version>${confluent-log4j.version}</version>
+        </dependency>
+       <!--
             This is a workaround for IntelliJ which seems to have a problem including junit + hamcrest
             as transitive dependencies of rest-utils-test. mvn properly resolves these, so it may have
             something to do with special junit handling and test scopes since rest-utils-test is not in


### PR DESCRIPTION
Cherry-pick commit from master in #732 wasn't sufficient because 5.4.x and 5.5.x have a separate `kafka-rest-scala-consumer`, which needs explicitly adding `confluent-log4j` as well. 