### PR TITLE
#748 - Allow config consumer.max.poll.records

### DIFF
--- a/kafka-rest-common/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest-common/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -57,7 +57,7 @@ public class KafkaRestConfig extends RestConfig {
   private static final String MAX_POLL_RECORDS_DOC =
           "The maximum number of records returned in a single call to poll().";
   // ensures poll is frequently needed and called
-  public static final String MAX_POLL_RECORDS_VALUE = "30";
+  public static final String MAX_POLL_RECORDS_DEFAULT = "30";
 
   public static final String HOST_NAME_CONFIG = "host.name";
   private static final String HOST_NAME_DOC =
@@ -370,6 +370,13 @@ public class KafkaRestConfig extends RestConfig {
         CONSUMER_MAX_THREADS_DEFAULT,
         Importance.MEDIUM,
         CONSUMER_MAX_THREADS_DOC
+    )
+    .define(
+        MAX_POLL_RECORDS_CONFIG,
+        Type.INT,
+        MAX_POLL_RECORDS_DEFAULT,
+        Importance.MEDIUM,
+        MAX_POLL_RECORDS_DOC
     )
     .define(
         ZOOKEEPER_CONNECT_CONFIG,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -17,7 +17,6 @@ package io.confluent.kafkarest.v2;
 
 import static io.confluent.kafkarest.KafkaRestConfig.CONSUMER_MAX_THREADS_CONFIG;
 import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_CONFIG;
-import static io.confluent.kafkarest.KafkaRestConfig.MAX_POLL_RECORDS_VALUE;
 
 import io.confluent.kafkarest.ConsumerInstanceId;
 import io.confluent.kafkarest.ConsumerReadCallback;
@@ -201,7 +200,10 @@ public class KafkaConsumerManager {
       //Properties props = (Properties) config.getOriginalProperties().clone();
       Properties props = config.getConsumerProperties();
       props.setProperty(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
-      props.setProperty(MAX_POLL_RECORDS_CONFIG, MAX_POLL_RECORDS_VALUE);
+      if (props.getProperty(MAX_POLL_RECORDS_CONFIG) == null) {
+        props.setProperty(MAX_POLL_RECORDS_CONFIG,
+                config.getInt(MAX_POLL_RECORDS_CONFIG).toString());
+      }
       props.setProperty("group.id", group);
       // This ID we pass here has to be unique, only pass a value along if the deprecated ID field
       // was passed in. This generally shouldn't be used, but is maintained for compatibility.


### PR DESCRIPTION
Currently the consumer `max.poll.records` configuration cannot be altered from the internally coded value of `30`.  This PR allows the consumer value to be changed to the users choice by setting `consumer.max.poll.records` in the `kafka-rest.properties` file.  If a different value is not set by the user, then the previous internally coded value of `30` will be used.