### PR TITLE
KREST-147: Make absolute URL generation consistent in V2 and V3.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -27,8 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -68,11 +66,12 @@ public class KafkaRestConfig extends RestConfig {
   // ensures poll is frequently needed and called
   public static final String MAX_POLL_RECORDS_VALUE = "30";
 
+  @Deprecated
   public static final String HOST_NAME_CONFIG = "host.name";
   private static final String HOST_NAME_DOC =
       "The host name used to generate absolute URLs in responses. If empty, the default canonical"
       + " hostname is used";
-  public static final String HOST_NAME_DEFAULT = "";
+  private static final String HOST_NAME_DEFAULT = "";
 
   public static final String ADVERTISED_LISTENERS_CONFIG = "advertised.listeners";
   protected static final String ADVERTISED_LISTENERS_DOC =
@@ -836,18 +835,6 @@ public class KafkaRestConfig extends RestConfig {
   @Override
   public RestMetricsContext getMetricsContext() {
     return metricsContext.metricsContext();
-  }
-
-  public int consumerPort(String scheme) throws URISyntaxException {
-    if (!getList(LISTENERS_CONFIG).isEmpty() && !getList(LISTENERS_CONFIG).get(0).isEmpty()) {
-      for (String listener : getList(LISTENERS_CONFIG)) {
-        URI uri = new URI(listener);
-        if (uri.getScheme().equals(scheme)) {
-          return uri.getPort();
-        }
-      }
-    }
-    return getInt(PORT_CONFIG);
   }
 
   public static KafkaRestConfig newConsumerConfig(KafkaRestConfig config,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -22,8 +22,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.HashSet;
+import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.Set;
 import javax.inject.Qualifier;
 import org.glassfish.hk2.api.AnnotationLiteral;
@@ -49,9 +51,12 @@ public final class ConfigModule extends AbstractBinder {
     bind(config).to(KafkaRestConfig.class);
 
     // Keep this list alphabetically sorted.
-    bind(config.getList(KafkaRestConfig.ADVERTISED_LISTENERS_CONFIG))
+    bind(
+        config.getList(KafkaRestConfig.ADVERTISED_LISTENERS_CONFIG).stream()
+            .map(URI::create)
+            .collect(Collectors.toList()))
         .qualifiedBy(new AdvertisedListenersConfigImpl())
-        .to(new TypeLiteral<List<String>>() { });
+        .to(new TypeLiteral<List<URI>>() { });
 
     bind(new HashSet<>(config.getList(KafkaRestConfig.API_ENDPOINTS_BLOCKLIST_CONFIG)))
         .qualifiedBy(new ApiEndpointsBlocklistConfigImpl())
@@ -65,9 +70,12 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new HostNameConfigImpl())
         .to(String.class);
 
-    bind(config.getList(RestConfig.LISTENERS_CONFIG))
+    bind(
+        config.getList(RestConfig.LISTENERS_CONFIG).stream()
+            .map(URI::create)
+            .collect(Collectors.toList()))
         .qualifiedBy(new ListenersConfigImpl())
-        .to(new TypeLiteral<List<String>>() { });
+        .to(new TypeLiteral<List<URI>>() { });
 
     bind(config.getInt(RestConfig.PORT_CONFIG))
         .qualifiedBy(new PortConfigImpl())

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
@@ -107,8 +107,8 @@ public final class ConsumersResource {
     }
     String instanceId =
         ctx.getKafkaConsumerManager().createConsumer(group, config.toConsumerInstanceConfig());
-    String instanceBaseUri = UriUtils.absoluteUriBuilder(ctx.getConfig(), uriInfo)
-        .path("instances").path(instanceId).build().toString();
+    String instanceBaseUri =
+        UriUtils.absoluteUri(ctx.getConfig(), uriInfo, "consumers", group, "instances", instanceId);
     return new CreateConsumerInstanceResponse(instanceId, instanceBaseUri);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
@@ -15,28 +15,30 @@
 
 package io.confluent.kafkarest.response;
 
-import com.google.common.collect.Iterables;
 import io.confluent.kafkarest.config.ConfigModule.AdvertisedListenersConfig;
 import io.confluent.kafkarest.config.ConfigModule.HostNameConfig;
 import io.confluent.kafkarest.config.ConfigModule.ListenersConfig;
 import io.confluent.kafkarest.config.ConfigModule.PortConfig;
+import java.net.URI;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
-final class UrlFactoryImpl implements UrlFactory {
+public final class UrlFactoryImpl implements UrlFactory {
 
   private static final char SEPARATOR = '/';
 
   private final String baseUrl;
 
   @Inject
-  UrlFactoryImpl(
+  public UrlFactoryImpl(
       @HostNameConfig String hostNameConfig,
       @PortConfig Integer portConfig,
-      @AdvertisedListenersConfig List<String> advertisedListenersConfig,
-      @ListenersConfig List<String> listenersConfig,
+      @AdvertisedListenersConfig List<URI> advertisedListenersConfig,
+      @ListenersConfig List<URI> listenersConfig,
       @Context UriInfo requestUriInfo
   ) {
     baseUrl =
@@ -64,8 +66,8 @@ final class UrlFactoryImpl implements UrlFactory {
   private static String computeBaseUrl(
       String hostNameConfig,
       Integer portConfig,
-      List<String> advertisedListenersConfig,
-      List<String> listenersConfig,
+      List<URI> advertisedListenersConfig,
+      List<URI> listenersConfig,
       UriInfo requestUriInfo
   ) {
     String scheme = computeScheme(requestUriInfo);
@@ -89,28 +91,64 @@ final class UrlFactoryImpl implements UrlFactory {
   private static String computeAuthority(
       String hostNameConfig,
       Integer portConfig,
-      List<String> advertisedListenersConfig,
-      List<String> listenersConfig,
+      List<URI> advertisedListenersConfig,
+      List<URI> listenersConfig,
       UriInfo requestUriInfo) {
-    // Preferences are, in order:
-    // 1. listener.authority, where listener in advertisedListenersConfig and
-    //                        listener.scheme = request.scheme
-    // 2. listener.authority, where listener in listenersConfig and
-    //                        listener.scheme = request.scheme
-    // 3. hostNameConfig:portConfig
-    // 4. request.authority
+    return Stream.of(
+        computeAuthorityFromAdvertisedListeners(advertisedListenersConfig, requestUriInfo),
+        computeAuthorityFromHostNameAndPort(
+            hostNameConfig, portConfig, listenersConfig, requestUriInfo),
+        computeAuthorityFromListeners(listenersConfig, requestUriInfo))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst()
+        .orElse(requestUriInfo.getAbsolutePath().getAuthority());
+  }
+
+  private static Optional<String> computeAuthorityFromAdvertisedListeners(
+      List<URI> advertisedListenersConfig, UriInfo requestUriInfo) {
     String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
-    for (String listener : Iterables.concat(advertisedListenersConfig, listenersConfig)) {
-      int protocolSeparator = listener.indexOf("://");
-      String listenerScheme = listener.substring(0, protocolSeparator);
-      if (requestScheme.equals(listenerScheme)) {
-        return listener.substring(protocolSeparator + 3);
+    for (URI listener : advertisedListenersConfig) {
+      if (requestScheme.equals(listener.getScheme())) {
+        return Optional.of(listener.getAuthority());
       }
     }
-    if (hostNameConfig != null && !hostNameConfig.isEmpty() && portConfig != null) {
-      return String.format("%s:%s", hostNameConfig, portConfig);
+    return Optional.empty();
+  }
+
+  private static Optional<String> computeAuthorityFromHostNameAndPort(
+      String hostNameConfig,
+      Integer portConfig,
+      List<URI> listenersConfig,
+      UriInfo requestUriInfo
+  ) {
+    String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
+    if (hostNameConfig == null || hostNameConfig.isEmpty()) {
+      return Optional.empty();
     }
-    return requestUriInfo.getAbsolutePath().getAuthority();
+
+    int port = -1;
+    if (requestUriInfo.getAbsolutePath().getPort() != -1) {
+      port = portConfig;
+      for (URI listener : listenersConfig) {
+        if (requestScheme.equals(listener.getScheme())) {
+          port = listener.getPort();
+        }
+      }
+    }
+
+    return Optional.of(String.format("%s%s", hostNameConfig, port != -1 ? ":" + port : ""));
+  }
+
+  private static Optional<String> computeAuthorityFromListeners(
+      List<URI> listenersConfig, UriInfo requestUriInfo) {
+    String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
+    for (URI listener : listenersConfig) {
+      if (requestScheme.equals(listener.getScheme())) {
+        return Optional.of(listener.getAuthority());
+      }
+    }
+    return Optional.empty();
   }
 
   private static String computeBasePath(UriInfo requestUriInfo) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
@@ -66,8 +66,8 @@ public class UrlFactoryImplTest {
         new UrlFactoryImpl(
             /* hostNameConfig= */ "",
             /* portConfig= */ 0,
-            singletonList("http://advertised.listener:2000"),
-            singletonList("http://listener:3000"),
+            singletonList(URI.create("http://advertised.listener:2000")),
+            singletonList(URI.create("http://listener:3000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -88,8 +88,8 @@ public class UrlFactoryImplTest {
         new UrlFactoryImpl(
             /* hostNameConfig= */ "",
             /* portConfig= */ 0,
-            singletonList("https://advertised.listener:2000"),
-            singletonList("http://listener:3000"),
+            singletonList(URI.create("https://advertised.listener:2000")),
+            singletonList(URI.create("http://listener:3000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -109,7 +109,7 @@ public class UrlFactoryImplTest {
             /* hostNameConfig= */ "",
             /* portConfig= */ 0,
             /* advertisedListeners= */ emptyList(),
-            singletonList("http://listener:2000"),
+            singletonList(URI.create("http://listener:2000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -129,7 +129,7 @@ public class UrlFactoryImplTest {
             /* hostNameConfig= */ "",
             /* portConfig= */ 0,
             /* advertisedListeners= */ emptyList(),
-            singletonList("https://listener:2000"),
+            singletonList(URI.create("https://listener:2000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -188,7 +188,7 @@ public class UrlFactoryImplTest {
         new UrlFactoryImpl(
             "hostname",
             2000,
-            singletonList("http://advertised.listener:2000"),
+            singletonList(URI.create("http://advertised.listener:2000")),
             emptyList(),
             requestUriInfo);
 
@@ -209,12 +209,12 @@ public class UrlFactoryImplTest {
             "hostname",
             2000,
             emptyList(),
-            singletonList("http://listener:2000"),
+            singletonList(URI.create("http://listener:2000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
 
-    assertEquals("http://listener:2000/foo/bar", url);
+    assertEquals("http://hostname:2000/foo/bar", url);
   }
 
   @Test
@@ -228,8 +228,8 @@ public class UrlFactoryImplTest {
         new UrlFactoryImpl(
             "",
             0,
-            singletonList("http://advertised.listener:2000"),
-            singletonList("http://listener:2000"),
+            singletonList(URI.create("http://advertised.listener:2000")),
+            singletonList(URI.create("http://listener:2000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -248,8 +248,8 @@ public class UrlFactoryImplTest {
         new UrlFactoryImpl(
             "hostname",
             2000,
-            singletonList("http://advertised.listener:2000"),
-            singletonList("http://listener:2000"),
+            singletonList(URI.create("http://advertised.listener:2000")),
+            singletonList(URI.create("http://listener:2000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
@@ -23,12 +23,10 @@ import org.junit.Test;
 import java.net.URI;
 import java.util.Properties;
 
-import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.UriUtils;
-import io.confluent.rest.RestConfigException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,10 +42,10 @@ public class UriUtilsTest {
   @Test
   public void testAbsoluteURIBuilderDefaultHost()  {
     KafkaRestConfig config = new KafkaRestConfig();
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com"));
     EasyMock.replay(uriInfo);
-    assertEquals("http://foo.com", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("http://foo.com", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
@@ -56,11 +54,10 @@ public class UriUtilsTest {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com"));
     EasyMock.replay(uriInfo);
-    assertEquals("http://bar.net", UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("http://bar.net", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
@@ -70,12 +67,10 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.PORT_CONFIG, 5000);
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com:5000"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com:5000"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:5000"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:5000"));
     EasyMock.replay(uriInfo);
-    assertEquals("http://bar.net:5000",
-                 UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("http://bar.net:5000", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
@@ -85,12 +80,11 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http:||0.0.0.0:9091");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com:9091"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com:9091"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9091"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9091"));
     EasyMock.replay(uriInfo);
 
-    UriUtils.absoluteUriBuilder(config, uriInfo);
+    UriUtils.absoluteUri(config, uriInfo);
   }
 
   @Test
@@ -99,12 +93,10 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:9091,https://0.0.0.0:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com:9091"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com:9091"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9091"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9091"));
     EasyMock.replay(uriInfo);
-    assertEquals("http://bar.net:9091",
-        UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("http://bar.net:9091", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
@@ -114,12 +106,10 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:9091,https://0.0.0.0:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("https://foo.com:9092"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("https://foo.com:9092"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("https://foo.com:9092"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("https://foo.com:9092"));
     EasyMock.replay(uriInfo);
-    assertEquals("https://bar.net:9092",
-        UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("https://bar.net:9092", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
@@ -129,12 +119,10 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://[fe80:0:1:2:3:4:5:6]:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com:9092"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com:9092"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9092"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9092"));
     EasyMock.replay(uriInfo);
-    assertEquals("http://bar.net:9092",
-        UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("http://bar.net:9092", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
@@ -145,12 +133,10 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://[fe80::1]:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePathBuilder())
-        .andReturn(UriBuilder.fromUri("http://foo.com:9092"));
-    EasyMock.expect(uriInfo.getAbsolutePath()).andReturn(URI.create("http://foo.com:9092"));
+    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9092"));
+    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9092"));
     EasyMock.replay(uriInfo);
-    assertEquals("http://bar.net:9092",
-        UriUtils.absoluteUriBuilder(config, uriInfo).build().toString());
+    assertEquals("http://bar.net:9092", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 }


### PR DESCRIPTION
Config advertised.listeners was added in 6.0.0 to specify which base path to use when generation absolute URLs in V3 API responses. Consume V2 API has a similar mechanism, that uses the host.name and port configs. This PR unifies both mechanisms, so that the URLs generated in both V2 and V3 are based on the same base path.