### PR TITLE
KREST-360: Start brokers concurrently in ClusterTestHarness

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -40,7 +40,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -60,7 +59,6 @@ import kafka.zk.KafkaZkClient;
 import kafka.zookeeper.ZooKeeperClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitionReassignment;
@@ -239,6 +237,7 @@ public abstract class ClusterTestHarness {
   private void startBrokersConcurrently(int numBrokers, Duration timeout) throws Exception {
     List<Future<KafkaServer>> serverFutures = new ArrayList<>(numBrokers);
     configs = new Vector<>();
+    servers = new Vector<>();
     ExecutorService executorService = Executors.newFixedThreadPool(numBrokers);
     try {
       for (int i = 0; i < numBrokers; i++) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -14,6 +14,7 @@
  */
 package io.confluent.kafkarest.integration;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 
 import io.confluent.common.utils.IntegrationTest;
@@ -24,6 +25,7 @@ import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.KafkaJsonSerializer;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.ProducerPool;
+import io.confluent.kafkarest.common.CompletableFutures;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -39,12 +41,14 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Invocation;
@@ -121,7 +125,6 @@ public abstract class ClusterTestHarness {
 
   private int numBrokers;
   private boolean withSchemaRegistry;
-
   // ZK Config
   protected String zkConnect;
   protected EmbeddedZookeeper zookeeper;
@@ -182,7 +185,7 @@ public abstract class ClusterTestHarness {
         time);
 
     // start brokers concurrently
-    startBrokersConcurrently(numBrokers, Duration.ofSeconds(60));
+    startBrokersConcurrently(numBrokers);
 
     brokerList =
         TestUtils.getBrokerListStrFromServers(JavaConverters.asScalaBuffer(servers),
@@ -234,39 +237,23 @@ public abstract class ClusterTestHarness {
     restServer.start();
   }
 
-  private void startBrokersConcurrently(int numBrokers, Duration timeout) throws Exception {
-    List<Future<KafkaServer>> serverFutures = new ArrayList<>(numBrokers);
-    configs = new Vector<>();
-    servers = new Vector<>();
-    ExecutorService executorService = Executors.newFixedThreadPool(numBrokers);
-    try {
-      for (int i = 0; i < numBrokers; i++) {
-        Properties props = getBrokerProperties(i);
-        serverFutures.add(executorService.submit(() -> {
-          KafkaConfig config = KafkaConfig.fromProps(props);
-          configs.add(config);
-          return TestUtils.createServer(config, new MockTime(System.currentTimeMillis(), System.nanoTime()));
-        }));
-      }
-
-      // Store the first server startup failure and throw the exception after going over all the
-      // kafka servers.
-      AtomicReference<Exception> serverStartupFailure = new AtomicReference<>();
-      for (Future<KafkaServer> futureServer : serverFutures) {
-        try {
-          KafkaServer server = futureServer.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-          servers.add(server);
-        } catch (Exception e) {
-          serverStartupFailure.compareAndSet(null, e);
-        }
-      }
-      if (serverStartupFailure.get() != null) {
-        throw serverStartupFailure.get();
-      }
-    } finally {
-      executorService.shutdownNow();
-      executorService.awaitTermination(30, TimeUnit.SECONDS);
-    }
+  private void startBrokersConcurrently(int numBrokers) {
+    configs =
+        IntStream.range(0, numBrokers)
+            .mapToObj(brokerId -> KafkaConfig.fromProps(getBrokerProperties(brokerId)))
+            .collect(toList());
+    servers =
+        CompletableFutures.allAsList(
+            configs.stream()
+                .map(
+                    config ->
+                        CompletableFuture.supplyAsync(
+                            () -> TestUtils.createServer(
+                                config,
+                                new MockTime(System.currentTimeMillis(),
+                                    System.nanoTime()))))
+                            .collect(toList()))
+                .join();
   }
 
   protected void setupAcls() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,14 +39,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -240,7 +233,8 @@ public abstract class ClusterTestHarness {
   private void startBrokersConcurrently(int numBrokers) {
     configs =
         IntStream.range(0, numBrokers)
-            .mapToObj(brokerId -> KafkaConfig.fromProps(getBrokerProperties(brokerId)))
+            .mapToObj(brokerId -> KafkaConfig.fromProps(
+                overrideBrokerProperties(brokerId, getBrokerProperties(brokerId))))
             .collect(toList());
     servers =
         CompletableFutures.allAsList(
@@ -252,8 +246,8 @@ public abstract class ClusterTestHarness {
                                 config,
                                 new MockTime(System.currentTimeMillis(),
                                     System.nanoTime()))))
-                            .collect(toList()))
-                .join();
+                .collect(toList()))
+            .join();
   }
 
   protected void setupAcls() {


### PR DESCRIPTION
### What
The integration tests in kafka rest use ClusterTestHarness that has set up to bring up the services. This PR concerns modifying the way kafka servers are set up. Currently, the brokers are started sequentially which is a drawback to have topics with replication_factor > 1. This PR works on concurrently starting brokers.

### Testing
Making sure all tests pass.

### References
Jira - https://confluentinc.atlassian.net/browse/KREST-360