### PR TITLE
KREST-456 Add API for creating a topic with custom partition-to-replicas assignments

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1501,16 +1501,16 @@ components:
               value:
                 topic_name: 'topic-Y'
                 replicas_assignments:
-                  - partition: 0
-                    replicas:
+                  - partition_id: 0
+                    broker_ids:
                       - 1
                       - 2
-                  - partition: 1
-                    replicas:
+                  - partition_id: 1
+                    broker_ids:
                       - 2
                       - 3
-                  - partition: 2
-                    replicas:
+                  - partition_id: 2
+                    broker_ids:
                       - 3
                       - 1
                 configs:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1011,8 +1011,6 @@ components:
       type: object
       required:
         - topic_name
-        - partitions_count
-        - replication_factor
       properties:
         topic_name:
           type: string
@@ -1020,6 +1018,20 @@ components:
           type: integer
         replication_factor:
           type: integer
+        replicas_assignments:
+          type: array
+          items:
+            type: object
+            required:
+              - partition
+              - replicas
+            properties:
+              partition:
+                type: integer
+              replicas:
+                type: array
+                items:
+                  type: integer
         configs:
           type: array
           items:
@@ -1474,15 +1486,38 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateTopicRequestData'
-          example:
-            topic_name: 'topic-X'
-            partitions_count: 64
-            replication_factor: 3
-            configs:
-              - name: 'cleanup.policy'
-                value: 'compact'
-              - name: 'compression.type'
-                value: 'gzip'
+          examples:
+            uniform_replication:
+              value:
+                topic_name: 'topic-X'
+                partitions_count: 64
+                replication_factor: 3
+                configs:
+                  - name: 'cleanup.policy'
+                    value: 'compact'
+                  - name: 'compression.type'
+                    value: 'gzip'
+            explicit_replicas_assignments:
+              value:
+                topic_name: 'topic-Y'
+                replicas_assignments:
+                  - partition: 0
+                    replicas:
+                      - 1
+                      - 2
+                  - partition: 1
+                    replicas:
+                      - 2
+                      - 3
+                  - partition: 2
+                    replicas:
+                      - 3
+                      - 1
+                configs:
+                  - name: 'cleanup.policy'
+                    value: 'compact'
+                  - name: 'compression.type'
+                    value: 'gzip'
 
     UpdateBrokerConfigRequest:
       description: 'The broker configuration parameter update request.'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1023,12 +1023,12 @@ components:
           items:
             type: object
             required:
-              - partition
-              - replicas
+              - partition_id
+              - broker_ids
             properties:
-              partition:
+              partition_id:
                 type: integer
-              replicas:
+              broker_ids:
                 type: array
                 items:
                   type: integer

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
-        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
 
@@ -35,12 +35,15 @@
             checks="(NPathComplexity)"
             files="(SchemaRestProducer|ConsumerInstanceConfig|ConsumerManager|KafkaConsumerManager|PartitionOffset|KafkaRestContextProvider).java"
     />
+
     <suppress
             checks="(MethodLength)"
             files="(KafkaRestConfig).java"
     />
+
     <suppress
             checks="(ParameterNumber)"
             files="(ClusterData).java"
     />
+
 </suppressions>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 
 /**
  * A service to manage Kafka {@link Topic Topics}.
@@ -51,13 +52,15 @@ public interface TopicManager {
   CompletableFuture<Optional<Topic>> getLocalTopic(String topicName);
 
   /**
-   * Creates a new Kafka {@link Topic}.
+   * Creates a new Kafka {@link Topic} with either partitions count and replication factor
+   * or explicitly specified partition-to-replicas assignments.
    */
   CompletableFuture<Void> createTopic(
       String clusterId,
       String topicName,
       Optional<Integer> partitionsCount,
       Optional<Short> replicationFactor,
+      @Nullable Map<Integer, List<Integer>> replicasAssignments,
       Map<String, Optional<String>> configs);
 
   /**

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nullable;
 
 /**
  * A service to manage Kafka {@link Topic Topics}.
@@ -60,7 +59,7 @@ public interface TopicManager {
       String topicName,
       Optional<Integer> partitionsCount,
       Optional<Short> replicationFactor,
-      @Nullable Map<Integer, List<Integer>> replicasAssignments,
+      Map<Integer, List<Integer>> replicasAssignments,
       Map<String, Optional<String>> configs);
 
   /**

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -174,7 +173,7 @@ final class TopicManagerImpl implements TopicManager {
       String topicName,
       Optional<Integer> partitionsCount,
       Optional<Short> replicationFactor,
-      @Nullable Map<Integer, List<Integer>> replicasAssignments,
+      Map<Integer, List<Integer>> replicasAssignments,
       Map<String, Optional<String>> configs) {
     requireNonNull(topicName);
 
@@ -183,7 +182,7 @@ final class TopicManagerImpl implements TopicManager {
 
     // A new topic can be created with either uniform replication according to the given partitions
     // count and replication factor, or explicitly specified partition-to-replicas assignments.
-    NewTopic createTopicRequest = replicasAssignments == null
+    NewTopic createTopicRequest = replicasAssignments.isEmpty()
         ? new NewTopic(topicName, partitionsCount, replicationFactor).configs(nullableConfigs)
         : new NewTopic(topicName, replicasAssignments).configs(nullableConfigs);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -181,8 +181,11 @@ final class TopicManagerImpl implements TopicManager {
     Map<String, String> nullableConfigs = new HashMap<>();
     configs.forEach((key, value) -> nullableConfigs.put(key, value.orElse(null)));
 
-    NewTopic createTopicRequest =
-        new NewTopic(topicName, partitionsCount, replicationFactor).configs(nullableConfigs);
+    // A new topic can be created with either uniform replication according to the given partitions
+    // count and replication factor, or explicitly specified partition-to-replicas assignments.
+    NewTopic createTopicRequest = replicasAssignments == null
+        ? new NewTopic(topicName, partitionsCount, replicationFactor).configs(nullableConfigs)
+        : new NewTopic(topicName, replicasAssignments).configs(nullableConfigs);
 
     return clusterManager.getCluster(clusterId)
         .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -173,6 +174,7 @@ final class TopicManagerImpl implements TopicManager {
       String topicName,
       Optional<Integer> partitionsCount,
       Optional<Short> replicationFactor,
+      @Nullable Map<Integer, List<Integer>> replicasAssignments,
       Map<String, Optional<String>> configs) {
     requireNonNull(topicName);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -83,8 +82,7 @@ public abstract class CreateTopicRequest {
 
     public abstract Builder setReplicationFactor(@Nullable Short replicationFactor);
 
-    public abstract Builder setReplicasAssignments(
-        @Nonnull Map<Integer, List<Integer>> replicasAssignments);
+    public abstract Builder setReplicasAssignments(Map<Integer, List<Integer>> replicasAssignments);
 
     public abstract Builder setConfigs(List<ConfigEntry> configs);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -40,14 +42,14 @@ public abstract class CreateTopicRequest {
   public abstract Optional<Short> getReplicationFactor();
 
   @JsonProperty("replicas_assignments")
-  @Nullable
   public abstract Map<Integer, List<Integer>> getReplicasAssignments();
 
   @JsonProperty("configs")
   public abstract ImmutableList<ConfigEntry> getConfigs();
 
   public static Builder builder() {
-    return new AutoValue_CreateTopicRequest.Builder();
+    return new AutoValue_CreateTopicRequest.Builder()
+        .setReplicasAssignments(Collections.emptyMap());
   }
 
   @JsonCreator
@@ -55,15 +57,16 @@ public abstract class CreateTopicRequest {
       @JsonProperty("topic_name") String topicName,
       @JsonProperty("partitions_count") @Nullable Integer partitionsCount,
       @JsonProperty("replication_factor") @Nullable Short replicationFactor,
-      @SuppressWarnings("checkstyle:LineLength")
-      @JsonProperty("replicas_assignments") @Nullable Map<Integer, List<Integer>> replicasAssignments,
+      @JsonProperty("replicas_assignments") @Nullable
+          Map<Integer, List<Integer>> replicasAssignments,
       @JsonProperty("configs") @Nullable List<ConfigEntry> configs
   ) {
     return builder()
         .setTopicName(topicName)
         .setPartitionsCount(partitionsCount)
         .setReplicationFactor(replicationFactor)
-        .setReplicasAssignments(replicasAssignments)
+        .setReplicasAssignments(
+            replicasAssignments != null ? replicasAssignments : Collections.emptyMap())
         .setConfigs(configs != null ? configs : ImmutableList.of())
         .build();
   }
@@ -80,8 +83,8 @@ public abstract class CreateTopicRequest {
 
     public abstract Builder setReplicationFactor(@Nullable Short replicationFactor);
 
-    @SuppressWarnings("checkstyle:LineLength")
-    public abstract Builder setReplicasAssignments(@Nullable Map<Integer, List<Integer>> replicasAssignments);
+    public abstract Builder setReplicasAssignments(
+        @Nonnull Map<Integer, List<Integer>> replicasAssignments);
 
     public abstract Builder setConfigs(List<ConfigEntry> configs);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -38,6 +39,10 @@ public abstract class CreateTopicRequest {
   @JsonProperty("replication_factor")
   public abstract Optional<Short> getReplicationFactor();
 
+  @JsonProperty("replicas_assignments")
+  @Nullable
+  public abstract Map<Integer, List<Integer>> getReplicasAssignments();
+
   @JsonProperty("configs")
   public abstract ImmutableList<ConfigEntry> getConfigs();
 
@@ -48,14 +53,17 @@ public abstract class CreateTopicRequest {
   @JsonCreator
   static CreateTopicRequest fromJson(
       @JsonProperty("topic_name") String topicName,
-      @JsonProperty("partitions_count") @Nullable  Integer partitionsCount,
+      @JsonProperty("partitions_count") @Nullable Integer partitionsCount,
       @JsonProperty("replication_factor") @Nullable Short replicationFactor,
+      @SuppressWarnings("checkstyle:LineLength")
+      @JsonProperty("replicas_assignments") @Nullable Map<Integer, List<Integer>> replicasAssignments,
       @JsonProperty("configs") @Nullable List<ConfigEntry> configs
   ) {
     return builder()
         .setTopicName(topicName)
         .setPartitionsCount(partitionsCount)
         .setReplicationFactor(replicationFactor)
+        .setReplicasAssignments(replicasAssignments)
         .setConfigs(configs != null ? configs : ImmutableList.of())
         .build();
   }
@@ -71,6 +79,9 @@ public abstract class CreateTopicRequest {
     public abstract Builder setPartitionsCount(@Nullable Integer partitionsCount);
 
     public abstract Builder setReplicationFactor(@Nullable Short replicationFactor);
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public abstract Builder setReplicasAssignments(@Nullable Map<Integer, List<Integer>> replicasAssignments);
 
     public abstract Builder setConfigs(List<ConfigEntry> configs);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -147,7 +147,7 @@ public final class TopicsResource {
     // We have no way of knowing the default replication factor in the Kafka broker. Also in case
     // of explicitly specified partition-to-replicas assignments, all partitions should have the
     // same number of replicas.
-    final short assumedReplicationFactor = replicationFactor.orElse(
+    short assumedReplicationFactor = replicationFactor.orElse(
         replicasAssignments.isEmpty()
             ? 0
             : (short) replicasAssignments.values().iterator().next().size());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -154,7 +154,7 @@ public final class TopicsResource {
 
     CompletableFuture<CreateTopicResponse> response =
         topicManager.get()
-            .createTopic(clusterId, topicName, partitionsCount, replicationFactor, configs)
+            .createTopic(clusterId, topicName, partitionsCount, replicationFactor, null, configs)
             .thenApply(none -> CreateTopicResponse.create(topicData));
 
     AsyncResponseBuilder.from(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -144,20 +144,21 @@ public final class TopicsResource {
             .stream()
             .collect(Collectors.toMap(ConfigEntry::getName, ConfigEntry::getValue));
 
-    // We have no way of knowing the default replication factor in the Kafka broker.
-    short rf = replicationFactor.orElse((short) 0);
-    if (replicasAssignments != null) {
-      // In case of explicitly specified partition-to-replicas assignments, all partitions should
-      // have the same number of replicas.
-      rf = (short) replicasAssignments.values().iterator().next().size();
-    }
+    // We have no way of knowing the default replication factor in the Kafka broker. Also in case
+    // of explicitly specified partition-to-replicas assignments, all partitions should have the
+    // same number of replicas.
+    final short assumedReplicationFactor = replicationFactor.orElse(
+        replicasAssignments.isEmpty()
+            ? 0
+            : (short) replicasAssignments.values().iterator().next().size());
+
     TopicData topicData =
         toTopicData(
             Topic.create(
                 clusterId,
                 topicName,
                 /* partitions= */ emptyList(),
-                rf,
+                assumedReplicationFactor,
                 /* isInternal= */ false));
 
     CompletableFuture<CreateTopicResponse> response =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -27,11 +27,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.Cluster;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -557,6 +560,7 @@ public class TopicManagerImplTest {
         TOPIC_1.getName(),
         Optional.of(TOPIC_1.getPartitions().size()),
         Optional.of(TOPIC_1.getReplicationFactor()),
+        /* replicasAssignments= */ null,
         singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
@@ -582,6 +586,7 @@ public class TopicManagerImplTest {
         TOPIC_1.getName(),
         /* partitionsCount= */ Optional.empty(),
         Optional.of(TOPIC_1.getReplicationFactor()),
+        /* replicasAssignments= */ null,
         singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
@@ -608,6 +613,43 @@ public class TopicManagerImplTest {
         TOPIC_1.getName(),
         Optional.of(TOPIC_1.getPartitions().size()),
         /* replicationFactor= */ Optional.empty(),
+        /* replicasAssignments= */ null,
+        singletonMap("cleanup.policy", Optional.of("compact"))).get();
+
+    verify(adminClient);
+  }
+
+  @Test
+  public void createTopic_nonExistingTopic_customReplicasAssignments_createsTopic()
+      throws Exception {
+    List<Integer> allReplicas = new ArrayList<>();
+    for (int replicaId = 1; replicaId <= TOPIC_1.getReplicationFactor(); replicaId++) {
+      allReplicas.add(replicaId);
+    }
+    ImmutableMap.Builder<Integer, List<Integer>> builder = new Builder<>();
+    for (int partitionId = 0; partitionId < TOPIC_1.getPartitions().size(); partitionId++) {
+      List<Integer> replicas = new ArrayList<>(allReplicas);
+      replicas.remove(partitionId % replicas.size());
+      builder.put(partitionId, replicas);
+    }
+    Map<Integer, List<Integer>> replicasAssignments = builder.build();
+
+    expect(clusterManager.getCluster(CLUSTER_ID)).andReturn(completedFuture(Optional.of(CLUSTER)));
+    expect(
+        adminClient.createTopics(
+            singletonList(
+                new NewTopic(TOPIC_1.getName(), replicasAssignments)
+                    .configs(singletonMap("cleanup.policy", "compact")))))
+        .andReturn(createTopicsResult);
+    expect(createTopicsResult.all()).andReturn(KafkaFuture.completedFuture(null));
+    replay(clusterManager, adminClient, createTopicsResult);
+
+    topicManager.createTopic(
+        CLUSTER_ID,
+        TOPIC_1.getName(),
+        /* partitionsCount= */ Optional.empty(),
+        /* replicationFactor= */ Optional.empty(),
+        replicasAssignments,
         singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
@@ -634,6 +676,7 @@ public class TopicManagerImplTest {
           TOPIC_1.getName(),
           Optional.of(TOPIC_1.getPartitions().size()),
           Optional.of(TOPIC_1.getReplicationFactor()),
+          /* replicasAssignments= */ null,
           singletonMap("cleanup.policy", Optional.of("compact"))).get();
       fail();
     } catch (ExecutionException e) {
@@ -654,6 +697,7 @@ public class TopicManagerImplTest {
           TOPIC_1.getName(),
           Optional.of(TOPIC_1.getPartitions().size()),
           Optional.of(TOPIC_1.getReplicationFactor()),
+          /* replicasAssignments= */ null,
           singletonMap("cleanup.policy", Optional.of("compact"))).get();
       fail();
     } catch (ExecutionException e) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -36,6 +36,7 @@ import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -560,7 +561,7 @@ public class TopicManagerImplTest {
         TOPIC_1.getName(),
         Optional.of(TOPIC_1.getPartitions().size()),
         Optional.of(TOPIC_1.getReplicationFactor()),
-        /* replicasAssignments= */ null,
+        /* replicasAssignments= */ Collections.emptyMap(),
         singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
@@ -586,7 +587,7 @@ public class TopicManagerImplTest {
         TOPIC_1.getName(),
         /* partitionsCount= */ Optional.empty(),
         Optional.of(TOPIC_1.getReplicationFactor()),
-        /* replicasAssignments= */ null,
+        /* replicasAssignments= */ Collections.emptyMap(),
         singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
@@ -613,7 +614,7 @@ public class TopicManagerImplTest {
         TOPIC_1.getName(),
         Optional.of(TOPIC_1.getPartitions().size()),
         /* replicationFactor= */ Optional.empty(),
-        /* replicasAssignments= */ null,
+        /* replicasAssignments= */ Collections.emptyMap(),
         singletonMap("cleanup.policy", Optional.of("compact"))).get();
 
     verify(adminClient);
@@ -676,7 +677,7 @@ public class TopicManagerImplTest {
           TOPIC_1.getName(),
           Optional.of(TOPIC_1.getPartitions().size()),
           Optional.of(TOPIC_1.getReplicationFactor()),
-          /* replicasAssignments= */ null,
+          /* replicasAssignments= */ Collections.emptyMap(),
           singletonMap("cleanup.policy", Optional.of("compact"))).get();
       fail();
     } catch (ExecutionException e) {
@@ -697,7 +698,7 @@ public class TopicManagerImplTest {
           TOPIC_1.getName(),
           Optional.of(TOPIC_1.getPartitions().size()),
           Optional.of(TOPIC_1.getReplicationFactor()),
-          /* replicasAssignments= */ null,
+          /* replicasAssignments= */ Collections.emptyMap(),
           singletonMap("cleanup.policy", Optional.of("compact"))).get();
       fail();
     } catch (ExecutionException e) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -318,6 +318,60 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
+  public void createTopic_nonExistingTopic_customReplicasAssignments_returnsCreatedTopic() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+    String topicName = "topic-4";
+
+    CreateTopicResponse expected =
+        CreateTopicResponse.create(
+            TopicData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/topics/" + topicName)
+                        .setResourceName("crn:///kafka=" + clusterId + "/topic=" + topicName)
+                        .build())
+                .setClusterId(clusterId)
+                .setTopicName(topicName)
+                .setInternal(false)
+                .setReplicationFactor(2) // As determined by the actual replicas asignments below.
+                .setPartitions(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/partitions"))
+                .setConfigs(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/configs"))
+                .setPartitionReassignments(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/" + clusterId
+                            + "/topics/" + topicName
+                            + "/partitions/-/reassignment"))
+                .build());
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(
+                Entity.entity(
+                    "{\"topic_name\":\"" + topicName
+                        + "\",\"replicas_assignments\":{\"0\":[1,2], \"1\":[2,3], \"2\":[3,1]}}",
+                    MediaType.APPLICATION_JSON));
+    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+
+    CreateTopicResponse actual = response.readEntity(CreateTopicResponse.class);
+    assertEquals(expected, actual);
+
+    assertTrue(getTopicNames().contains(topicName));
+  }
+
+  @Test
   public void createTopic_existingTopic_returnsBadRequest() {
     String clusterId = getClusterId();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -44,6 +44,7 @@ import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -463,7 +464,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             Optional.of(TOPIC_1.getReplicationFactor()),
-            /* replicasAssignments= */ null,
+            /* replicasAssignments= */ Collections.emptyMap(),
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(completedFuture(null));
     replay(topicManager);
@@ -494,7 +495,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             /* partitionsCount= */ Optional.empty(),
             Optional.of(TOPIC_1.getReplicationFactor()),
-            /* replicasAssignments= */ null,
+            /* replicasAssignments= */ Collections.emptyMap(),
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(completedFuture(null));
     replay(topicManager);
@@ -524,7 +525,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             /* replicationFactor= */ Optional.empty(),
-            /* replicasAssignments= */ null,
+            /* replicasAssignments= */ Collections.emptyMap(),
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(completedFuture(null));
     replay(topicManager);
@@ -597,7 +598,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             Optional.of(TOPIC_1.getReplicationFactor()),
-            /* replicasAssignments= */ null,
+            /* replicasAssignments= */ Collections.emptyMap(),
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(failedFuture(new TopicExistsException("")));
     replay(topicManager);
@@ -625,7 +626,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             Optional.of(TOPIC_1.getReplicationFactor()),
-            /* replicasAssignments= */ null,
+            /* replicasAssignments= */ Collections.emptyMap(),
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(failedFuture(new NotFoundException()));
     replay(topicManager);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -325,6 +325,33 @@ public class TopicsResourceTest {
 
   private TopicsResource topicsResource;
 
+  private static TopicData newTopicData(
+      String topicName,
+      boolean isInternal,
+      int replicationFactor) {
+    return TopicData.builder()
+        .setMetadata(
+            Resource.Metadata.builder()
+                .setSelf(String.format("/v3/clusters/cluster-1/topics/%s", topicName))
+                .setResourceName(String.format("crn:///kafka=cluster-1/topic=%s", topicName))
+                .build())
+        .setClusterId("cluster-1")
+        .setTopicName(topicName)
+        .setInternal(isInternal)
+        .setReplicationFactor(replicationFactor)
+        .setPartitions(
+            Resource.Relationship.create(
+                String.format("/v3/clusters/cluster-1/topics/%s/partitions", topicName)))
+        .setConfigs(
+            Resource.Relationship.create(
+                String.format("/v3/clusters/cluster-1/topics/%s/configs", topicName)))
+        .setPartitionReassignments(
+            Resource.Relationship.create(
+                String.format("/v3/clusters/cluster-1/topics/%s/partitions/-/reassignment",
+                    topicName)))
+        .build();
+  }
+
   @Before
   public void setUp() {
     topicsResource =
@@ -352,69 +379,9 @@ public class TopicsResourceTest {
                         .build())
                 .setData(
                     Arrays.asList(
-                        TopicData.builder()
-                            .setMetadata(
-                                Resource.Metadata.builder()
-                                    .setSelf("/v3/clusters/cluster-1/topics/topic-1")
-                                    .setResourceName("crn:///kafka=cluster-1/topic=topic-1")
-                                    .build())
-                            .setClusterId("cluster-1")
-                            .setTopicName("topic-1")
-                            .setInternal(true)
-                            .setReplicationFactor(3)
-                            .setPartitions(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-1/partitions"))
-                            .setConfigs(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                            .setPartitionReassignments(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-1/partitions"
-                                        + "/-/reassignment"))
-                            .build(),
-                        TopicData.builder()
-                            .setMetadata(
-                                Resource.Metadata.builder()
-                                    .setSelf("/v3/clusters/cluster-1/topics/topic-2")
-                                    .setResourceName("crn:///kafka=cluster-1/topic=topic-2")
-                                    .build())
-                            .setClusterId("cluster-1")
-                            .setTopicName("topic-2")
-                            .setInternal(true)
-                            .setReplicationFactor(3)
-                            .setPartitions(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-2/partitions"))
-                            .setConfigs(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-2/configs"))
-                            .setPartitionReassignments(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-2/partitions"
-                                        + "/-/reassignment"))
-                            .build(),
-                        TopicData.builder()
-                            .setMetadata(
-                                Resource.Metadata.builder()
-                                    .setSelf("/v3/clusters/cluster-1/topics/topic-3")
-                                    .setResourceName("crn:///kafka=cluster-1/topic=topic-3")
-                                    .build())
-                            .setClusterId("cluster-1")
-                            .setTopicName("topic-3")
-                            .setInternal(false)
-                            .setReplicationFactor(3)
-                            .setPartitions(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-3/partitions"))
-                            .setConfigs(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-3/configs"))
-                            .setPartitionReassignments(
-                                Resource.Relationship.create(
-                                    "/v3/clusters/cluster-1/topics/topic-3/partitions"
-                                        + "/-/reassignment"))
-                            .build()))
+                        newTopicData("topic-1", true, 3),
+                        newTopicData("topic-2", true, 3),
+                        newTopicData("topic-3", false, 3)))
                 .build());
 
     assertEquals(expected, response.getValue());
@@ -454,27 +421,7 @@ public class TopicsResourceTest {
     topicsResource.getTopic(response, TOPIC_1.getClusterId(), TOPIC_1.getName());
 
     GetTopicResponse expected =
-        GetTopicResponse.create(
-            TopicData.builder()
-                .setMetadata(
-                    Resource.Metadata.builder()
-                        .setSelf("/v3/clusters/cluster-1/topics/topic-1")
-                        .setResourceName("crn:///kafka=cluster-1/topic=topic-1")
-                        .build())
-                .setClusterId("cluster-1")
-                .setTopicName("topic-1")
-                .setInternal(true)
-                .setReplicationFactor(3)
-                .setPartitions(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions"))
-                .setConfigs(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                .setPartitionReassignments(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
-                .build());
+        GetTopicResponse.create(newTopicData("topic-1", true, 3));
 
     assertEquals(expected, response.getValue());
   }
@@ -528,27 +475,7 @@ public class TopicsResourceTest {
             .build());
 
     CreateTopicResponse expected =
-        CreateTopicResponse.create(
-            TopicData.builder()
-                .setMetadata(
-                    Resource.Metadata.builder()
-                        .setSelf("/v3/clusters/cluster-1/topics/topic-1")
-                        .setResourceName("crn:///kafka=cluster-1/topic=topic-1")
-                        .build())
-                .setClusterId("cluster-1")
-                .setTopicName("topic-1")
-                .setInternal(false)
-                .setReplicationFactor(3)
-                .setPartitions(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions"))
-                .setConfigs(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                .setPartitionReassignments(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
-                .build());
+        CreateTopicResponse.create(newTopicData("topic-1", false, 3));
 
     assertEquals(expected, response.getValue());
   }
@@ -577,27 +504,7 @@ public class TopicsResourceTest {
             .build());
 
     CreateTopicResponse expected =
-        CreateTopicResponse.create(
-            TopicData.builder()
-                .setMetadata(
-                    Resource.Metadata.builder()
-                        .setSelf("/v3/clusters/cluster-1/topics/topic-1")
-                        .setResourceName("crn:///kafka=cluster-1/topic=topic-1")
-                        .build())
-                .setClusterId("cluster-1")
-                .setTopicName("topic-1")
-                .setInternal(false)
-                .setReplicationFactor(3)
-                .setPartitions(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions"))
-                .setConfigs(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                .setPartitionReassignments(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
-                .build());
+        CreateTopicResponse.create(newTopicData("topic-1", false, 3));
 
     assertEquals(expected, response.getValue());
   }
@@ -626,27 +533,7 @@ public class TopicsResourceTest {
             .build());
 
     CreateTopicResponse expected =
-        CreateTopicResponse.create(
-            TopicData.builder()
-                .setMetadata(
-                    Resource.Metadata.builder()
-                        .setSelf("/v3/clusters/cluster-1/topics/topic-1")
-                        .setResourceName("crn:///kafka=cluster-1/topic=topic-1")
-                        .build())
-                .setClusterId("cluster-1")
-                .setTopicName("topic-1")
-                .setInternal(false)
-                .setReplicationFactor(0)
-                .setPartitions(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions"))
-                .setConfigs(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/configs"))
-                .setPartitionReassignments(
-                    Resource.Relationship.create(
-                        "/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignment"))
-                .build());
+        CreateTopicResponse.create(newTopicData("topic-1", false, 0));
 
     assertEquals(expected, response.getValue());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -577,12 +577,14 @@ public class TopicsResourceTest {
         TOPIC_1.getClusterId(),
         CreateTopicRequest.builder()
             .setTopicName(TOPIC_1.getName())
+            .setReplicasAssignments(replicasAssignments)
             .setConfigs(
                 singletonList(CreateTopicRequest.ConfigEntry.create("cleanup.policy", "compact")))
             .build());
 
+    short expectedRf = (short) (TOPIC_1.getReplicationFactor() - 1);
     CreateTopicResponse expected =
-        CreateTopicResponse.create(newTopicData("topic-1", false, 0));
+        CreateTopicResponse.create(newTopicData("topic-1", false, expectedRf));
 
     assertEquals(expected, response.getValue());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import io.confluent.kafkarest.controllers.TopicManager;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
@@ -40,7 +42,10 @@ import io.confluent.kafkarest.entities.v3.TopicDataList;
 import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import javax.ws.rs.NotFoundException;
@@ -458,6 +463,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             Optional.of(TOPIC_1.getReplicationFactor()),
+            /* replicasAssignments= */ null,
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(completedFuture(null));
     replay(topicManager);
@@ -488,6 +494,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             /* partitionsCount= */ Optional.empty(),
             Optional.of(TOPIC_1.getReplicationFactor()),
+            /* replicasAssignments= */ null,
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(completedFuture(null));
     replay(topicManager);
@@ -517,6 +524,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             /* replicationFactor= */ Optional.empty(),
+            /* replicasAssignments= */ null,
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(completedFuture(null));
     replay(topicManager);
@@ -539,6 +547,47 @@ public class TopicsResourceTest {
   }
 
   @Test
+  public void createTopic_nonExistingTopic_customReplicasAssignments_createsTopic() {
+    List<Integer> allReplicas = new ArrayList<>();
+    for (int replicaId = 1; replicaId <= TOPIC_1.getReplicationFactor(); replicaId++) {
+      allReplicas.add(replicaId);
+    }
+    ImmutableMap.Builder<Integer, List<Integer>> builder = new Builder<>();
+    for (int partitionId = 0; partitionId < TOPIC_1.getPartitions().size(); partitionId++) {
+      List<Integer> replicas = new ArrayList<>(allReplicas);
+      replicas.remove(partitionId % replicas.size());
+      builder.put(partitionId, replicas);
+    }
+    Map<Integer, List<Integer>> replicasAssignments = builder.build();
+
+    expect(
+        topicManager.createTopic(
+            CLUSTER_ID,
+            TOPIC_1.getName(),
+            /* partitionsCount= */ Optional.empty(),
+            /* replicationFactor= */ Optional.empty(),
+            replicasAssignments,
+            singletonMap("cleanup.policy", Optional.of("compact"))))
+        .andReturn(completedFuture(null));
+    replay(topicManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    topicsResource.createTopic(
+        response,
+        TOPIC_1.getClusterId(),
+        CreateTopicRequest.builder()
+            .setTopicName(TOPIC_1.getName())
+            .setConfigs(
+                singletonList(CreateTopicRequest.ConfigEntry.create("cleanup.policy", "compact")))
+            .build());
+
+    CreateTopicResponse expected =
+        CreateTopicResponse.create(newTopicData("topic-1", false, 0));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
   public void createTopic_existingTopic_throwsTopicExists() {
     expect(
         topicManager.createTopic(
@@ -546,6 +595,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             Optional.of(TOPIC_1.getReplicationFactor()),
+            /* replicasAssignments= */ null,
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(failedFuture(new TopicExistsException("")));
     replay(topicManager);
@@ -573,6 +623,7 @@ public class TopicsResourceTest {
             TOPIC_1.getName(),
             Optional.of(TOPIC_1.getPartitions().size()),
             Optional.of(TOPIC_1.getReplicationFactor()),
+            /* replicasAssignments= */ null,
             singletonMap("cleanup.policy", Optional.of("compact"))))
         .andReturn(failedFuture(new NotFoundException()));
     replay(topicManager);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -583,9 +583,9 @@ public class TopicsResourceTest {
                 singletonList(CreateTopicRequest.ConfigEntry.create("cleanup.policy", "compact")))
             .build());
 
-    short expectedRf = (short) (TOPIC_1.getReplicationFactor() - 1);
-    CreateTopicResponse expected =
-        CreateTopicResponse.create(newTopicData("topic-1", false, expectedRf));
+    short expectedReplicationFactor = (short) (TOPIC_1.getReplicationFactor() - 1);
+    CreateTopicResponse expected = CreateTopicResponse.create(
+        newTopicData("topic-1", false, expectedReplicationFactor));
 
     assertEquals(expected, response.getValue());
   }


### PR DESCRIPTION
This change adds the ability to create a topic with a custom, explicitly specified mapping of partition to broker replicas.

The approach taken is the path of least resistance - adding yet another parameter to the `TopicManager` topic creation API, and not that far from the approach taken in the Kafka Admin client where the `NewTopic` spec contains both a field for such mappings, and fields for number of partitions and replication factor.
- Alternatively we could have introduced a DTO/spec object acting akin to `NewTopic` in the Kafka Admin client. This would have kept the `TopicManager` API more stable, but it would have added yet another class representing some form of a topic (alongside `CreateTopicRequest`, `Topic`, `TopicData`, `NewTopic`).  Having in mind that `TopicManager` is an internal abstraction, and not an actual API, I decided against that.
- Also we could have added a method overload in the `TopicManager`, but I didn't like how this would have meant slightly more changes in `TopicsResource` (in order to determine which overload to call after processing a topic creation request), so I decided against that too.

The change includes a corresponding update to the OpenAPI spec, although I'd appreciate a specifically close look at that part of the change.
It also includes some slight refactoring related to tests and checkstyle (and not the new API).

Aside from running tests locally it was also tested with the minimal Docker setup + simple cURL calls - e.g. 
```
curl -X POST -H "Content-Type: application/json" -d '{"topic_name":"ddimitrov","replicas_assignments":{"0":[1,2],"1":[2,3],"2":[3,1]}}' http://localhost:9391/v3/clusters/WSk_4zf7S0a-tLCF8QFCuQ/topics
```
- One interesting finding there is that apparently the new API does require the same number of partitions for all replicas, contrary to what the Kafka Admin client Javadoc claims.