### PR TITLE
KREST-200: Never user listeners for URL generation in V2 and V3.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
@@ -97,8 +97,7 @@ public final class UrlFactoryImpl implements UrlFactory {
     return Stream.of(
         computeAuthorityFromAdvertisedListeners(advertisedListenersConfig, requestUriInfo),
         computeAuthorityFromHostNameAndPort(
-            hostNameConfig, portConfig, listenersConfig, requestUriInfo),
-        computeAuthorityFromListeners(listenersConfig, requestUriInfo))
+            hostNameConfig, portConfig, listenersConfig, requestUriInfo))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .findFirst()
@@ -138,17 +137,6 @@ public final class UrlFactoryImpl implements UrlFactory {
     }
 
     return Optional.of(String.format("%s%s", hostNameConfig, port != -1 ? ":" + port : ""));
-  }
-
-  private static Optional<String> computeAuthorityFromListeners(
-      List<URI> listenersConfig, UriInfo requestUriInfo) {
-    String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
-    for (URI listener : listenersConfig) {
-      if (requestScheme.equals(listener.getScheme())) {
-        return Optional.of(listener.getAuthority());
-      }
-    }
-    return Optional.empty();
   }
 
   private static String computeBasePath(UriInfo requestUriInfo) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
@@ -77,7 +77,7 @@ public class UrlFactoryImplTest {
 
   @Test
   public void
-  create_withAdvertisedListenerDifferentSchemeAndListenerSameScheme_returnsUrlRelativeToListenerSameScheme
+  create_withAdvertisedListenerDifferentSchemeAndListenerSameScheme_returnsUrlRelativeToRequestUri
       () {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
@@ -94,11 +94,11 @@ public class UrlFactoryImplTest {
 
     String url = urlFactory.create("foo", "bar");
 
-    assertEquals("http://listener:3000/foo/bar", url);
+    assertEquals("http://1.2.3.4:1000/foo/bar", url);
   }
 
   @Test
-  public void create_withListenerSameScheme_returnsUrlRelativeToListenerSameScheme() {
+  public void create_withListenerSameScheme_returnsUrlRelativeToRequestUri() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
     expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
@@ -114,7 +114,7 @@ public class UrlFactoryImplTest {
 
     String url = urlFactory.create("foo", "bar");
 
-    assertEquals("http://listener:2000/foo/bar", url);
+    assertEquals("http://1.2.3.4:1000/foo/bar", url);
   }
 
   @Test


### PR DESCRIPTION
https://github.com/confluentinc/kafka-rest/pull/768 introduced a regression in V2 absolute URL generation, whereas before listeners was never used for generation, and now it takes precedence over request URI. This PR fixes the regression by never using listeners for URL generation (both for V2 and V3 APIs). Request URI is always a better guess then listeners, and people should be able to override it using advertised.listeners or host.name and port as before.