### PR TITLE
Renaming consumer group lag to consumer group lag summary for clarity

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -322,19 +322,19 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumersResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag-summary:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
-      summary: 'Get Consumer Group Lag.'
+      summary: 'Get Consumer Group Lag Summary.'
       description: 'Returns the max and total lag of the consumers belonging to the specified consumer group.'
       tags:
         - Consumer Group
       responses:
         '200':
-          $ref: '#/components/responses/GetConsumerGroupLagResponse'
+          $ref: '#/components/responses/GetConsumerGroupLagSummaryResponse'
 
   /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
     parameters:
@@ -1204,7 +1204,7 @@ components:
             - state
             - coordinator
             - consumers
-            - lag
+            - lag_summary
           properties:
             cluster_id:
               type: string
@@ -1220,7 +1220,7 @@ components:
               $ref: '#/components/schemas/Relationship'
             consumer:
               $ref: '#/components/schemas/Relationship'
-            lag:
+            lag_summary:
               $ref: '#/components/schemas/Relationship'
 
     ConsumerGroupDataList:
@@ -1294,7 +1294,7 @@ components:
               items:
                 $ref: '#/components/schemas/ConsumerLagData'
 
-    ConsumerGroupLagData:
+    ConsumerGroupLagSummaryData:
       allOf:
         - $ref: '#/components/schemas/Resource'
         - type: object
@@ -1888,18 +1888,20 @@ components:
               related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
             consumers:
               related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+            lag_summary:
+              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
 
-    GetConsumerGroupLagResponse:
+    GetConsumerGroupLagSummaryResponse:
       description: 'The max and total consumer lag in a consumer group.'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ConsumerGroupLagData'
+            $ref: '#/components/schemas/ConsumerGroupLagSummaryData'
           example:
-            kind: 'KafkaConsumerGroupLag'
+            kind: 'KafkaConsumerGroupLagSummary'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag'
-              resource_name: 'crn:///kafka=cluster-1/consumer-groups=consumer-group-1/lag'
+              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+              resource_name: 'crn:///kafka=cluster-1/consumer-groups=consumer-group-1/lag-summary'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
             max_lag_consumer_id: 'consumer-1'
@@ -2382,6 +2384,8 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
                 consumers:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+                lag_summary:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
               - kind: 'KafkaConsumerGroup'
                 metadata:
                   self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-2'
@@ -2395,6 +2399,8 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/2'
                 consumers:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-2/consumers'
+                lag_summary:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-2/lag-summary'
               - kind: 'KafkaConsumerGroup'
                 metadata:
                   self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3'
@@ -2408,6 +2414,8 @@ components:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3'
                 consumers:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
+                lag_summary:
+                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3/lag-summary'
 
     ListConsumerLagsResponse:
      description: 'The list of consumer lags.'

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManager.java
@@ -15,18 +15,18 @@
 
 package io.confluent.kafkarest.controllers;
 
-import io.confluent.kafkarest.entities.ConsumerGroupLag;
+import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * A service to manage Kafka {@link ConsumerGroupLag ConsumerGroupLags}.
+ * A service to manage Kafka {@link ConsumerGroupLagSummary ConsumerGroupLagSummary}.
  */
-public interface ConsumerGroupLagManager {
+public interface ConsumerGroupLagSummaryManager {
 
   /**
-   * Returns the Kafka {@link ConsumerGroupLag} with the given {@code consumerGroupId}.
+   * Returns the Kafka {@link ConsumerGroupLagSummary} with the given {@code consumerGroupId}.
    */
-  CompletableFuture<Optional<ConsumerGroupLag>> getConsumerGroupLag(
+  CompletableFuture<Optional<ConsumerGroupLagSummary>> getConsumerGroupLagSummary(
       String clusterId, String consumerGroupId);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImpl.java
@@ -38,7 +38,8 @@ final class ConsumerGroupLagSummaryManagerImpl
     extends AbstractConsumerLagManager implements ConsumerGroupLagSummaryManager {
 
   private final ConsumerGroupManager consumerGroupManager;
-  private static final Logger log = LoggerFactory.getLogger(ConsumerGroupLagSummaryManagerImpl.class);
+  private static final Logger log =
+      LoggerFactory.getLogger(ConsumerGroupLagSummaryManagerImpl.class);
 
   @Inject
   ConsumerGroupLagSummaryManagerImpl(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImpl.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
-import io.confluent.kafkarest.entities.ConsumerGroupLag;
+import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
 import io.confluent.kafkarest.entities.Partition;
 import java.util.Map;
 import java.util.Optional;
@@ -34,14 +34,14 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class ConsumerGroupLagManagerImpl
-    extends AbstractConsumerLagManager implements ConsumerGroupLagManager {
+final class ConsumerGroupLagSummaryManagerImpl
+    extends AbstractConsumerLagManager implements ConsumerGroupLagSummaryManager {
 
   private final ConsumerGroupManager consumerGroupManager;
-  private static final Logger log = LoggerFactory.getLogger(ConsumerGroupLagManagerImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(ConsumerGroupLagSummaryManagerImpl.class);
 
   @Inject
-  ConsumerGroupLagManagerImpl(
+  ConsumerGroupLagSummaryManagerImpl(
       Admin kafkaAdminClient,
       ConsumerGroupManager consumerGroupManager) {
     super(kafkaAdminClient);
@@ -49,7 +49,7 @@ final class ConsumerGroupLagManagerImpl
   }
 
   @Override
-  public CompletableFuture<Optional<ConsumerGroupLag>> getConsumerGroupLag(
+  public CompletableFuture<Optional<ConsumerGroupLagSummary>> getConsumerGroupLagSummary(
       String clusterId,
       String consumerGroupId
   ) {
@@ -71,21 +71,21 @@ final class ConsumerGroupLagManagerImpl
                             getLatestOffsets(fetchedCurrentOffsets)
                                 .thenApply(
                                     latestOffsets ->
-                                       Optional.of(createConsumerGroupLag(
+                                       Optional.of(createConsumerGroupLagSummary(
                                            clusterId,
                                            consumerGroup,
                                            fetchedCurrentOffsets,
                                            latestOffsets)))));
   }
 
-  private static ConsumerGroupLag createConsumerGroupLag(
+  private static ConsumerGroupLagSummary createConsumerGroupLagSummary(
       String clusterId,
       ConsumerGroup consumerGroup,
       Map<TopicPartition, OffsetAndMetadata> fetchedCurrentOffsets,
       Map<TopicPartition, ListOffsetsResultInfo> latestOffsets) {
     Map<Partition, Consumer> partitionAssignment = consumerGroup.getPartitionAssignment();
-    ConsumerGroupLag.Builder consumerGroupLag =
-        ConsumerGroupLag.builder()
+    ConsumerGroupLagSummary.Builder consumerGroupLagSummary =
+        ConsumerGroupLagSummary.builder()
             .setClusterId(clusterId)
             .setConsumerGroupId(consumerGroup.getConsumerGroupId());
     fetchedCurrentOffsets.keySet().forEach(
@@ -102,7 +102,7 @@ final class ConsumerGroupLagManagerImpl
           Optional<Long> latestOffset =
               getLatestOffset(latestOffsets, topicPartition);
           if (currentOffset.isPresent() && latestOffset.isPresent()) {
-            consumerGroupLag.addOffset(
+            consumerGroupLagSummary.addOffset(
                 topicPartition.topic(),
                 consumer.map(Consumer::getConsumerId).orElse(""),
                 consumer.flatMap(Consumer::getInstanceId),
@@ -120,6 +120,6 @@ final class ConsumerGroupLagManagerImpl
                 latestOffset.orElse(null));
           }
         });
-    return consumerGroupLag.build();
+    return consumerGroupLagSummary.build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -29,7 +29,7 @@ public final class ControllersModule extends AbstractBinder {
     bind(ClusterConfigManagerImpl.class).to(ClusterConfigManager.class);
     bind(ClusterManagerImpl.class).to(ClusterManager.class);
     bind(ConsumerAssignmentManagerImpl.class).to(ConsumerAssignmentManager.class);
-    bind(ConsumerGroupLagManagerImpl.class).to(ConsumerGroupLagManager.class);
+    bind(ConsumerGroupLagSummaryManagerImpl.class).to(ConsumerGroupLagSummaryManager.class);
     bind(ConsumerGroupManagerImpl.class).to(ConsumerGroupManager.class);
     bind(ConsumerLagManagerImpl.class).to(ConsumerLagManager.class);
     bind(ConsumerManagerImpl.class).to(ConsumerManager.class);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroupLagSummary.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroupLagSummary.java
@@ -19,9 +19,9 @@ import com.google.auto.value.AutoValue;
 import java.util.Optional;
 
 @AutoValue
-public abstract class ConsumerGroupLag {
+public abstract class ConsumerGroupLagSummary {
 
-  ConsumerGroupLag() {
+  ConsumerGroupLagSummary() {
   }
 
   public abstract String getClusterId();
@@ -43,7 +43,7 @@ public abstract class ConsumerGroupLag {
   public abstract Long getTotalLag();
 
   public static Builder builder() {
-    return new AutoValue_ConsumerGroupLag.Builder();
+    return new AutoValue_ConsumerGroupLagSummary.Builder();
   }
 
   @AutoValue.Builder
@@ -97,6 +97,6 @@ public abstract class ConsumerGroupLag {
 
     public abstract Builder setTotalLag(Long totalLag);
 
-    public abstract ConsumerGroupLag build();
+    public abstract ConsumerGroupLagSummary build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupData.java
@@ -48,8 +48,8 @@ public abstract class ConsumerGroupData extends Resource {
   @JsonProperty("consumers")
   public abstract Relationship getConsumers();
 
-  @JsonProperty("lag")
-  public abstract Relationship getLag();
+  @JsonProperty("lag_summary")
+  public abstract Relationship getLagSummary();
 
   public static Builder builder() {
     return new AutoValue_ConsumerGroupData.Builder().setKind("KafkaConsumerGroup");
@@ -75,7 +75,7 @@ public abstract class ConsumerGroupData extends Resource {
       @JsonProperty("state") State state,
       @JsonProperty("coordinator") Relationship coordinator,
       @JsonProperty("consumers") Relationship consumers,
-      @JsonProperty("lag") Relationship lag
+      @JsonProperty("lag_summary") Relationship lagSummary
   ) {
     return builder()
         .setKind(kind)
@@ -87,7 +87,7 @@ public abstract class ConsumerGroupData extends Resource {
         .setState(state)
         .setCoordinator(coordinator)
         .setConsumers(consumers)
-        .setLag(lag)
+        .setLagSummary(lagSummary)
         .build();
   }
 
@@ -111,7 +111,7 @@ public abstract class ConsumerGroupData extends Resource {
 
     public abstract Builder setConsumers(Relationship consumers);
 
-    public abstract Builder setLag(Relationship lag);
+    public abstract Builder setLagSummary(Relationship lagSummary);
 
     public abstract ConsumerGroupData build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupLagSummaryData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupLagSummaryData.java
@@ -18,14 +18,14 @@ package io.confluent.kafkarest.entities.v3;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import io.confluent.kafkarest.entities.ConsumerGroupLag;
+import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class ConsumerGroupLagData extends Resource {
+public abstract class ConsumerGroupLagSummaryData extends Resource {
 
-  ConsumerGroupLagData() {
+  ConsumerGroupLagSummaryData() {
   }
 
   @JsonProperty("cluster_id")
@@ -62,25 +62,25 @@ public abstract class ConsumerGroupLagData extends Resource {
   public abstract Relationship getMaxLagPartition();
 
   public static Builder builder() {
-    return new AutoValue_ConsumerGroupLagData.Builder().setKind("KafkaConsumerGroupLag");
+    return new AutoValue_ConsumerGroupLagSummaryData.Builder().setKind("KafkaConsumerGroupLagSummary");
   }
 
-  public static Builder fromConsumerGroupLag(ConsumerGroupLag consumerGroupLag) {
+  public static Builder fromConsumerGroupLagSummary(ConsumerGroupLagSummary consumerGroupLagSummary) {
     return builder()
-        .setClusterId(consumerGroupLag.getClusterId())
-        .setConsumerGroupId(consumerGroupLag.getConsumerGroupId())
-        .setMaxLag(consumerGroupLag.getMaxLag())
-        .setTotalLag(consumerGroupLag.getTotalLag())
-        .setMaxLagConsumerId(consumerGroupLag.getMaxLagConsumerId())
-        .setMaxLagClientId(consumerGroupLag.getMaxLagClientId())
-        .setMaxLagInstanceId(consumerGroupLag.getMaxLagInstanceId().orElse(null))
-        .setMaxLagTopicName(consumerGroupLag.getMaxLagTopicName())
-        .setMaxLagPartitionId(consumerGroupLag.getMaxLagPartitionId());
+        .setClusterId(consumerGroupLagSummary.getClusterId())
+        .setConsumerGroupId(consumerGroupLagSummary.getConsumerGroupId())
+        .setMaxLag(consumerGroupLagSummary.getMaxLag())
+        .setTotalLag(consumerGroupLagSummary.getTotalLag())
+        .setMaxLagConsumerId(consumerGroupLagSummary.getMaxLagConsumerId())
+        .setMaxLagClientId(consumerGroupLagSummary.getMaxLagClientId())
+        .setMaxLagInstanceId(consumerGroupLagSummary.getMaxLagInstanceId().orElse(null))
+        .setMaxLagTopicName(consumerGroupLagSummary.getMaxLagTopicName())
+        .setMaxLagPartitionId(consumerGroupLagSummary.getMaxLagPartitionId());
   }
 
   // CHECKSTYLE:OFF:ParameterNumber
   @JsonCreator
-  static ConsumerGroupLagData fromJson(
+  static ConsumerGroupLagSummaryData fromJson(
       @JsonProperty("kind") String kind,
       @JsonProperty("metadata") Metadata metadata,
       @JsonProperty("cluster_id") String clusterId,
@@ -141,6 +141,6 @@ public abstract class ConsumerGroupLagData extends Resource {
 
     public abstract Builder setMaxLagPartition(Relationship maxLagPartition);
 
-    public abstract ConsumerGroupLagData build();
+    public abstract ConsumerGroupLagSummaryData build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupLagSummaryData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupLagSummaryData.java
@@ -62,10 +62,13 @@ public abstract class ConsumerGroupLagSummaryData extends Resource {
   public abstract Relationship getMaxLagPartition();
 
   public static Builder builder() {
-    return new AutoValue_ConsumerGroupLagSummaryData.Builder().setKind("KafkaConsumerGroupLagSummary");
+    return new AutoValue_ConsumerGroupLagSummaryData.Builder()
+        .setKind("KafkaConsumerGroupLagSummary");
   }
 
-  public static Builder fromConsumerGroupLagSummary(ConsumerGroupLagSummary consumerGroupLagSummary) {
+  public static Builder fromConsumerGroupLagSummary(
+      ConsumerGroupLagSummary consumerGroupLagSummary
+  ) {
     return builder()
         .setClusterId(consumerGroupLagSummary.getClusterId())
         .setConsumerGroupId(consumerGroupLagSummary.getConsumerGroupId())

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetConsumerGroupLagSummaryResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/GetConsumerGroupLagSummaryResponse.java
@@ -20,20 +20,20 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-public abstract class GetConsumerGroupLagResponse {
+public abstract class GetConsumerGroupLagSummaryResponse {
 
-  GetConsumerGroupLagResponse() {
+  GetConsumerGroupLagSummaryResponse() {
   }
 
   @JsonValue
-  public abstract ConsumerGroupLagData getValue();
+  public abstract ConsumerGroupLagSummaryData getValue();
 
-  public static GetConsumerGroupLagResponse create(ConsumerGroupLagData value) {
-    return new AutoValue_GetConsumerGroupLagResponse(value);
+  public static GetConsumerGroupLagSummaryResponse create(ConsumerGroupLagSummaryData value) {
+    return new AutoValue_GetConsumerGroupLagSummaryResponse(value);
   }
 
   @JsonCreator
-  static GetConsumerGroupLagResponse fromJson(ConsumerGroupLagData value) {
+  static GetConsumerGroupLagSummaryResponse fromJson(ConsumerGroupLagSummaryData value) {
     return create(value);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResource.java
@@ -74,12 +74,15 @@ public final class ConsumerGroupLagSummariesResource {
             .thenApply(groupLagSummary -> groupLagSummary.orElseThrow(NotFoundException::new))
             .thenApply(
                 groupLagSummary ->
-                    GetConsumerGroupLagSummaryResponse.create(toConsumerGroupLagSummaryData(groupLagSummary)));
+                    GetConsumerGroupLagSummaryResponse.create(
+                        toConsumerGroupLagSummaryData(groupLagSummary)));
 
     AsyncResponses.asyncResume(asyncResponse, response);
   }
 
-  private ConsumerGroupLagSummaryData toConsumerGroupLagSummaryData(ConsumerGroupLagSummary groupLagSummary) {
+  private ConsumerGroupLagSummaryData toConsumerGroupLagSummaryData(
+      ConsumerGroupLagSummary groupLagSummary
+  ) {
     return ConsumerGroupLagSummaryData.fromConsumerGroupLagSummary(groupLagSummary)
         .setMetadata(
             Resource.Metadata.builder()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResource.java
@@ -17,10 +17,10 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
-import io.confluent.kafkarest.controllers.ConsumerGroupLagManager;
-import io.confluent.kafkarest.entities.ConsumerGroupLag;
-import io.confluent.kafkarest.entities.v3.ConsumerGroupLagData;
-import io.confluent.kafkarest.entities.v3.GetConsumerGroupLagResponse;
+import io.confluent.kafkarest.controllers.ConsumerGroupLagSummaryManager;
+import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
+import io.confluent.kafkarest.entities.v3.ConsumerGroupLagSummaryData;
+import io.confluent.kafkarest.entities.v3.GetConsumerGroupLagSummaryResponse;
 import io.confluent.kafkarest.entities.v3.Resource;
 import io.confluent.kafkarest.entities.v3.Resource.Relationship;
 import io.confluent.kafkarest.extension.ResourceBlocklistFeature.ResourceName;
@@ -40,64 +40,64 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 
-@Path("/v3/clusters/{clusterId}/consumer-groups/{consumerGroupId}/lag")
-@ResourceName("api.v3.consumer-group-lag.*")
-public final class ConsumerGroupLagsResource {
+@Path("/v3/clusters/{clusterId}/consumer-groups/{consumerGroupId}/lag-summary")
+@ResourceName("api.v3.consumer-group-lag-summary.*")
+public final class ConsumerGroupLagSummariesResource {
 
-  private final Provider<ConsumerGroupLagManager> consumerGroupLagManager;
+  private final Provider<ConsumerGroupLagSummaryManager> consumerGroupLagSummaryManager;
   private final CrnFactory crnFactory;
   private final UrlFactory urlFactory;
 
   @Inject
-  public ConsumerGroupLagsResource(
-      Provider<ConsumerGroupLagManager> consumerGroupLagManager,
+  public ConsumerGroupLagSummariesResource(
+      Provider<ConsumerGroupLagSummaryManager> consumerGroupLagSummaryManager,
       CrnFactory crnFactory,
       UrlFactory urlFactory
   ) {
-    this.consumerGroupLagManager = requireNonNull(consumerGroupLagManager);
+    this.consumerGroupLagSummaryManager = requireNonNull(consumerGroupLagSummaryManager);
     this.crnFactory = requireNonNull(crnFactory);
     this.urlFactory = requireNonNull(urlFactory);
   }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @PerformanceMetric("v3.consumer-group-lag.get")
-  @ResourceName("api.v3.consumer-group-lag.get")
-  public void getConsumerGroupLag(
+  @PerformanceMetric("v3.consumer-group-lag-summary.get")
+  @ResourceName("api.v3.consumer-group-lag-summary.get")
+  public void getConsumerGroupLagSummary(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
       @PathParam("consumerGroupId") String consumerGroupId
   ) {
-    CompletableFuture<GetConsumerGroupLagResponse> response =
-        consumerGroupLagManager.get()
-            .getConsumerGroupLag(clusterId, consumerGroupId)
-            .thenApply(groupLag -> groupLag.orElseThrow(NotFoundException::new))
+    CompletableFuture<GetConsumerGroupLagSummaryResponse> response =
+        consumerGroupLagSummaryManager.get()
+            .getConsumerGroupLagSummary(clusterId, consumerGroupId)
+            .thenApply(groupLagSummary -> groupLagSummary.orElseThrow(NotFoundException::new))
             .thenApply(
-                groupLag ->
-                    GetConsumerGroupLagResponse.create(toConsumerGroupLagData(groupLag)));
+                groupLagSummary ->
+                    GetConsumerGroupLagSummaryResponse.create(toConsumerGroupLagSummaryData(groupLagSummary)));
 
     AsyncResponses.asyncResume(asyncResponse, response);
   }
 
-  private ConsumerGroupLagData toConsumerGroupLagData(ConsumerGroupLag groupLag) {
-    return ConsumerGroupLagData.fromConsumerGroupLag(groupLag)
+  private ConsumerGroupLagSummaryData toConsumerGroupLagSummaryData(ConsumerGroupLagSummary groupLagSummary) {
+    return ConsumerGroupLagSummaryData.fromConsumerGroupLagSummary(groupLagSummary)
         .setMetadata(
             Resource.Metadata.builder()
                 .setSelf(
                     urlFactory.create(
                         "v3",
                         "clusters",
-                        groupLag.getClusterId(),
+                        groupLagSummary.getClusterId(),
                         "consumer-groups",
-                        groupLag.getConsumerGroupId(),
-                        "lag"))
+                        groupLagSummary.getConsumerGroupId(),
+                        "lag-summary"))
                 .setResourceName(
                     crnFactory.create(
                         "kafka",
-                        groupLag.getClusterId(),
+                        groupLagSummary.getClusterId(),
                         "consumer-group",
-                        groupLag.getConsumerGroupId(),
-                        "lag",
+                        groupLagSummary.getConsumerGroupId(),
+                        "lag-summary",
                         null))
                 .build())
         .setMaxLagConsumer(
@@ -105,21 +105,21 @@ public final class ConsumerGroupLagsResource {
                 urlFactory.create(
                     "v3",
                     "clusters",
-                    groupLag.getClusterId(),
+                    groupLagSummary.getClusterId(),
                     "consumer-groups",
-                    groupLag.getConsumerGroupId(),
+                    groupLagSummary.getConsumerGroupId(),
                     "consumers",
-                    groupLag.getMaxLagConsumerId())))
+                    groupLagSummary.getMaxLagConsumerId())))
         .setMaxLagPartition(
             Relationship.create(
                 urlFactory.create(
                     "v3",
                     "clusters",
-                    groupLag.getClusterId(),
+                    groupLagSummary.getClusterId(),
                     "topics",
-                    groupLag.getMaxLagTopicName(),
+                    groupLagSummary.getMaxLagTopicName(),
                     "partitions",
-                    Integer.toString(groupLag.getMaxLagPartitionId()))))
+                    Integer.toString(groupLagSummary.getMaxLagPartitionId()))))
         .build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResource.java
@@ -145,7 +145,7 @@ public final class ConsumerGroupsResource {
                     "consumer-groups",
                     consumerGroup.getConsumerGroupId(),
                     "consumers")))
-        .setLag(
+        .setLagSummary(
             Relationship.create(
                 urlFactory.create(
                     "v3",
@@ -153,7 +153,7 @@ public final class ConsumerGroupsResource {
                     clusterId,
                     "consumer-groups",
                     consumerGroup.getConsumerGroupId(),
-                    "lag")))
+                    "lag-summary")))
         .build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
@@ -31,7 +31,7 @@ public final class V3ResourcesFeature implements Feature {
     configurable.register(ClusterConfigsResource.class);
     configurable.register(ClustersResource.class);
     configurable.register(ConsumerAssignmentsResource.class);
-    configurable.register(ConsumerGroupLagsResource.class);
+    configurable.register(ConsumerGroupLagSummariesResource.class);
     configurable.register(ConsumerGroupsResource.class);
     configurable.register(ConsumersResource.class);
     configurable.register(ConsumerLagsResource.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
@@ -96,10 +96,10 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
                                 Relationship.create(
                                     baseUrl + "/v3/clusters/" + clusterId
                                         + "/consumer-groups/consumer-group-1/consumers"))
-                            .setLag(
+                            .setLagSummary(
                                 Relationship.create(
                                     baseUrl + "/v3/clusters/" + clusterId
-                                        + "/consumer-groups/consumer-group-1/lag"))
+                                        + "/consumer-groups/consumer-group-1/lag-summary"))
                             .build()))
                 .build());
 
@@ -175,10 +175,10 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
                     Relationship.create(
                         baseUrl + "/v3/clusters/" + clusterId
                             + "/consumer-groups/consumer-group-1/consumers"))
-                .setLag(
+                .setLagSummary(
                     Relationship.create(
                         baseUrl + "/v3/clusters/" + clusterId
-                            + "/consumer-groups/consumer-group-1/lag"))
+                            + "/consumer-groups/consumer-group-1/lag-summary"))
                 .build());
 
     Response response =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResourceTest.java
@@ -20,10 +20,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 
-import io.confluent.kafkarest.controllers.ConsumerGroupLagManager;
-import io.confluent.kafkarest.entities.ConsumerGroupLag;
-import io.confluent.kafkarest.entities.v3.ConsumerGroupLagData;
-import io.confluent.kafkarest.entities.v3.GetConsumerGroupLagResponse;
+import io.confluent.kafkarest.controllers.ConsumerGroupLagSummaryManager;
+import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
+import io.confluent.kafkarest.entities.v3.ConsumerGroupLagSummaryData;
+import io.confluent.kafkarest.entities.v3.GetConsumerGroupLagSummaryResponse;
 import io.confluent.kafkarest.entities.v3.Resource;
 import io.confluent.kafkarest.entities.v3.Resource.Relationship;
 import io.confluent.kafkarest.response.CrnFactoryImpl;
@@ -40,15 +40,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class ConsumerGroupLagsResourceTest {
+public class ConsumerGroupLagSummariesResourceTest {
 
   private static final String CLUSTER_ID = "cluster-1";
   private static final String CONSUMER_GROUP_ID = "consumer-group-1";
   private static final String CONSUMER_ID = "consumer-1";
   private static final String CLIENT_ID = "client-1";
 
-  private static final ConsumerGroupLag CONSUMER_GROUP_LAG_1 =
-      ConsumerGroupLag.builder()
+  private static final ConsumerGroupLagSummary CONSUMER_GROUP_LAG_1 =
+      ConsumerGroupLagSummary.builder()
           .setClusterId(CLUSTER_ID)
           .setConsumerGroupId(CONSUMER_GROUP_ID)
           .setMaxLag(100L)
@@ -63,34 +63,34 @@ public class ConsumerGroupLagsResourceTest {
   public final EasyMockRule mocks = new EasyMockRule(this);
 
   @Mock
-  private ConsumerGroupLagManager consumerGroupLagManager;
+  private ConsumerGroupLagSummaryManager consumerGroupLagSummaryManager;
 
-  private ConsumerGroupLagsResource consumerGroupLagsResource;
+  private ConsumerGroupLagSummariesResource consumerGroupLagSummariesResource;
 
   @Before
   public void setUp() {
-    consumerGroupLagsResource =
-        new ConsumerGroupLagsResource(
-            () -> consumerGroupLagManager, new CrnFactoryImpl(""), new FakeUrlFactory());
+    consumerGroupLagSummariesResource =
+        new ConsumerGroupLagSummariesResource(
+            () -> consumerGroupLagSummaryManager, new CrnFactoryImpl(""), new FakeUrlFactory());
   }
 
   @Test
-  public void getConsumerGroupLag_returnsConsumerGroupLag() {
-    expect(consumerGroupLagManager.getConsumerGroupLag(CLUSTER_ID, CONSUMER_GROUP_ID))
+  public void getConsumerGroupLagSummary_returnsConsumerGroupLagSummary() {
+    expect(consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID))
         .andReturn(completedFuture(Optional.of(CONSUMER_GROUP_LAG_1)));
-    replay(consumerGroupLagManager);
+    replay(consumerGroupLagSummaryManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerGroupLagsResource.getConsumerGroupLag(response, CLUSTER_ID, CONSUMER_GROUP_ID);
+    consumerGroupLagSummariesResource.getConsumerGroupLagSummary(response, CLUSTER_ID, CONSUMER_GROUP_ID);
 
-    GetConsumerGroupLagResponse expected =
-        GetConsumerGroupLagResponse.create(
-            ConsumerGroupLagData.fromConsumerGroupLag(CONSUMER_GROUP_LAG_1)
+    GetConsumerGroupLagSummaryResponse expected =
+        GetConsumerGroupLagSummaryResponse.create(
+            ConsumerGroupLagSummaryData.fromConsumerGroupLagSummary(CONSUMER_GROUP_LAG_1)
                 .setMetadata(
                     Resource.Metadata.builder()
-                        .setSelf("/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag")
+                        .setSelf("/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary")
                         .setResourceName(
-                            "crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag")
+                            "crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag-summary")
                         .build())
                 .setMaxLagConsumer(
                     Relationship.create("/v3/clusters/cluster-1/consumer-groups/consumer-group-1/"
@@ -103,13 +103,13 @@ public class ConsumerGroupLagsResourceTest {
   }
 
   @Test
-  public void getConsumerGroupLag_nonExistingConsumerGroupLag_throwsNotFound() {
-    expect(consumerGroupLagManager.getConsumerGroupLag(CLUSTER_ID, CONSUMER_GROUP_ID))
+  public void getConsumerGroupLagSummary_nonExistingConsumerGroupLagSummary_throwsNotFound() {
+    expect(consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID))
         .andReturn(completedFuture(Optional.empty()));
-    replay(consumerGroupLagManager);
+    replay(consumerGroupLagSummaryManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerGroupLagsResource.getConsumerGroupLag(response, CLUSTER_ID, CONSUMER_GROUP_ID);
+    consumerGroupLagSummariesResource.getConsumerGroupLagSummary(response, CLUSTER_ID, CONSUMER_GROUP_ID);
 
     assertEquals(NotFoundException.class, response.getException().getClass());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResourceTest.java
@@ -295,9 +295,9 @@ public class ConsumerGroupsResourceTest {
                                 Relationship.create(
                                     "/v3/clusters/cluster-1/consumer-groups/consumer-group-1"
                                         + "/consumers"))
-                            .setLag(
+                            .setLagSummary(
                                 Relationship.create(
-                                    "/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag"))
+                                    "/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary"))
                             .build(),
                         ConsumerGroupData.fromConsumerGroup(CONSUMER_GROUPS[1])
                             .setMetadata(
@@ -313,9 +313,10 @@ public class ConsumerGroupsResourceTest {
                                 Relationship.create(
                                     "/v3/clusters/cluster-1/consumer-groups/consumer-group-2"
                                         + "/consumers"))
-                            .setLag(
+                            .setLagSummary(
                                 Relationship.create(
-                                    "/v3/clusters/cluster-1/consumer-groups/consumer-group-2/lag"))
+                                    "/v3/clusters/cluster-1/consumer-groups/consumer-group-2"
+                                        + "/lag-summary"))
                             .build()))
                 .build());
 
@@ -349,9 +350,9 @@ public class ConsumerGroupsResourceTest {
                 .setConsumers(
                     Relationship.create(
                         "/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers"))
-                .setLag(
+                .setLagSummary(
                     Relationship.create(
-                        "/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag"))
+                        "/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary"))
                 .build());
 
     assertEquals(expected, response.getValue());


### PR DESCRIPTION
The name `ConsumerGroupLag` isn't too clear, especially when we also have `ConsumerLag`
Regenerating kafka-rest-sdk-go further illustrates the vagueness - https://github.com/confluentinc/kafka-rest-sdk-go/pull/5#discussion_r573758885

Also realized during refactoring that openapi.yaml was missing `lag_summary` links for ConsumerGroup