### PR TITLE
KREST-155: Make partitions_count and replication_factor optional in Create Topic V3 API.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -56,9 +56,9 @@ public interface TopicManager {
   CompletableFuture<Void> createTopic(
       String clusterId,
       String topicName,
-      int partitionsCount,
-      short replicationFactor,
-      Map<String, String> configs);
+      Optional<Integer> partitionsCount,
+      Optional<Short> replicationFactor,
+      Map<String, Optional<String>> configs);
 
   /**
    * Deletes the Kafka {@link Topic} with the given {@code topicName}.

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -25,6 +25,7 @@ import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -170,13 +171,16 @@ final class TopicManagerImpl implements TopicManager {
   public CompletableFuture<Void> createTopic(
       String clusterId,
       String topicName,
-      int partitionsCount,
-      short replicationFactor,
-      Map<String, String> configs) {
+      Optional<Integer> partitionsCount,
+      Optional<Short> replicationFactor,
+      Map<String, Optional<String>> configs) {
     requireNonNull(topicName);
 
+    Map<String, String> nullableConfigs = new HashMap<>();
+    configs.forEach((key, value) -> nullableConfigs.put(key, value.orElse(null)));
+
     NewTopic createTopicRequest =
-        new NewTopic(topicName, partitionsCount, replicationFactor).configs(configs);
+        new NewTopic(topicName, partitionsCount, replicationFactor).configs(nullableConfigs);
 
     return clusterManager.getCluster(clusterId)
         .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
@@ -33,10 +33,10 @@ public abstract class CreateTopicRequest {
   public abstract String getTopicName();
 
   @JsonProperty("partitions_count")
-  public abstract int getPartitionsCount();
+  public abstract Optional<Integer> getPartitionsCount();
 
   @JsonProperty("replication_factor")
-  public abstract short getReplicationFactor();
+  public abstract Optional<Short> getReplicationFactor();
 
   @JsonProperty("configs")
   public abstract ImmutableList<ConfigEntry> getConfigs();
@@ -48,8 +48,8 @@ public abstract class CreateTopicRequest {
   @JsonCreator
   static CreateTopicRequest fromJson(
       @JsonProperty("topic_name") String topicName,
-      @JsonProperty("partitions_count") int partitionsCount,
-      @JsonProperty("replication_factor") short replicationFactor,
+      @JsonProperty("partitions_count") @Nullable  Integer partitionsCount,
+      @JsonProperty("replication_factor") @Nullable Short replicationFactor,
       @JsonProperty("configs") @Nullable List<ConfigEntry> configs
   ) {
     return builder()
@@ -68,9 +68,9 @@ public abstract class CreateTopicRequest {
 
     public abstract Builder setTopicName(String topicName);
 
-    public abstract Builder setPartitionsCount(int partitionsCount);
+    public abstract Builder setPartitionsCount(@Nullable Integer partitionsCount);
 
-    public abstract Builder setReplicationFactor(short replicationFactor);
+    public abstract Builder setReplicationFactor(@Nullable Short replicationFactor);
 
     public abstract Builder setConfigs(List<ConfigEntry> configs);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.kafkarest.controllers.TopicManager;
 import io.confluent.kafkarest.entities.Topic;
 import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
+import io.confluent.kafkarest.entities.v3.CreateTopicRequest.ConfigEntry;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicsResponse;
@@ -35,8 +36,8 @@ import io.confluent.kafkarest.response.UrlFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
 import java.net.URI;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -129,13 +130,12 @@ public final class TopicsResource {
       @Valid CreateTopicRequest request
   ) {
     String topicName = request.getTopicName();
-    int partitionsCount = request.getPartitionsCount();
-    short replicationFactor = request.getReplicationFactor();
-
-    // TODO: Change to Map<String, Optional<String>>
-    Map<String, String> configs = new HashMap<>();
-    request.getConfigs()
-        .forEach(entry -> configs.put(entry.getName(), entry.getValue().orElse(null)));
+    Optional<Integer> partitionsCount = request.getPartitionsCount();
+    Optional<Short> replicationFactor = request.getReplicationFactor();
+    Map<String, Optional<String>> configs =
+        request.getConfigs()
+            .stream()
+            .collect(Collectors.toMap(ConfigEntry::getName, ConfigEntry::getValue));
 
     TopicData topicData =
         toTopicData(
@@ -143,7 +143,8 @@ public final class TopicsResource {
                 clusterId,
                 topicName,
                 /* partitions= */ emptyList(),
-                replicationFactor,
+                // We have no way of knowing the default replication factor in the Kafka broker.
+                replicationFactor.orElse((short) 0),
                 /* isInternal= */ false));
 
     CompletableFuture<CreateTopicResponse> response =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -555,9 +555,60 @@ public class TopicManagerImplTest {
     topicManager.createTopic(
         CLUSTER_ID,
         TOPIC_1.getName(),
-        TOPIC_1.getPartitions().size(),
-        TOPIC_1.getReplicationFactor(),
-        singletonMap("cleanup.policy", "compact")).get();
+        Optional.of(TOPIC_1.getPartitions().size()),
+        Optional.of(TOPIC_1.getReplicationFactor()),
+        singletonMap("cleanup.policy", Optional.of("compact"))).get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void createTopic_nonExistingTopic_defaultPartitionsCount_createsTopic() throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.createTopics(
+            singletonList(
+                new NewTopic(
+                    TOPIC_1.getName(),
+                    /* numPartitions= */ Optional.empty(),
+                    Optional.of(TOPIC_1.getReplicationFactor()))
+                    .configs(singletonMap("cleanup.policy", "compact")))))
+        .andReturn(createTopicsResult);
+    expect(createTopicsResult.all()).andReturn(KafkaFuture.completedFuture(null));
+    replay(clusterManager, adminClient, createTopicsResult);
+
+    topicManager.createTopic(
+        CLUSTER_ID,
+        TOPIC_1.getName(),
+        /* partitionsCount= */ Optional.empty(),
+        Optional.of(TOPIC_1.getReplicationFactor()),
+        singletonMap("cleanup.policy", Optional.of("compact"))).get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void createTopic_nonExistingTopic_defaultReplicationFactor_createsTopic()
+      throws Exception {
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.createTopics(
+            singletonList(
+                new NewTopic(
+                    TOPIC_1.getName(),
+                    Optional.of(TOPIC_1.getPartitions().size()),
+                    /* replicationFactor= */ Optional.empty())
+                    .configs(singletonMap("cleanup.policy", "compact")))))
+        .andReturn(createTopicsResult);
+    expect(createTopicsResult.all()).andReturn(KafkaFuture.completedFuture(null));
+    replay(clusterManager, adminClient, createTopicsResult);
+
+    topicManager.createTopic(
+        CLUSTER_ID,
+        TOPIC_1.getName(),
+        Optional.of(TOPIC_1.getPartitions().size()),
+        /* replicationFactor= */ Optional.empty(),
+        singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
   }
@@ -581,9 +632,9 @@ public class TopicManagerImplTest {
       topicManager.createTopic(
           CLUSTER_ID,
           TOPIC_1.getName(),
-          TOPIC_1.getPartitions().size(),
-          TOPIC_1.getReplicationFactor(),
-          singletonMap("cleanup.policy", "compact")).get();
+          Optional.of(TOPIC_1.getPartitions().size()),
+          Optional.of(TOPIC_1.getReplicationFactor()),
+          singletonMap("cleanup.policy", Optional.of("compact"))).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(TopicExistsException.class, e.getCause().getClass());
@@ -601,9 +652,9 @@ public class TopicManagerImplTest {
       topicManager.createTopic(
           CLUSTER_ID,
           TOPIC_1.getName(),
-          TOPIC_1.getPartitions().size(),
-          TOPIC_1.getReplicationFactor(),
-          singletonMap("cleanup.policy", "compact")).get();
+          Optional.of(TOPIC_1.getPartitions().size()),
+          Optional.of(TOPIC_1.getReplicationFactor()),
+          singletonMap("cleanup.policy", Optional.of("compact"))).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -47,7 +47,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   private static final String TOPIC_3 = "topic-3";
 
   public TopicsResourceIntegrationTest() {
-    super(/* numBrokers= */ 1, /* withSchemaRegistry= */ false);
+    super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
   }
 
   @Before
@@ -63,6 +63,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   @Override
   public Properties overrideBrokerProperties(int i, Properties props) {
     props.put("delete.topic.enable", true);
+    props.put("default.replication.factor", 2);
     return props;
   }
 
@@ -405,7 +406,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
                 .setInternal(false)
-                .setReplicationFactor(1)
+                .setReplicationFactor(0)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -432,8 +433,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .post(
                 Entity.entity(
                     "{\"topic_name\":\"" + topicName + "\",\"partitions_count\":1," +
-                        "\"replication_factor\":1,\"configs\":[{\"name\":\"cleanup.policy\"," +
-                        "\"value\":\"compact\"}]}",
+                        "\"configs\":[{\"name\":\"cleanup.policy\",\"value\":\"compact\"}]}",
                     MediaType.APPLICATION_JSON));
     assertEquals(Status.CREATED.getStatusCode(), createTopicResponse.getStatus());
 
@@ -458,7 +458,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
                 .setInternal(false)
-                .setReplicationFactor(1)
+                .setReplicationFactor(2)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl


### PR DESCRIPTION
They default to `num.partitions` and `default.replication.factor` broker configs, respectively.