### PR TITLE
[WIP] Proposed changes to openapi.yaml for consumer lag metrics

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -336,12 +336,12 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerGroupLagResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/topics/{topic_name}/partitions/{partition_id}/lag:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/lags/{consumer_group_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
-      - $ref: '#/components/parameters/ConsumerGroupId'
       - $ref: '#/components/parameters/TopicName'
       - $ref: '#/components/parameters/PartitionId'
+      - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
       summary: 'Get Consumer Lag'
@@ -352,7 +352,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerLagResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/topics/-/partitions/-/lag:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
       parameters:
         - $ref: '#/components/parameters/ClusterId'
         - $ref: '#/components/parameters/ConsumerGroupId'
@@ -1235,7 +1235,6 @@ components:
             - consumer_group_id
             - topic_name
             - partition_id
-            - partition
             - current_offset
             - log_end_offset
             - lag
@@ -1250,8 +1249,6 @@ components:
               type: string
             partition_id:
               type: integer
-            partition:
-              $ref: '#/components/schemas/Relationship'
             current_offset:
               type: integer
             log_end_offset:
@@ -1824,7 +1821,7 @@ components:
             partition:
               related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
             lag:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/consumer-groups/1/lag'
+              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-group-1'
 
     GetConsumerGroupResponse:
       description: 'The consumer group.'
@@ -1879,14 +1876,12 @@ components:
           example:
             kind: 'KafkaConsumerLag'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/1/topics/topic-1/partitions/1/lag'
-              resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=1/lag'
+              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-group-1'
+              resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags/consumer-group=consumer-group-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
             topic_name: 'topic-1'
             partition_id: 1
-            partition:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
             consumer_id: 'consumer-1'
             instance_id: 'consumer-instance-1'
             client_id: 'client-1'
@@ -2287,7 +2282,7 @@ components:
                 partition:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
                 lag:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/consumer-groups/1/lag'
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-group-1'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
                   self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-2/partitions/2'
@@ -2300,7 +2295,7 @@ components:
                 partition:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2'
                 lag:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2/consumer-groups/1/lag'
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2/lags/consumer-groups-1'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
                   self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-3/partitions/3'
@@ -2313,7 +2308,7 @@ components:
                 partition:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3'
                 lag:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3/consumer-groups/1/lag'
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3/lags/consumer-groups-1'
 
     ListConsumerGroupsResponse:
       description: 'The list of consumer groups.'
@@ -2376,19 +2371,17 @@ components:
          example:
            kind: 'KafkaConsumerLagList'
            metadata:
-             self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topics/-/partitions/-/lag'
+             self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags'
              next: null
            data:
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topics/topic-1/partitions/1/lag'
-                 resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=1/lag'
+                 self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-groups/consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags/consumer-group=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
                partition_id: 1
-               partition:
-                 related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
                consumer_id: 'consumer-1'
                instance_id: 'consumer-instance-1'
                client_id: 'client-1'
@@ -2397,14 +2390,12 @@ components:
                lag: 100
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topics/topic-1/partitions/2/lag'
-                 resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=2/lag'
+                 self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/lags/consumer-groups/consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/lags/consumer-group=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
                partition_id: 2
-               partition:
-                 related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2'
                consumer_id: 'consumer-2'
                instance_id: 'consumer-instance-2'
                client_id: 'client-2'
@@ -2413,14 +2404,12 @@ components:
                lag: 10
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topic-1/partitions/3/lag'
-                 resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=3/lag'
+                 self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/lags/consumer-groups/consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/lags/consumer-group=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
                partition_id: 3
-               partition:
-                 related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3'
                consumer_id: 'consumer-3'
                instance_id: 'consumer-instance-3'
                client_id: 'client-3'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1259,7 +1259,7 @@ components:
               items:
                 $ref: '#/components/schemas/ConsumerLagData'
 
-    MaxConsumerLagData:
+    ConsumerLagSummaryData:
       allOf:
         - $ref: '#/components/schemas/Resource'
         - type: object

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -336,33 +336,35 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerGroupLagResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/lag:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/topics/{topic_name}/partitions/{partition_id}/lag:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
+      - $ref: '#/components/parameters/TopicName'
+      - $ref: '#/components/parameters/PartitionId'
+
+    get:
+      summary: 'Get Consumer Lag'
+      description: 'Returns the consumer lag on a partition with the given `partition_id`.'
+      tags:
+        - Partition
+      responses:
+        '200':
+          $ref: '#/components/responses/GetConsumerLagResponse'
+
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/topics/-/partitions/-/lag:
+      parameters:
+        - $ref: '#/components/parameters/ClusterId'
+        - $ref: '#/components/parameters/ConsumerGroupId'
 
       get:
-        summary: 'Get Consumer Lag'
-        description: 'Returns lag of the specified consumer.'
+        summary: 'List Consumer Lags'
+        description: 'Returns a list of consumer lags of the consumers belonging to the specified consumer group.'
         tags:
           - Consumer Group
         responses:
           '200':
-            $ref: '#/components/responses/GetConsumerLagResponse'
-
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/-/lag:
-    parameters:
-      - $ref: '#/components/parameters/ClusterId'
-      - $ref: '#/components/parameters/ConsumerGroupId'
-
-    get:
-      summary: 'List Consumer Lags'
-      description: 'Returns a list of consumer lags of the consumers belonging to the specified consumer group.'
-      tags:
-        - Consumer Group
-      responses:
-        '200':
-          $ref: '#/components/responses/ListConsumerLagsResponse'
+            $ref: '#/components/responses/ListConsumerLagsResponse'
 
   /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}:
     parameters:
@@ -1108,6 +1110,7 @@ components:
             - topic_name
             - partition_id
             - partition
+            - lag
           properties:
             cluster_id:
               type: string
@@ -1120,6 +1123,8 @@ components:
             partition_id:
               type: integer
             partition:
+              $ref: '#/components/schemas/Relationship'
+            lag:
               $ref: '#/components/schemas/Relationship'
 
     ConsumerAssignmentDataList:
@@ -1228,19 +1233,25 @@ components:
           required:
             - cluster_id
             - consumer_group_id
+            - topic_name
+            - partition_id
+            - partition
             - current_offset
             - log_end_offset
             - lag
             - consumer_id
             - client_id
-            - topic_name
-            - partition_id
-            - partition
           properties:
             cluster_id:
               type: string
             consumer_group_id:
               type: string
+            topic_name:
+              type: string
+            partition_id:
+              type: integer
+            partition:
+              $ref: '#/components/schemas/Relationship'
             current_offset:
               type: integer
             log_end_offset:
@@ -1254,12 +1265,6 @@ components:
               nullable: true
             client_id:
               type: string
-            topic_name:
-              type: string
-            partition_id:
-              type: integer
-            partition:
-              $ref: '#/components/schemas/Relationship'
 
     ConsumerLagDataList:
       allOf:
@@ -1540,7 +1545,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/TopicData'
-                
+
     UpdateConfigRequestData:
       type: object
       properties:
@@ -1818,6 +1823,8 @@ components:
             partition_id: 1
             partition:
               related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+            lag:
+              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/consumer-groups/1/lag'
 
     GetConsumerGroupResponse:
       description: 'The consumer group.'
@@ -1872,17 +1879,20 @@ components:
           example:
             kind: 'KafkaConsumerLag'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/lag'
-              resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/lag'
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/1/topics/topic-1/partitions/1/lag'
+              resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=1/lag'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
-            consumer_id: 'consumer-1'
-            instance_id: 'consumer-instance-1'
-            client_id: 'client-1'
             topic_name: 'topic-1'
             partition_id: 1
             partition:
               related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+            consumer_id: 'consumer-1'
+            instance_id: 'consumer-instance-1'
+            client_id: 'client-1'
+            current_offset: 1
+            log_end_offset: 101
+            lag: 100
 
     GetConsumerResponse:
       description: 'The consumer.'
@@ -2276,6 +2286,8 @@ components:
                 partition_id: 1
                 partition:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+                lag:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/consumer-groups/1/lag'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
                   self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-2/partitions/2'
@@ -2287,6 +2299,8 @@ components:
                 partition_id: 2
                 partition:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2'
+                lag:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2/consumer-groups/1/lag'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
                   self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-3/partitions/3'
@@ -2298,6 +2312,8 @@ components:
                 partition_id: 3
                 partition:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3'
+                lag:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3/consumer-groups/1/lag'
 
     ListConsumerGroupsResponse:
       description: 'The list of consumer groups.'
@@ -2352,56 +2368,65 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
 
     ListConsumerLagsResponse:
-      description: 'The list of consumer lags.'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ConsumerLagDataList'
-          example:
-            kind: 'KafkaConsumerLagList'
-            metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/-/lag'
-              next: null
-            data:
-              - kind: 'KafkaConsumerLag'
-                metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/lag'
-                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/lag'
-                cluster_id: 'cluster-1'
-                consumer_group_id: 'consumer-group-1'
-                consumer_id: 'consumer-1'
-                instance_id: 'consumer-instance-1'
-                client_id: 'client-1'
-                topic_name: 'topic-1'
-                partition_id: 1
-                partition:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
-              - kind: 'KafkaConsumerLag'
-                metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/lag'
-                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-2/lag'
-                cluster_id: 'cluster-1'
-                consumer_group_id: 'consumer-group-1'
-                consumer_id: 'consumer-2'
-                instance_id: 'consumer-instance-2'
-                client_id: 'client-2'
-                topic_name: 'topic-1'
-                partition_id: 2
-                partition:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2'
-              - kind: 'KafkaConsumerLag'
-                metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-3/lag'
-                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-3/lag'
-                cluster_id: 'cluster-1'
-                consumer_group_id: 'consumer-group-1'
-                consumer_id: 'consumer-3'
-                instance_id: 'consumer-instance-3'
-                client_id: 'client-3'
-                topic_name: 'topic-1'
-                partition_id: 3
-                partition:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3'
+     description: 'The list of consumer lags.'
+     content:
+       application/json:
+         schema:
+           $ref: '#/components/schemas/ConsumerLagDataList'
+         example:
+           kind: 'KafkaConsumerLagList'
+           metadata:
+             self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topics/-/partitions/-/lag'
+             next: null
+           data:
+             - kind: 'KafkaConsumerLag'
+               metadata:
+                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topics/topic-1/partitions/1/lag'
+                 resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=1/lag'
+               cluster_id: 'cluster-1'
+               consumer_group_id: 'consumer-group-1'
+               topic_name: 'topic-1'
+               partition_id: 1
+               partition:
+                 related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+               consumer_id: 'consumer-1'
+               instance_id: 'consumer-instance-1'
+               client_id: 'client-1'
+               current_offset: 1
+               log_end_offset: 101
+               lag: 100
+             - kind: 'KafkaConsumerLag'
+               metadata:
+                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topics/topic-1/partitions/2/lag'
+                 resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=2/lag'
+               cluster_id: 'cluster-1'
+               consumer_group_id: 'consumer-group-1'
+               topic_name: 'topic-1'
+               partition_id: 2
+               partition:
+                 related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2'
+               consumer_id: 'consumer-2'
+               instance_id: 'consumer-instance-2'
+               client_id: 'client-2'
+               current_offset: 1
+               log_end_offset: 11
+               lag: 10
+             - kind: 'KafkaConsumerLag'
+               metadata:
+                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/topic-1/partitions/3/lag'
+                 resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/topic=topic-1/partition=3/lag'
+               cluster_id: 'cluster-1'
+               consumer_group_id: 'consumer-group-1'
+               topic_name: 'topic-1'
+               partition_id: 3
+               partition:
+                 related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3'
+               consumer_id: 'consumer-3'
+               instance_id: 'consumer-instance-3'
+               client_id: 'client-3'
+               current_offset: 1
+               log_end_offset: 1
+               lag: 0
 
     ListConsumersResponse:
       description: 'The list of consumers.'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -322,6 +322,34 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumersResponse'
 
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag_summary:
+    parameters:
+      - $ref: '#/components/parameters/ClusterId'
+      - $ref: '#/components/parameters/ConsumerGroupId'
+
+    get:
+      summary: 'Get Consumer Lag Summary.'
+      description: 'Returns the max and total lag of the consumers belonging to the specified consumer group.'
+      tags:
+        - Consumer Group
+      responses:
+        '200':
+          $ref: '#/components/responses/GetConsumerLagSummaryResponse'
+
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag:
+    parameters:
+      - $ref: '#/components/parameters/ClusterId'
+      - $ref: '#/components/parameters/ConsumerGroupId'
+
+    get:
+      summary: 'List Consumer Lags'
+      description: 'Returns a list of consumer lags of the consumers belonging to the specified consumer group.'
+      tags:
+        - Consumer Group
+      responses:
+        '200':
+          $ref: '#/components/responses/ListConsumerLagsResponse'
+
   /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -1179,6 +1207,95 @@ components:
         - DEAD
         - EMPTY
 
+    ConsumerLagData:
+      allOf:
+        - $ref: '#/components/schemas/Resource'
+        - type: object
+          required:
+            - current_offset
+            - log_end_offset
+            - lag
+            - cluster_id
+            - consumer_group_id
+            - consumer_id
+            - client_id
+            - topic_name
+            - partition_id
+            - partition
+          properties:
+            current_offset:
+              type: integer
+            log_end_offset:
+              type: integer
+            lag:
+              type: integer
+            cluster_id:
+              type: string
+            consumer_group_id:
+              type: string
+            consumer_id:
+              type: string
+            instance_id:
+              type: string
+              nullable: true
+            client_id:
+              type: string
+            topic_name:
+              type: string
+            partition_id:
+              type: integer
+            partition:
+              $ref: '#/components/schemas/Relationship'
+
+    ConsumerLagDataList:
+      allOf:
+        - $ref: '#/components/schemas/ResourceCollection'
+        - type: object
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/ConsumerLagData'
+
+    MaxConsumerLagData:
+      allOf:
+        - $ref: '#/components/schemas/Resource'
+        - type: object
+          required:
+            - max_lag
+            - total_lag
+            - cluster_id
+            - consumer_group_id
+            - max_lag_consumer_id
+            - max_lag_client_id
+            - max_lag_topic_name
+            - max_lag_partition_id
+            - max_lag_partition
+          properties:
+            max_lag:
+              type: integer
+            total_lag:
+              type: integer
+            cluster_id:
+              type: string
+            consumer_group_id:
+              type: string
+            max_lag_consumer_id:
+              type: string
+            max_lag_instance_id:
+              type: string
+              nullable: true
+            max_lag_client_id:
+              type: string
+            max_lag_topic_name:
+              type: string
+            max_lag_partition_id:
+              type: integer
+            max_lag_partition:
+              $ref: '#/components/schemas/Relationship'
+
     PartitionData:
       allOf:
         - $ref: '#/components/schemas/Resource'
@@ -1709,6 +1826,30 @@ components:
             consumers:
               related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
 
+    GetConsumerLagSummaryResponse:
+      description: 'The max and total consumer lag in a consumer group.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ConsumerLagSummaryData'
+          example:
+            kind: 'KafkaConsumerLagSummary'
+            metadata:
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups-lag-summary/consumer-group-1'
+              resource_name: 'crn:///kafka=cluster-1/consumer-group-lag-summary=consumer-group-1'
+            max_lag: 100
+            total_lag: 110
+            cluster_id: 'cluster-1'
+            consumer_group_id: 'consumer-group-1'
+            state: 'STABLE'
+            consumer_id: 'consumer-1'
+            instance_id: 'consumer-instance-1'
+            client_id: 'client-1'
+            max_topic_name: 'topic-1'
+            max_partition_id: 1
+            max_partition:
+              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+
     GetConsumerResponse:
       description: 'The consumer.'
       content:
@@ -2175,6 +2316,58 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3'
                 consumers:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
+
+    ListConsumerLagsResponse:
+      description: 'The list of consumer lags.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ConsumerLagDataList'
+          example:
+            kind: 'KafkaConsumerLagList'
+            metadata:
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags'
+              next: null
+            data:
+              - kind: 'KafkaConsumerLag'
+                metadata:
+                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags/consumer-1'
+                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer-lag=consumer-1'
+                cluster_id: 'cluster-1'
+                consumer_group_id: 'consumer-group-1'
+                consumer_id: 'consumer-1'
+                instance_id: 'consumer-instance-1'
+                client_id: 'client-1'
+                topic_name: 'topic-1'
+                partition_id: 1
+                partition:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              - kind: 'KafkaConsumerLag'
+                metadata:
+                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags/consumer-2'
+                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer-lag=consumer-2'
+                cluster_id: 'cluster-1'
+                consumer_group_id: 'consumer-group-1'
+                consumer_id: 'consumer-2'
+                instance_id: 'consumer-instance-2'
+                client_id: 'client-2'
+                topic_name: 'topic-1'
+                partition_id: 2
+                partition:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2'
+              - kind: 'KafkaConsumerLag'
+                metadata:
+                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags/consumer-3'
+                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer-lag=consumer-3'
+                cluster_id: 'cluster-1'
+                consumer_group_id: 'consumer-group-1'
+                consumer_id: 'consumer-3'
+                instance_id: 'consumer-instance-3'
+                client_id: 'client-3'
+                topic_name: 'topic-1'
+                partition_id: 3
+                partition:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3'
 
     ListConsumersResponse:
       description: 'The list of consumers.'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -800,6 +800,8 @@ components:
               type: string
             resource_type:
               $ref: '#/components/schemas/AclResourceType'
+            resource_name:
+              type: string
             pattern_type:
               $ref: '#/components/schemas/AclPatternType'
             principal:
@@ -1036,6 +1038,8 @@ components:
       properties:
         resource_type:
           $ref: '#/components/schemas/AclResourceType'
+        resource_name:
+          type: string
         pattern_type:
           $ref: '#/components/schemas/AclPatternType'
         principal:
@@ -1877,7 +1881,7 @@ components:
             kind: 'KafkaConsumerLag'
             metadata:
               self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-group-1'
-              resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags=consumer-group-1'
+              resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lag=consumer-group-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
             topic_name: 'topic-1'
@@ -2377,7 +2381,7 @@ components:
              - kind: 'KafkaConsumerLag'
                metadata:
                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-groups/consumer-group-1'
-                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags=consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lag=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
@@ -2391,7 +2395,7 @@ components:
              - kind: 'KafkaConsumerLag'
                metadata:
                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/lags/consumer-groups/consumer-group-1'
-                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/lags=consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/lag=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
@@ -2405,7 +2409,7 @@ components:
              - kind: 'KafkaConsumerLag'
                metadata:
                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/lags/consumer-groups/consumer-group-1'
-                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/lags=consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/lag=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1877,7 +1877,7 @@ components:
             kind: 'KafkaConsumerLag'
             metadata:
               self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-group-1'
-              resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags/consumer-group=consumer-group-1'
+              resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags=consumer-group-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
             topic_name: 'topic-1'
@@ -2377,7 +2377,7 @@ components:
              - kind: 'KafkaConsumerLag'
                metadata:
                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/lags/consumer-groups/consumer-group-1'
-                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags/consumer-group=consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/lags=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
@@ -2391,7 +2391,7 @@ components:
              - kind: 'KafkaConsumerLag'
                metadata:
                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/lags/consumer-groups/consumer-group-1'
-                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/lags/consumer-group=consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/lags=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'
@@ -2405,7 +2405,7 @@ components:
              - kind: 'KafkaConsumerLag'
                metadata:
                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/lags/consumer-groups/consumer-group-1'
-                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/lags/consumer-group=consumer-group-1'
+                 resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/lags=consumer-group-1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
                topic_name: 'topic-1'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -800,8 +800,6 @@ components:
               type: string
             resource_type:
               $ref: '#/components/schemas/AclResourceType'
-            resource_name:
-              type: string
             pattern_type:
               $ref: '#/components/schemas/AclPatternType'
             principal:
@@ -1038,8 +1036,6 @@ components:
       properties:
         resource_type:
           $ref: '#/components/schemas/AclResourceType'
-        resource_name:
-          type: string
         pattern_type:
           $ref: '#/components/schemas/AclPatternType'
         principal:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -322,21 +322,35 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumersResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag_summary:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
-      summary: 'Get Consumer Lag Summary.'
+      summary: 'Get Consumer Group Lag.'
       description: 'Returns the max and total lag of the consumers belonging to the specified consumer group.'
       tags:
         - Consumer Group
       responses:
         '200':
-          $ref: '#/components/responses/GetConsumerLagSummaryResponse'
+          $ref: '#/components/responses/GetConsumerGroupLagResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/lag:
+    parameters:
+      - $ref: '#/components/parameters/ClusterId'
+      - $ref: '#/components/parameters/ConsumerGroupId'
+
+      get:
+        summary: 'Get Consumer Lag'
+        description: 'Returns lag of the specified consumer.'
+        tags:
+          - Consumer Group
+        responses:
+          '200':
+            $ref: '#/components/responses/GetConsumerLagResponse'
+
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/-/lag:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -1212,27 +1226,27 @@ components:
         - $ref: '#/components/schemas/Resource'
         - type: object
           required:
+            - cluster_id
+            - consumer_group_id
             - current_offset
             - log_end_offset
             - lag
-            - cluster_id
-            - consumer_group_id
             - consumer_id
             - client_id
             - topic_name
             - partition_id
             - partition
           properties:
+            cluster_id:
+              type: string
+            consumer_group_id:
+              type: string
             current_offset:
               type: integer
             log_end_offset:
               type: integer
             lag:
               type: integer
-            cluster_id:
-              type: string
-            consumer_group_id:
-              type: string
             consumer_id:
               type: string
             instance_id:
@@ -1259,29 +1273,29 @@ components:
               items:
                 $ref: '#/components/schemas/ConsumerLagData'
 
-    ConsumerLagSummaryData:
+    ConsumerGroupLagData:
       allOf:
         - $ref: '#/components/schemas/Resource'
         - type: object
           required:
-            - max_lag
-            - total_lag
             - cluster_id
             - consumer_group_id
+            - max_lag
+            - total_lag
             - max_lag_consumer_id
             - max_lag_client_id
             - max_lag_topic_name
             - max_lag_partition_id
             - max_lag_partition
           properties:
-            max_lag:
-              type: integer
-            total_lag:
-              type: integer
             cluster_id:
               type: string
             consumer_group_id:
               type: string
+            max_lag:
+              type: integer
+            total_lag:
+              type: integer
             max_lag_consumer_id:
               type: string
             max_lag_instance_id:
@@ -1826,28 +1840,48 @@ components:
             consumers:
               related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
 
-    GetConsumerLagSummaryResponse:
+    GetConsumerGroupLagResponse:
       description: 'The max and total consumer lag in a consumer group.'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ConsumerLagSummaryData'
+            $ref: '#/components/schemas/ConsumerGroupLagData'
           example:
-            kind: 'KafkaConsumerLagSummary'
+            kind: 'KafkaConsumerGroupLag'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups-lag-summary/consumer-group-1'
-              resource_name: 'crn:///kafka=cluster-1/consumer-group-lag-summary=consumer-group-1'
-            max_lag: 100
-            total_lag: 110
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag'
+              resource_name: 'crn:///kafka=cluster-1/consumer-groups=consumer-group-1/lag'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
-            state: 'STABLE'
+            max_lag: 100
+            total_lag: 110
             consumer_id: 'consumer-1'
             instance_id: 'consumer-instance-1'
             client_id: 'client-1'
             max_topic_name: 'topic-1'
             max_partition_id: 1
             max_partition:
+              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+
+    GetConsumerLagResponse:
+      description: 'The consumer lag.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ConsumerLagData'
+          example:
+            kind: 'KafkaConsumerLag'
+            metadata:
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/lag'
+              resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/lag'
+            cluster_id: 'cluster-1'
+            consumer_group_id: 'consumer-group-1'
+            consumer_id: 'consumer-1'
+            instance_id: 'consumer-instance-1'
+            client_id: 'client-1'
+            topic_name: 'topic-1'
+            partition_id: 1
+            partition:
               related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
 
     GetConsumerResponse:
@@ -2326,13 +2360,13 @@ components:
           example:
             kind: 'KafkaConsumerLagList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags'
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/-/lag'
               next: null
             data:
               - kind: 'KafkaConsumerLag'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags/consumer-1'
-                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer-lag=consumer-1'
+                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/lag'
+                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/lag'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
                 consumer_id: 'consumer-1'
@@ -2344,8 +2378,8 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
               - kind: 'KafkaConsumerLag'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags/consumer-2'
-                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer-lag=consumer-2'
+                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/lag'
+                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-2/lag'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
                 consumer_id: 'consumer-2'
@@ -2357,8 +2391,8 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2'
               - kind: 'KafkaConsumerLag'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumer-lags/consumer-3'
-                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer-lag=consumer-3'
+                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-3/lag'
+                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-3/lag'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
                 consumer_id: 'consumer-3'


### PR DESCRIPTION
Related 1-pager here: https://confluentinc.atlassian.net/wiki/spaces/~797050444/pages/1643188895/One+Pager+Exposing+Consumer+Lag

Adding a consumer lag summary call (returns max and total lag of a consumer group) and list consumer lags call (returns lag for all consumers in a consumer group).

Would appreciate any feedback! especially on the fields being returned (e.g. consumer_id, instance_id)