### PR TITLE
KREST-524 Fix a test failure caused by a HashSet used concurrently.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/DefaultKafkaRestContextTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/DefaultKafkaRestContextTest.java
@@ -3,9 +3,9 @@ package io.confluent.kafkarest.unit;
 import io.confluent.kafkarest.DefaultKafkaRestContext;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.KafkaRestContext;
+import java.util.concurrent.CopyOnWriteArraySet;
 import org.junit.Before;
 import org.junit.Test;
-import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DefaultKafkaRestContextTest {
@@ -35,7 +36,7 @@ public class DefaultKafkaRestContextTest {
 
     @Test
     public void testGetProducerPoolThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
         // Captures reference as it's invoked.
@@ -43,14 +44,14 @@ public class DefaultKafkaRestContextTest {
             executor.submit(() -> refs.add(context.getProducerPool()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetKafkaConsumerManagerThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
         // Captures reference as it's invoked.
@@ -58,14 +59,14 @@ public class DefaultKafkaRestContextTest {
             executor.submit(() -> refs.add(context.getKafkaConsumerManager()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetAdminThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
         // Captures reference as it's invoked.
@@ -73,7 +74,7 @@ public class DefaultKafkaRestContextTest {
             executor.submit(() -> refs.add(context.getAdmin()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }


### PR DESCRIPTION
Tested locally in IntelliJ IDEA and via the command line.
With both approaches the results were fairly consistent, and out of 100 runs of `DefaultKafkaRestContextTest` (so a total of 300 tests):
- **before** the change, there were consistently between 5 and 10 failures.
- **after** the change, there were consistently no failures.