### PR TITLE
KREST-558 Backport the fix for KREST-524 (fixing a concurrent test failure) to 5.5.x and 6.0.x.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/DefaultKafkaRestContextTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/DefaultKafkaRestContextTest.java
@@ -5,14 +5,15 @@ import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.rest.RestConfigException;
 import org.junit.Test;
-import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultKafkaRestContextTest {
     KafkaRestConfig restConfig;
@@ -30,7 +31,7 @@ public class DefaultKafkaRestContextTest {
 
     @Test
     public void testGetProducerPoolThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
         KafkaRestContext ctx = newContext(restConfig);
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
@@ -40,14 +41,14 @@ public class DefaultKafkaRestContextTest {
                     refs.add(ctx.getProducerPool()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetAdminClientWrapperThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
         KafkaRestContext ctx = newContext(restConfig);
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
@@ -57,14 +58,14 @@ public class DefaultKafkaRestContextTest {
                     refs.add(ctx.getAdminClientWrapper()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetKafkaConsumerManagerThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
         KafkaRestContext ctx = newContext(restConfig);
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
@@ -74,14 +75,14 @@ public class DefaultKafkaRestContextTest {
                     refs.add(ctx.getKafkaConsumerManager()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetAdminThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
         KafkaRestContext ctx = newContext(restConfig);
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
@@ -91,7 +92,7 @@ public class DefaultKafkaRestContextTest {
                     refs.add(ctx.getAdmin()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }


### PR DESCRIPTION
As the changes causing the [KREST-524](https://confluentinc.atlassian.net/browse/KREST-524)/[KREST-558](https://confluentinc.atlassian.net/browse/KREST-558) failures originally landed in `5.5.x`, the corresponding fix should have been merged starting from there.

This change cherry-picks it in `5.5.x` - it also needs to be merged up from there to `6.0.x`.
- From `6.0.x` though it's probably best to just `-s ours` merge up to `6.1.x` and `master`.

Tested locally in IntelliJ IDEA, by running 100 runs of `DefaultKafkaRestContextTest` (so a total of 400 tests):
- **before** the change, there were consistently between 5 and 10 failures.
- **after** the change, there were consistently no failures.