### PR TITLE
KREST-7: Make advertised.listeners and listeners precede host.name:port.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
@@ -93,15 +93,12 @@ final class UrlFactoryImpl implements UrlFactory {
       List<String> listenersConfig,
       UriInfo requestUriInfo) {
     // Preferences are, in order:
-    // 1. hostNameConfig:portConfig
-    // 2. listener.authority, where listener in advertisedListenersConfig and
+    // 1. listener.authority, where listener in advertisedListenersConfig and
     //                        listener.scheme = request.scheme
-    // 3. listener.authority, where listener in listenersConfig and
+    // 2. listener.authority, where listener in listenersConfig and
     //                        listener.scheme = request.scheme
+    // 3. hostNameConfig:portConfig
     // 4. request.authority
-    if (!hostNameConfig.isEmpty()) {
-      return String.format("%s:%s", hostNameConfig, portConfig);
-    }
     String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
     for (String listener : Iterables.concat(advertisedListenersConfig, listenersConfig)) {
       int protocolSeparator = listener.indexOf("://");
@@ -109,6 +106,9 @@ final class UrlFactoryImpl implements UrlFactory {
       if (requestScheme.equals(listenerScheme)) {
         return listener.substring(protocolSeparator + 3);
       }
+    }
+    if (hostNameConfig != null && !hostNameConfig.isEmpty() && portConfig != null) {
+      return String.format("%s:%s", hostNameConfig, portConfig);
     }
     return requestUriInfo.getAbsolutePath().getAuthority();
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
@@ -41,7 +41,8 @@ public class UrlFactoryImplTest {
 
   @Test
   public void create_withHostNameAndPortConfig_returnsUrlRelativeToHostNameAndPortConfig() {
-    expect(requestUriInfo.getAbsolutePath()).andReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
+    expect(requestUriInfo.getAbsolutePath())
+        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
     expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
     replay(requestUriInfo);
 
@@ -174,5 +175,85 @@ public class UrlFactoryImplTest {
     String url = urlFactory.create("foo", "bar");
 
     assertEquals("http://1.2.3.4:1000/xxx/foo/bar", url);
+  }
+
+  @Test
+  public void testCreateHostAndAdvertisedListenerReturnsRelativeToAdvertisedListener() {
+    expect(requestUriInfo.getAbsolutePath())
+        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
+    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    replay(requestUriInfo);
+
+    UrlFactory urlFactory =
+        new UrlFactoryImpl(
+            "hostname",
+            2000,
+            singletonList("http://advertised.listener:2000"),
+            emptyList(),
+            requestUriInfo);
+
+    String url = urlFactory.create("foo", "bar");
+
+    assertEquals("http://advertised.listener:2000/foo/bar", url);
+  }
+
+  @Test
+  public void testCreateHostAndListenerReturnsRelativeToListener() {
+    expect(requestUriInfo.getAbsolutePath())
+        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
+    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    replay(requestUriInfo);
+
+    UrlFactory urlFactory =
+        new UrlFactoryImpl(
+            "hostname",
+            2000,
+            emptyList(),
+            singletonList("http://listener:2000"),
+            requestUriInfo);
+
+    String url = urlFactory.create("foo", "bar");
+
+    assertEquals("http://listener:2000/foo/bar", url);
+  }
+
+  @Test
+  public void testCreateAdvertisedListenerAndListenerReturnsRelativeToAdvertisedListener() {
+    expect(requestUriInfo.getAbsolutePath())
+        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
+    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    replay(requestUriInfo);
+
+    UrlFactory urlFactory =
+        new UrlFactoryImpl(
+            "",
+            0,
+            singletonList("http://advertised.listener:2000"),
+            singletonList("http://listener:2000"),
+            requestUriInfo);
+
+    String url = urlFactory.create("foo", "bar");
+
+    assertEquals("http://advertised.listener:2000/foo/bar", url);
+  }
+
+  @Test
+  public void testCreateHostAdvertisedListenerAndListenerReturnsRelativeToAdvertisedListener() {
+    expect(requestUriInfo.getAbsolutePath())
+        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
+    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    replay(requestUriInfo);
+
+    UrlFactory urlFactory =
+        new UrlFactoryImpl(
+            "hostname",
+            2000,
+            singletonList("http://advertised.listener:2000"),
+            singletonList("http://listener:2000"),
+            requestUriInfo);
+
+    String url = urlFactory.create("foo", "bar");
+
+    assertEquals("http://advertised.listener:2000/foo/bar", url);
   }
 }


### PR DESCRIPTION
For V3 APIs, the preference order for returned URLs should be:

1. advertised.listeners config
2. listeners config
3. host.name and port config
4. request base URL

Currently the order is (3, 1, 2, 4). Reorder them to the correct order.