### PR TITLE
ST-3461: Nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 #!/usr/bin/env groovy
 common {
   slackChannel = '#rest-proxy-eng'
-  upstreamProjects = 'confluentinc/schema-registry'
+  downStreamRepos = ["confluent-security-plugins", "ce-kafka-rest",
+    "confluent-cloud-plugins"]
+  nanoVersion = true
 }

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -54,9 +54,9 @@ endif
 
 build: apply-patches
 ifeq ($(SKIP_TESTS),yes)
-	mvn -DskipTests=true install
+	mvn -B -DskipTests=true install
 else
-	mvn install
+	mvn -B install
 endif
 
 BINPATH=$(PREFIX)/bin
@@ -102,7 +102,7 @@ test:
 
 
 
-RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//' -e 's/-hotfix[0-9]*//')
+RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//' -e 's/-hotfix[0-9]*//' -e 's/-[0-9]*//')
 # Get any -alpha, -beta (preview), -rc (release candidate), -SNAPSHOT (nightly), -cp (confluent patch), -hotfix piece that we need to put into the Release part of
 # the version since RPM versions don't support non-numeric
 # characters. Ultimately, for something like 0.8.2-beta, we want to end up with

--- a/kafka-rest-console-scripts/pom.xml
+++ b/kafka-rest-console-scripts/pom.xml
@@ -10,7 +10,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-rest-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-rest-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>kafka-rest</artifactId>
@@ -18,6 +18,10 @@
         produce and consume messages, view the state of the cluster, and perform administrative
         actions without using the native Kafka protocol or clients.
     </description>
+
+    <properties>
+        <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -31,6 +35,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils</artifactId>
+            <version>${io.confluent.rest-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -45,22 +50,22 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-serializer</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-schema-serializer</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-serializer</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -88,6 +93,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils-test</artifactId>
+            <version>${io.confluent.rest-utils.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -117,7 +123,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.schema-registry.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <artifactId>kafka-rest-parent</artifactId>
     <packaging>pom</packaging>
     <name>kafka-rest-parent</name>
+    <version>6.1.0-0</version>
     <organization>
         <name>Confluent, Inc.</name>
         <url>http://confluent.io</url>
@@ -47,6 +48,7 @@
     <properties>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
+        <io.confluent.kafka-rest.version>6.1.0-0</io.confluent.kafka-rest.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Setting the jenkins config to use nano versioning. No longer need to define upstream repos as we now define downstream repos which will be automated in the future. Removed all of the snapshot versions and replaced with nano versions. Updated all of the dependency versions. Updated the make file so the rpm version parsing works with nano versioning, and applied the batch mode option to all maven commands so we don't get download progress and color codes in the CI logs.

These changes will be merged during phase two of the nano versioning roll out.