### PR TITLE
Allow setting the request contentType in testProduceToAuthorizationError

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractProducerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractProducerTest.java
@@ -130,16 +130,23 @@ public class AbstractProducerTest<TopicRequestT, PartitionRequestT> extends Clus
   }
 
   protected void testProduceToAuthorizationError(String topicName, TopicRequestT request) {
-    testProduceToAuthorizationError(topicName, request, Collections.emptyMap());
+    testProduceToAuthorizationError(
+        topicName, request, Versions.KAFKA_V2_JSON_BINARY);
+  }
+
+  protected void testProduceToAuthorizationError(
+      String topicName, TopicRequestT request, String contentType) {
+    testProduceToAuthorizationError(topicName, request, contentType, Collections.emptyMap());
   }
 
   protected void testProduceToAuthorizationError(
       String topicName,
       TopicRequestT request,
+      String contentType,
       Map<String, String> queryParams
   ) {
     Response response = request("/topics/" + topicName, queryParams)
-        .post(Entity.entity(request, Versions.KAFKA_V2_JSON_BINARY));
+        .post(Entity.entity(request, contentType));
 
     assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
     final ProduceResponse produceResponse =


### PR DESCRIPTION
This enables correctly running some tests in `confluent-security-plugins/confluent-kafka-rest-security-plugin` (PR to follow soon).

_Nota bene_: I'd like to avoid keeping the possibly redundant `(String, TopicRequestT, Map<String, String>)` overload, so hopefully the PR CI will check and notify me if a downstream dependency breaks due to that overload's removal. If CI is green, I'll add reviewers for this PR.