### PR TITLE
KREST-558 6.0.x

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/DefaultKafkaRestContextTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/DefaultKafkaRestContextTest.java
@@ -5,9 +5,9 @@ import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.KafkaRestContext;
 import org.junit.Before;
 import org.junit.Test;
-import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DefaultKafkaRestContextTest {
@@ -35,7 +36,7 @@ public class DefaultKafkaRestContextTest {
 
     @Test
     public void testGetProducerPoolThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
         // Captures reference as it's invoked.
@@ -43,14 +44,14 @@ public class DefaultKafkaRestContextTest {
             executor.submit(() -> refs.add(context.getProducerPool()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetKafkaConsumerManagerThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
         // Captures reference as it's invoked.
@@ -58,14 +59,14 @@ public class DefaultKafkaRestContextTest {
             executor.submit(() -> refs.add(context.getKafkaConsumerManager()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }
 
     @Test
     public void testGetAdminThreadSafety() throws InterruptedException {
-        Set<Object> refs = new HashSet<>();
+        Set<Object> refs = new CopyOnWriteArraySet<>();
 
         ExecutorService executor = Executors.newFixedThreadPool(100);
         // Captures reference as it's invoked.
@@ -73,7 +74,7 @@ public class DefaultKafkaRestContextTest {
             executor.submit(() -> refs.add(context.getAdmin()));
         }
         executor.shutdown();
-        executor.awaitTermination(60, TimeUnit.SECONDS);
+        assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS));
 
         assertEquals(1, refs.size());
     }


### PR DESCRIPTION
See #799 - this is a manual merge of the `5.5.x` fix from there into a `6.0.x`-based branch.
Created explicitly (and not `pint merge`-d) because the simple merge hits conflicts.

Tested locally in IntelliJ IDEA, by running 100 runs of `DefaultKafkaRestContextTest` (so a total of 300 tests):
- **before** the change, there were consistently between 5 and 10 failures.
- **after** the change, there were consistently no failures.