### PR TITLE
Write balancer port on `base-uri`

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -74,6 +74,12 @@ public class KafkaRestConfig extends RestConfig {
       + " hostname is used";
   public static final String HOST_NAME_DEFAULT = "";
 
+  public static final String HOST_PORT_CONFIG = "host.port";
+  private static final String HOST_PORT_DOC =
+      "The host port used to generate absolute URLs in responses. If empty, the default canonical"
+          + " port is used";
+  public static final String HOST_PORT_DEFAULT = "-1";
+
   public static final String ADVERTISED_LISTENERS_CONFIG = "advertised.listeners";
   protected static final String ADVERTISED_LISTENERS_DOC =
       "List of advertised listeners. Used when generating absolute URLs in responses. Protocols"
@@ -375,6 +381,12 @@ public class KafkaRestConfig extends RestConfig {
         Type.STRING,
         HOST_NAME_DEFAULT,
         Importance.MEDIUM, HOST_NAME_DOC
+    )
+    .define(
+        HOST_PORT_CONFIG,
+        Type.INT,
+        HOST_PORT_DEFAULT,
+        Importance.MEDIUM, HOST_PORT_DOC
     )
     .define(
         ADVERTISED_LISTENERS_CONFIG,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/UriUtils.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/UriUtils.java
@@ -35,7 +35,10 @@ public class UriUtils {
       URI origAbsoluteUri = uriInfo.getAbsolutePath();
       builder.scheme(origAbsoluteUri.getScheme());
       // Only reset the port if it was set in the original URI
-      if (origAbsoluteUri.getPort() != -1) {
+      Integer port = config.getInt(KafkaRestConfig.HOST_PORT_CONFIG);
+      if (port != null && port != -1) {
+        builder.port(port);
+      } else if (origAbsoluteUri.getPort() != -1) {
         try {
           builder.port(config.consumerPort(origAbsoluteUri.getScheme()));
         } catch (URISyntaxException e) {


### PR DESCRIPTION
Sometimes it's usefull to return external balancer's port in `base-uri` 

Settings

`host.port=9090`

If this property is set, then  `base-uri` will contain the port `9090`