### PR TITLE
Allow translation of enum path params based on @JsonValue.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/extension/EnumConverterProvider.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/extension/EnumConverterProvider.java
@@ -17,12 +17,24 @@ package io.confluent.kafkarest.extension;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 
 public final class EnumConverterProvider implements ParamConverterProvider {
+
+  private static final Table<Class<?>, String, Enum<?>> enumMapper =
+      Tables.synchronizedTable(HashBasedTable.create());
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -31,7 +43,52 @@ public final class EnumConverterProvider implements ParamConverterProvider {
     if (!Enum.class.isAssignableFrom(rawType)) {
       return null;
     }
-    return (ParamConverter<T>) new EnumConverter<>((Class<Enum>) rawType);
+
+    ParamConverter<T> converter = (ParamConverter<T>) new EnumConverter<>((Class<Enum>) rawType);
+    if (enumMapper.containsRow(rawType)) {
+      return converter;
+    }
+
+    List<Method> jsonValueMethods =
+        Arrays.stream(rawType.getMethods())
+            .filter(method -> method.getAnnotation(JsonValue.class) != null)
+            .collect(Collectors.toList());
+
+    if (jsonValueMethods.size() > 1) {
+      throw new RuntimeException(
+          "Multiple methods annotated with @JsonValue in " + rawType.getName());
+    }
+
+    if (jsonValueMethods.isEmpty()) {
+      for (T constant : rawType.getEnumConstants()) {
+        Enum<?> casted = (Enum<?>) constant;
+        enumMapper.put(rawType, casted.name().toUpperCase(), casted);
+      }
+      return converter;
+    }
+
+    Method jsonValueMethod = jsonValueMethods.get(0);
+    for (T constant : rawType.getEnumConstants()) {
+      String returnedValue;
+      try {
+        returnedValue = (String) jsonValueMethod.invoke(constant);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(
+            String.format(
+                "@JsonValue annotated method in %s is not public.", rawType.getName()));
+      } catch (InvocationTargetException e) {
+        throw new RuntimeException(e);
+      } catch (ClassCastException e) {
+        throw new RuntimeException(
+            String.format(
+                "@JsonValue annotated method in %s does not return String.",
+                rawType.getName()));
+      }
+
+      enumMapper.put(rawType, returnedValue.toUpperCase(), (Enum<?>) constant);
+    }
+
+    return converter;
   }
 
   private static final class EnumConverter<T extends Enum<T>>
@@ -44,11 +101,18 @@ public final class EnumConverterProvider implements ParamConverterProvider {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public T fromString(String value) {
       if (value == null) {
         return null;
       }
-      return Enum.valueOf(enumClass, value.toUpperCase());
+
+      T cached = (T) enumMapper.get(enumClass, value.toUpperCase());
+      if (cached == null) {
+        throw new RuntimeException(
+            String.format("No constant in %s matched %s", enumClass.getName(), value));
+      }
+      return cached;
     }
 
     @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/extension/EnumConverterProviderTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/extension/EnumConverterProviderTest.java
@@ -1,0 +1,154 @@
+package io.confluent.kafkarest.extension;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.lang.annotation.Annotation;
+import javax.ws.rs.ext.ParamConverter;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EnumConverterProviderTest {
+
+  private final EnumConverterProvider converterProvider = new EnumConverterProvider();
+
+  @Test
+  public void enumWithNoJsonValueMatchesConstantName() {
+    ParamConverter<EnumWithNoJsonValue> converter =
+        converterProvider.getConverter(
+            EnumWithNoJsonValue.class, EnumWithNoJsonValue.class, new Annotation[0]);
+
+    assertNotNull(converter);
+    assertEquals(EnumWithNoJsonValue.FOO, converter.fromString("foo"));
+    assertEquals(EnumWithNoJsonValue.BAR, converter.fromString("BAR"));
+  }
+
+  @Test
+  public void enumWithSingleJsonValueMatchesOnJsonValue() {
+    ParamConverter<EnumWithSingleJsonValue> converter =
+        converterProvider.getConverter(
+            EnumWithSingleJsonValue.class, EnumWithSingleJsonValue.class, new Annotation[0]);
+
+    assertNotNull(converter);
+    assertEquals(EnumWithSingleJsonValue.FOO, converter.fromString("abc"));
+    assertEquals(EnumWithSingleJsonValue.BAR, converter.fromString("123"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void enumWithMultipleJsonValueThrowsException() {
+    converterProvider.getConverter(
+        EnumWithMultipleJsonValue.class, EnumWithMultipleJsonValue.class, new Annotation[0]);
+  }
+
+  // TODO(rigelbm): Figure out why we are able to call a private method in an enum class.
+  @Ignore
+  @Test(expected = RuntimeException.class)
+  public void enumWithPrivateJsonValueThrowsException() {
+    converterProvider.getConverter(
+        EnumWithPrivateJsonValue.class, EnumWithPrivateJsonValue.class, new Annotation[0]);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void enumWithNonStringJsonValueThrowsException() {
+    converterProvider.getConverter(
+        EnumWithNonStringJsonValue.class, EnumWithNonStringJsonValue.class, new Annotation[0]);
+  }
+
+  public enum EnumWithNoJsonValue {
+
+    FOO("abc"),
+
+    BAR("123");
+
+    private final String foobar;
+
+    EnumWithNoJsonValue(String foobar) {
+      this.foobar = foobar;
+    }
+
+    public String getFoobar() {
+      return foobar;
+    }
+  }
+
+  public enum EnumWithSingleJsonValue {
+
+    FOO("abc"),
+
+    BAR("123");
+
+    private final String foobar;
+
+    EnumWithSingleJsonValue(String foobar) {
+      this.foobar = foobar;
+    }
+
+    @JsonValue
+    public String getFoobar() {
+      return foobar;
+    }
+  }
+
+  public enum EnumWithMultipleJsonValue {
+
+    FOO("abc"),
+
+    BAR("123");
+
+    private final String foobar;
+
+    EnumWithMultipleJsonValue(String foobar) {
+      this.foobar = foobar;
+    }
+
+    @JsonValue
+    public String getFoobar() {
+      return foobar;
+    }
+
+    @JsonValue
+    public String getFozbaz() {
+      return foobar;
+    }
+  }
+
+  private enum EnumWithPrivateJsonValue {
+
+    FOO("abc"),
+
+    BAR("123");
+
+    private final String foobar;
+
+    EnumWithPrivateJsonValue(String foobar) {
+      this.foobar = foobar;
+    }
+
+    @JsonValue
+    private String getFoobar() {
+      return foobar;
+    }
+  }
+
+  public enum EnumWithNonStringJsonValue {
+
+    FOO("abc"),
+
+    BAR("123");
+
+    private final String foobar;
+
+    EnumWithNonStringJsonValue(String foobar) {
+      this.foobar = foobar;
+    }
+
+    @JsonValue
+    public int getFoobar() {
+      return foobar.length();
+    }
+  }
+}


### PR DESCRIPTION
Jackson has a nice feature which allows it to parse JSON values as enums based on a method annotated in the enum class with `@JsonValue`. Currently we only support parsing enums from path params via name (case-insensitive) matching. This PR extends the parsing logic to also parse based on `@JsonValue` annotated method, if one is available in the class.