### PR TITLE
KREST-491 Test with exponential backoff retries racy checks causing flaky failures in TopicsResourceIntegrationTest

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -31,7 +31,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Supplier;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import org.apache.avro.generic.IndexedRecord;
@@ -40,6 +43,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +51,9 @@ public class TestUtils {
 
   private static final Logger log = LoggerFactory.getLogger(TestUtils.class);
   private static final ObjectMapper jsonParser = new ObjectMapper();
+
+  private static final int DEFAULT_EXP_BACKOFF_RETRIES = 3;
+  private static final long DEFAULT_INITIAL_BACKOFF_MS = 200;
 
   /**
    * Try to read the entity. If parsing fails, errors are rethrown, but the raw entity is also logged for debugging.
@@ -70,7 +77,6 @@ public class TestUtils {
       throw t;
     }
   }
-
 
   /**
    * Asserts that the response received an HTTP 200 status code, as well as some optional
@@ -126,7 +132,6 @@ public class TestUtils {
       this.expected = expected;
     }
   }
-
 
   /**
    * Parses the given JSON string into Jackson's generic JsonNode structure. Useful for generation
@@ -241,6 +246,37 @@ public class TestUtils {
         valueDeserializerClassName, new Properties(), validateContents);
   }
 
+  public static <T> void testWithRetry(Supplier<Boolean> testCondition, String errorMessage) {
+    testWithRetry(
+        testCondition,
+        errorMessage,
+        DEFAULT_EXP_BACKOFF_RETRIES,
+        DEFAULT_INITIAL_BACKOFF_MS,
+        TimeUnit.MILLISECONDS);
+  }
+
+  public static <T> void testWithRetry(
+      Supplier<Boolean> testCondition,
+      String errorMessage,
+      int numRetries,
+      long initialBackoff,
+      TimeUnit backoffTimeUnit) {
+    long backoffInNs = backoffTimeUnit.toNanos(initialBackoff);
+    for (int i = 0; i <= numRetries; i++) {
+      if (testCondition.get()) {
+        return;
+      }
+      LockSupport.parkNanos(backoffInNs);
+      backoffInNs *= 2;
+    }
+    Assert.fail(
+        String.format(
+            "%s. Failed after %d exponential backoff retries with %d ms initial backoff",
+            errorMessage,
+            numRetries,
+            backoffTimeUnit.toMillis(initialBackoff)));
+  }
+
   private static <V, K> Map<Object, Integer> topicCounts(final KafkaConsumer<K, V> consumer,
                                                          final String topicName,
                                                          final List<? extends ProduceRecord<K,V>> records,
@@ -271,7 +307,6 @@ public class TestUtils {
     consumer.close();
     return msgCounts;
   }
-
 
   private static <K, V> KafkaConsumer<K, V> createConsumer(String bootstrapServers, String groupId,
                                                           String consumerId, Long consumerTimeout,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.kafkarest.integration.v3;
 
+import static io.confluent.kafkarest.TestUtils.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.kafkarest.entities.ConfigSource;
@@ -314,7 +314,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
     CreateTopicResponse actual = response.readEntity(CreateTopicResponse.class);
     assertEquals(expected, actual);
 
-    assertTrue(getTopicNames().contains(topicName));
+    testWithRetry(
+        () -> getTopicNames().contains(topicName),
+        String.format("Topic names should contain %s after its creation", topicName));
   }
 
   @Test
@@ -368,7 +370,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
     CreateTopicResponse actual = response.readEntity(CreateTopicResponse.class);
     assertEquals(expected, actual);
 
-    assertTrue(getTopicNames().contains(topicName));
+    testWithRetry(
+        () -> getTopicNames().contains(topicName),
+        String.format("Topic names should contain %s after its creation", topicName));
   }
 
   @Test
@@ -408,7 +412,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .delete();
     assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
     assertTrue(response.readEntity(String.class).isEmpty());
-    assertFalse(getTopicNames().contains(TOPIC_1));
+    testWithRetry(
+        () -> !getTopicNames().contains(TOPIC_1),
+        String.format("Topic names should not contain %s after its deletion", TOPIC_1));
   }
 
   @Test
@@ -495,7 +501,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
         createTopicResponse.readEntity(CreateTopicResponse.class);
 
     assertEquals(expectedCreateTopicResponse, actualCreateTopicResponse);
-    assertTrue(getTopicNames().contains(topicName));
+    testWithRetry(
+        () -> getTopicNames().contains(topicName),
+        String.format("Topic names should contain %s after its creation", topicName));
 
     GetTopicResponse expectedExistingGetTopicResponse =
         GetTopicResponse.create(
@@ -600,7 +608,9 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .delete();
     assertEquals(Status.NO_CONTENT.getStatusCode(), deleteTopicResponse.getStatus());
     assertTrue(deleteTopicResponse.readEntity(String.class).isEmpty());
-    assertFalse(getTopicNames().contains(topicName));
+    testWithRetry(
+        () -> !getTopicNames().contains(topicName),
+        String.format("Topic names should not contain %s after its deletion", topicName));
 
     Response deletedGetTopicResponse =
         request("/v3/clusters/" + clusterId + "/topics/" + topicName)


### PR DESCRIPTION
Adds a simple test retry utility that should help with inherently racy test procedures that nevertheless are expected to pass if given a little bit of slack.

One example of a procedure like that is topic creation/deletion immediately followed by checking for the topic's presence/absence in the list of available topics.
- To me this sounded like a pretty bad case of not reading your own writes, but apparently this is a known issue related to reading from different data sources (broker vs ZK).

Before this change, when running locally on my machine, the flaky tests causing [KREST-491](https://confluentinc.atlassian.net/browse/KREST-491) and [KREST-496](https://confluentinc.atlassian.net/browse/KREST-496) were failing ~30 times out of 200 total test runs. After this change, they were failing 0 times out of 200 total test runs.
- Tested by keeping just the corresponding 2 tests in the test file and running
```
rm ~/Desktop/KREST-491.log && for i in {1..100}; do mvn -f kafka-rest/pom.xml -Dit.test=TopicsResourceIntegrationTest test-compile failsafe:integration-test >> ~/Desktop/KREST-491.log; done
```
