### PR TITLE
KREST-5: Add JMX metrics for all V3 endpoints.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
@@ -33,6 +33,7 @@ import io.confluent.kafkarest.entities.v3.SearchAclsResponse;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
@@ -70,6 +71,7 @@ public final class AclsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.acls.list")
   public void searchAcls(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -146,6 +148,7 @@ public final class AclsResource {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.acls.create")
   public void createAcl(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -205,6 +208,7 @@ public final class AclsResource {
 
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.acls.delete")
   public void deleteAcls(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchAction.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.kafkarest.controllers.BrokerConfigManager;
 import io.confluent.kafkarest.entities.v3.AlterBrokerConfigBatchRequest;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -48,6 +49,7 @@ public final class AlterBrokerConfigBatchAction {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.configs.alter")
   public void alterBrokerConfigBatch(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchAction.java
@@ -21,6 +21,7 @@ import io.confluent.kafkarest.controllers.ClusterConfigManager;
 import io.confluent.kafkarest.entities.ClusterConfig;
 import io.confluent.kafkarest.entities.v3.AlterClusterConfigBatchRequest;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -49,6 +50,7 @@ public final class AlterClusterConfigBatchAction {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.configs.alter")
   public void alterClusterConfigBatch(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.kafkarest.controllers.TopicConfigManager;
 import io.confluent.kafkarest.entities.v3.AlterTopicConfigBatchRequest;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -48,6 +49,7 @@ public final class AlterTopicConfigBatchAction {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.configs.alter")
   public void alterTopicConfigBatch(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokerConfigsResource.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ public final class BrokerConfigsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.configs.list")
   public void listBrokerConfigs(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -105,6 +107,7 @@ public final class BrokerConfigsResource {
   @GET
   @Path("/{name}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.configs.get")
   public void getBrokerConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -124,6 +127,7 @@ public final class BrokerConfigsResource {
   @Path("/{name}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.configs.update")
   public void updateBrokerConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -144,6 +148,7 @@ public final class BrokerConfigsResource {
   @DELETE
   @Path("/{name}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.configs.delete")
   public void resetBrokerConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/BrokersResource.java
@@ -28,6 +28,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -61,6 +62,7 @@ public final class BrokersResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.list")
   public void listBrokers(
       @Suspended AsyncResponse asyncResponse, @PathParam("clusterId") String clusterId) {
     CompletableFuture<ListBrokersResponse> response =
@@ -87,6 +89,7 @@ public final class BrokersResource {
   @GET
   @Path("/{brokerId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.get")
   public void getBroker(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClusterConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClusterConfigsResource.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ public final class ClusterConfigsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.configs.list")
   public void listClusterConfigs(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -106,6 +108,7 @@ public final class ClusterConfigsResource {
   @GET
   @Path("/{name}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.configs.get")
   public void getClusterConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -125,6 +128,7 @@ public final class ClusterConfigsResource {
   @Path("/{name}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.configs.update")
   public void upsertClusterConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -145,6 +149,7 @@ public final class ClusterConfigsResource {
   @DELETE
   @Path("/{name}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.configs.delete")
   public void deleteClusterConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ClustersResource.java
@@ -28,6 +28,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -61,6 +62,7 @@ public final class ClustersResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.list")
   public void listClusters(@Suspended AsyncResponse asyncResponse) {
     CompletableFuture<ListClustersResponse> response =
         clusterManager.get()
@@ -85,6 +87,7 @@ public final class ClustersResource {
   @GET
   @Path("/{clusterId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.clusters.get")
   public void getCluster(
       @Suspended AsyncResponse asyncResponse, @PathParam("clusterId") String clusterId) {
     CompletableFuture<GetClusterResponse> response =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerAssignmentsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerAssignmentsResource.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -65,6 +66,7 @@ public final class ConsumerAssignmentsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.consumer-assignments.list")
   public void listConsumerAssignments(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -106,6 +108,7 @@ public final class ConsumerAssignmentsResource {
   @GET
   @Path("/{topicName}/partitions/{partitionId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.consumer-assignments.get")
   public void getConsumerAssignment(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResource.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -61,6 +62,7 @@ public final class ConsumerGroupsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.consumer-groups.list")
   public void listConsumerGroups(
       @Suspended AsyncResponse asyncResponse, @PathParam("clusterId") String clusterId) {
     CompletableFuture<ListConsumerGroupsResponse> response =
@@ -90,6 +92,7 @@ public final class ConsumerGroupsResource {
   @GET
   @Path("/{consumerGroupId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.consumer-groups.get")
   public void getConsumerGroup(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumersResource.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -60,6 +61,7 @@ public final class ConsumersResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.consumers.list")
   public void listConsumers(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -96,6 +98,7 @@ public final class ConsumersResource {
   @GET
   @Path("/{consumerId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.consumers.get")
   public void getConsumer(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/GetReassignmentAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/GetReassignmentAction.java
@@ -25,6 +25,7 @@ import io.confluent.kafkarest.entities.v3.Resource;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -56,6 +57,7 @@ public final class GetReassignmentAction {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.partitions.reassignment.get")
   public void getReassignment(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ListAllReassignmentsAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ListAllReassignmentsAction.java
@@ -27,6 +27,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -58,6 +59,7 @@ public final class ListAllReassignmentsAction {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics-partitions-reassignment.list")
   public void listReassignments(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/PartitionsResource.java
@@ -28,6 +28,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -61,6 +62,7 @@ public final class PartitionsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.partitions.list")
   public void listPartitions(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -95,6 +97,7 @@ public final class PartitionsResource {
   @GET
   @Path("/{partitionId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.partitions.get")
   public void getPartition(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ReplicasResource.java
@@ -28,6 +28,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -58,6 +59,7 @@ public final class ReplicasResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.replicas.list")
   public void listReplicas(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -96,6 +98,7 @@ public final class ReplicasResource {
   @GET
   @Path("/{brokerId}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.replicas.get")
   public void getReplica(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReassignmentsByTopicAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReassignmentsByTopicAction.java
@@ -27,6 +27,7 @@ import io.confluent.kafkarest.entities.v3.SearchReassignmentsByTopicResponse;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -58,6 +59,7 @@ public final class SearchReassignmentsByTopicAction {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.partitions-reassignment.list")
   public void listReassignmentsByTopic(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/SearchReplicasByBrokerAction.java
@@ -28,6 +28,7 @@ import io.confluent.kafkarest.entities.v3.SearchReplicasByBrokerResponse;
 import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -57,6 +58,7 @@ public final class SearchReplicasByBrokerAction {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.brokers.partition-replicas.list")
   public void searchReplicasByBroker(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicConfigsResource.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -69,6 +70,7 @@ public final class TopicConfigsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.configs.list")
   public void listTopicConfigs(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -105,6 +107,7 @@ public final class TopicConfigsResource {
   @GET
   @Path("/{name}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.configs.get")
   public void getTopicConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -124,6 +127,7 @@ public final class TopicConfigsResource {
   @Path("/{name}")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.configs.update")
   public void updateTopicConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -144,6 +148,7 @@ public final class TopicConfigsResource {
   @DELETE
   @Path("/{name}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.configs.delete")
   public void resetTopicConfig(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -32,6 +32,7 @@ import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
+import io.confluent.rest.annotations.PerformanceMetric;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -75,6 +76,7 @@ public final class TopicsResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.list")
   public void listTopics(
       @Suspended AsyncResponse asyncResponse, @PathParam("clusterId") String clusterId) {
     CompletableFuture<ListTopicsResponse> response =
@@ -102,6 +104,7 @@ public final class TopicsResource {
   @GET
   @Path("/{topicName}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.get")
   public void getTopic(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -119,6 +122,7 @@ public final class TopicsResource {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.create")
   public void createTopic(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -156,6 +160,7 @@ public final class TopicsResource {
   @DELETE
   @Path("/{topicName}")
   @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.topics.delete")
   public void deleteTopic(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,

--- a/testing/environments/minimal/docker-compose.yml
+++ b/testing/environments/minimal/docker-compose.yml
@@ -91,5 +91,7 @@ services:
       KAFKA_REST_LISTENERS: "http://0.0.0.0:9391"
       KAFKA_REST_HOST_NAME: "localhost"
       KAFKA_REST_ZOOKEEPER_CONNECT: "zookeeper:9091"
+      JMX_PORT: 9392
     ports:
       - "9391:9391"
+      - "9392:9392"


### PR DESCRIPTION
Tested using VisualVM.

Prefixes:

```
v3.clusters.list.
v3.clusters.get.
v3.acls.list.
v3.acls.create.
v3.acls.delete.
v3.clusters.configs.list.
v3.clusters.configs.alter.
v3.clusters.configs.get.
v3.clusters.configs.update.
v3.clusters.configs.delete.
v3.brokers.list.
v3.brokers.get.
v3.brokers.configs.list.
v3.brokers.configs.alter.
v3.brokers.configs.get.
v3.brokers.configs.update.
v3.brokers.configs.delete.
v3.brokers.partition-replicas.list.
v3.consumer-groups.list.
v3.consumer-gropus.get.
v3.consumers.list.
v3.consumers.get.
v3.consumer-assignments.list.
v3.consumer-assignments.get.
v3.topics.list.
v3.topics.create.
v3.topics.get.
v3.topics.delete.
v3.topics.configs.list.
v3.topics.configs.alter.
v3.topics.configs.get.
v3.topics.configs.update.
v3.topics.configs.delete.
v3.partitions.list.
v3.partitions.get.
v3.topics-partitions-reassignment.list.
v3.topics.partitions-reassignments.list.
v3.topics.partitions.reassignment.get.
v3.replicas.list.
v3.replicas.get.
```

Suffixes:

```
request-byte-rate: Bytes/second of incoming requests
request-error-rate: The average number of requests per second that resulted in HTTP error responses
request-latency-avg: The average request latency in ms
request-latency-max: The maximum request latency in ms
request-rate: The average number of HTTP requests per second.
request-size-avg: The average request size in bytes
request-size-max: The maximum request size in bytes
response-byte-rate: Bytes/second of outgoing responses
response-rate: The average number of HTTP responses per second.
response-size-avg: The average response size in bytes
response-size-max: The maximum response size in bytes
```