### PR TITLE
KREST-561: Add retries for flaky tests.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -246,33 +246,29 @@ public class TestUtils {
         valueDeserializerClassName, new Properties(), validateContents);
   }
 
-  public static <T> void testWithRetry(Supplier<Boolean> testCondition, String errorMessage) {
-    testWithRetry(
-        testCondition,
-        errorMessage,
-        DEFAULT_EXP_BACKOFF_RETRIES,
-        DEFAULT_INITIAL_BACKOFF);
+  public static void testWithRetry(Runnable assertions) {
+    testWithRetry(assertions, DEFAULT_EXP_BACKOFF_RETRIES, DEFAULT_INITIAL_BACKOFF);
   }
 
-  public static <T> void testWithRetry(
-      Supplier<Boolean> testCondition,
-      String errorMessage,
-      int numRetries,
-      Duration initialBackoff) {
+  public static void testWithRetry(Runnable assertions, int numRetries, Duration initialBackoff) {
     Duration backoff = initialBackoff;
-    for (int i = 0; i <= numRetries; i++) {
-      if (testCondition.get()) {
+    for (int i = 0;; i++) {
+      try {
+        assertions.run();
         return;
+      } catch (Throwable e) {
+        if (i == numRetries) {
+          throw new AssertionError(
+              String.format(
+                  "Failed after %d exponential backoff retries with %d ms initial backoff.",
+                  numRetries,
+                  initialBackoff.toMillis()),
+              e);
+        }
       }
       LockSupport.parkNanos(backoff.toNanos());
       backoff = backoff.multipliedBy(2L);
     }
-    Assert.fail(
-        String.format(
-            "%s. Failed after %d exponential backoff retries with %d ms initial backoff",
-            errorMessage,
-            numRetries,
-            initialBackoff.toMillis()));
   }
 
   private static <V, K> Map<Object, Integer> topicCounts(final KafkaConsumer<K, V> consumer,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -256,14 +256,14 @@ public class TestUtils {
       try {
         assertions.run();
         return;
-      } catch (Throwable e) {
+      } catch (Throwable t) {
         if (i == numRetries) {
           throw new AssertionError(
               String.format(
                   "Failed after %d exponential backoff retries with %d ms initial backoff.",
                   numRetries,
                   initialBackoff.toMillis()),
-              e);
+              t);
         }
       }
       LockSupport.parkNanos(backoff.toNanos());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokerConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/BrokerConfigsResourceIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.confluent.kafkarest.integration.v3;
 
+import static io.confluent.kafkarest.TestUtils.testWithRetry;
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -358,18 +359,21 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterUpdate =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
 
-    GetBrokerConfigResponse actualAfterUpdate =
-        responseAfterUpdate.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedAfterUpdate, actualAfterUpdate);
+          GetBrokerConfigResponse actualAfterUpdate =
+              responseAfterUpdate.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedAfterUpdate, actualAfterUpdate);
+        });
 
     Response resetResponse =
         request(
@@ -410,18 +414,21 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterReset =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterReset.getStatus());
+    testWithRetry(
+        () -> {
+          Response responseAfterReset =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterReset.getStatus());
 
-    GetBrokerConfigResponse actualAfterReset =
-        responseAfterReset.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedAfterReset, actualAfterReset);
+          GetBrokerConfigResponse actualAfterReset =
+              responseAfterReset.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedAfterReset, actualAfterReset);
+        });
   }
 
   @Test
@@ -605,28 +612,34 @@ public class BrokerConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterUpdate1 =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/max.connections")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
-    GetBrokerConfigResponse actualResponseAfterUpdate1 =
-        responseAfterUpdate1.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate1 =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/max.connections")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
+          GetBrokerConfigResponse actualResponseAfterUpdate1 =
+              responseAfterUpdate1.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+        });
 
-    Response responseAfterUpdate2 =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
-    GetBrokerConfigResponse actualResponseAfterUpdate2 =
-        responseAfterUpdate2.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate2 =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
+          GetBrokerConfigResponse actualResponseAfterUpdate2 =
+              responseAfterUpdate2.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+        });
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClusterConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClusterConfigsResourceIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.confluent.kafkarest.integration.v3;
 
+import static io.confluent.kafkarest.TestUtils.testWithRetry;
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertEquals;
 
@@ -147,15 +148,18 @@ public class ClusterConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterUpdate =
-        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate =
+              request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
 
-    GetClusterConfigResponse actualAfterUpdate =
-        responseAfterUpdate.readEntity(GetClusterConfigResponse.class);
-    assertEquals(expectedAfterUpdate, actualAfterUpdate);
+          GetClusterConfigResponse actualAfterUpdate =
+              responseAfterUpdate.readEntity(GetClusterConfigResponse.class);
+          assertEquals(expectedAfterUpdate, actualAfterUpdate);
+        });
 
     GetBrokerConfigResponse expectedBrokerAfterUpdate =
         GetBrokerConfigResponse.create(
@@ -213,11 +217,14 @@ public class ClusterConfigsResourceIntegrationTest extends ClusterTestHarness {
             .delete();
     assertEquals(Status.NO_CONTENT.getStatusCode(), resetResponse.getStatus());
 
-    Response responseAfterReset =
-        request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.NOT_FOUND.getStatusCode(), responseAfterReset.getStatus());
+    testWithRetry(
+        () -> {
+          Response responseAfterReset =
+              request("/v3/clusters/" + clusterId + "/broker-configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.NOT_FOUND.getStatusCode(), responseAfterReset.getStatus());
+        });
 
     GetBrokerConfigResponse expectedBrokerAfterReset =
         GetBrokerConfigResponse.create(
@@ -251,18 +258,21 @@ public class ClusterConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response brokerResponseAfterReset =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), brokerResponseAfterReset.getStatus());
+    testWithRetry(
+        () -> {
+          Response brokerResponseAfterReset =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), brokerResponseAfterReset.getStatus());
 
-    GetBrokerConfigResponse actualBrokerAfterReset =
-        brokerResponseAfterReset.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedBrokerAfterReset, actualBrokerAfterReset);
+          GetBrokerConfigResponse actualBrokerAfterReset =
+              brokerResponseAfterReset.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedBrokerAfterReset, actualBrokerAfterReset);
+        });
   }
 
   @Test
@@ -374,28 +384,34 @@ public class ClusterConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterUpdate1 =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/max.connections")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
-    GetBrokerConfigResponse actualResponseAfterUpdate1 =
-        responseAfterUpdate1.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate1 =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/max.connections")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
+          GetBrokerConfigResponse actualResponseAfterUpdate1 =
+              responseAfterUpdate1.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+        });
 
-    Response responseAfterUpdate2 =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/brokers/" + brokerId
-                + "/configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
-    GetBrokerConfigResponse actualResponseAfterUpdate2 =
-        responseAfterUpdate2.readEntity(GetBrokerConfigResponse.class);
-    assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate2 =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/brokers/" + brokerId
+                      + "/configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
+          GetBrokerConfigResponse actualResponseAfterUpdate2 =
+              responseAfterUpdate2.readEntity(GetBrokerConfigResponse.class);
+          assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+        });
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicConfigsResourceIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.integration.v3;
 
+import static io.confluent.kafkarest.TestUtils.testWithRetry;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -375,18 +376,21 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterUpdate =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/topics/" + TOPIC_1
-                + "/configs/cleanup.policy")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/topics/" + TOPIC_1
+                      + "/configs/cleanup.policy")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate.getStatus());
 
-    GetTopicConfigResponse actualResponseAfterUpdate =
-        responseAfterUpdate.readEntity(GetTopicConfigResponse.class);
-    assertEquals(expectedAfterUpdate, actualResponseAfterUpdate);
+          GetTopicConfigResponse actualResponseAfterUpdate =
+              responseAfterUpdate.readEntity(GetTopicConfigResponse.class);
+          assertEquals(expectedAfterUpdate, actualResponseAfterUpdate);
+        });
 
     Response resetResponse =
         request(
@@ -428,18 +432,21 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterReset =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/topics/" + TOPIC_1
-                + "/configs/cleanup.policy")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterReset.getStatus());
+    testWithRetry(
+        () -> {
+          Response responseAfterReset =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/topics/" + TOPIC_1
+                      + "/configs/cleanup.policy")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterReset.getStatus());
 
-    GetTopicConfigResponse actualResponseAfterReset =
-        responseAfterReset.readEntity(GetTopicConfigResponse.class);
-    assertEquals(expectedAfterReset, actualResponseAfterReset);
+          GetTopicConfigResponse actualResponseAfterReset =
+              responseAfterReset.readEntity(GetTopicConfigResponse.class);
+          assertEquals(expectedAfterReset, actualResponseAfterReset);
+        });
   }
 
   @Test
@@ -610,28 +617,34 @@ public class TopicConfigsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response responseAfterUpdate1 =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/topics/" + TOPIC_1
-                + "/configs/cleanup.policy")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
-    GetTopicConfigResponse actualResponseAfterUpdate1 =
-        responseAfterUpdate1.readEntity(GetTopicConfigResponse.class);
-    assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate1 =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/topics/" + TOPIC_1
+                      + "/configs/cleanup.policy")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate1.getStatus());
+          GetTopicConfigResponse actualResponseAfterUpdate1 =
+              responseAfterUpdate1.readEntity(GetTopicConfigResponse.class);
+          assertEquals(expectedAfterUpdate1, actualResponseAfterUpdate1);
+        });
 
-    Response responseAfterUpdate2 =
-        request(
-            "/v3/clusters/" + clusterId
-                + "/topics/" + TOPIC_1
-                + "/configs/compression.type")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
-    GetTopicConfigResponse actualResponseAfterUpdate2 =
-        responseAfterUpdate2.readEntity(GetTopicConfigResponse.class);
-    assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+    testWithRetry(
+        () -> {
+          Response responseAfterUpdate2 =
+              request(
+                  "/v3/clusters/" + clusterId
+                      + "/topics/" + TOPIC_1
+                      + "/configs/compression.type")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), responseAfterUpdate2.getStatus());
+          GetTopicConfigResponse actualResponseAfterUpdate2 =
+              responseAfterUpdate2.readEntity(GetTopicConfigResponse.class);
+          assertEquals(expectedAfterUpdate2, actualResponseAfterUpdate2);
+        });
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.integration.v3;
 
 import static io.confluent.kafkarest.TestUtils.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.kafkarest.entities.ConfigSource;
@@ -182,12 +183,18 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response response =
-        request("/v3/clusters/" + clusterId + "/topics").accept(MediaType.APPLICATION_JSON).get();
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    testWithRetry(
+        () -> {
+          Response response =
+              request("/v3/clusters/" + clusterId + "/topics")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
 
-    ListTopicsResponse actual = response.readEntity(ListTopicsResponse.class);
-    assertEquals(expected, actual);
+          assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+          ListTopicsResponse actual = response.readEntity(ListTopicsResponse.class);
+          assertEquals(expected, actual);
+        });
   }
 
   @Test
@@ -315,8 +322,10 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(expected, actual);
 
     testWithRetry(
-        () -> getTopicNames().contains(topicName),
-        String.format("Topic names should contain %s after its creation", topicName));
+        () ->
+            assertTrue(
+                String.format("Topic names should contain %s after its creation", topicName),
+                getTopicNames().contains(topicName)));
   }
 
   @Test
@@ -371,8 +380,10 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(expected, actual);
 
     testWithRetry(
-        () -> getTopicNames().contains(topicName),
-        String.format("Topic names should contain %s after its creation", topicName));
+        () ->
+            assertTrue(
+                String.format("Topic names should contain %s after its creation", topicName),
+                getTopicNames().contains(topicName)));
   }
 
   @Test
@@ -413,8 +424,10 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
     assertTrue(response.readEntity(String.class).isEmpty());
     testWithRetry(
-        () -> !getTopicNames().contains(TOPIC_1),
-        String.format("Topic names should not contain %s after its deletion", TOPIC_1));
+        () ->
+            assertFalse(
+                String.format("Topic names should not contain %s after its deletion", TOPIC_1),
+                getTopicNames().contains(TOPIC_1)));
   }
 
   @Test
@@ -502,8 +515,10 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
 
     assertEquals(expectedCreateTopicResponse, actualCreateTopicResponse);
     testWithRetry(
-        () -> getTopicNames().contains(topicName),
-        String.format("Topic names should contain %s after its creation", topicName));
+        () ->
+            assertTrue(
+                String.format("Topic names should contain %s after its creation", topicName),
+                getTopicNames().contains(topicName)));
 
     GetTopicResponse expectedExistingGetTopicResponse =
         GetTopicResponse.create(
@@ -541,15 +556,18 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             + "/partitions/-/reassignment"))
                 .build());
 
-    Response existingTopicResponse =
-        request("/v3/clusters/" + clusterId + "/topics/" + topicName)
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), existingTopicResponse.getStatus());
+    testWithRetry(
+        () -> {
+          Response existingTopicResponse =
+              request("/v3/clusters/" + clusterId + "/topics/" + topicName)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), existingTopicResponse.getStatus());
 
-    GetTopicResponse actualExistingGetTopicResponse =
-        existingTopicResponse.readEntity(GetTopicResponse.class);
-    assertEquals(expectedExistingGetTopicResponse, actualExistingGetTopicResponse);
+          GetTopicResponse actualExistingGetTopicResponse =
+              existingTopicResponse.readEntity(GetTopicResponse.class);
+          assertEquals(expectedExistingGetTopicResponse, actualExistingGetTopicResponse);
+        });
 
     GetTopicConfigResponse expectedExistingGetTopicConfigResponse =
         GetTopicConfigResponse.create(
@@ -609,8 +627,10 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(Status.NO_CONTENT.getStatusCode(), deleteTopicResponse.getStatus());
     assertTrue(deleteTopicResponse.readEntity(String.class).isEmpty());
     testWithRetry(
-        () -> !getTopicNames().contains(topicName),
-        String.format("Topic names should not contain %s after its deletion", topicName));
+        () ->
+            assertFalse(
+                String.format("Topic names should not contain %s after its deletion", topicName),
+                getTopicNames().contains(topicName)));
 
     Response deletedGetTopicResponse =
         request("/v3/clusters/" + clusterId + "/topics/" + topicName)


### PR DESCRIPTION
All of the tests below are flaky due to lack of consistency for admin operations in Kafka.

Test failures addressed:
* https://confluentinc.atlassian.net/browse/KREST-522
* https://confluentinc.atlassian.net/browse/KREST-527
* https://confluentinc.atlassian.net/browse/KREST-542
* https://confluentinc.atlassian.net/browse/KREST-546
* https://confluentinc.atlassian.net/browse/KREST-547
* https://confluentinc.atlassian.net/browse/KREST-555