### PR TITLE
Adding retries to ConsumerLagsResourceIntegrationTest

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
@@ -84,6 +84,13 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
     produce(topic1, 0, request1);
     produce(topic2, 1, request1);
 
+    // stores expected currentOffsets and logEndOffsets for each topic partition after sending
+    // 3 records to topic1 partition0 and topic2 partition1
+    long[][] expectedOffsets = new long[numTopics][numPartitions];
+    expectedOffsets[0][0] = 3;
+    expectedOffsets[1][1] = 3;
+    // all other values default to 0L
+
     KafkaConsumer<?, ?> consumer1 = createConsumer(group1, "client-1");
     KafkaConsumer<?, ?> consumer2 = createConsumer(group1, "client-2");
 
@@ -100,13 +107,6 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
           // commit offsets from consuming from subscribed topics
           consumer1.commitSync();
           consumer2.commitSync();
-
-          // stores expected currentOffsets and logEndOffsets for each topic partition after sending
-          // 3 records to topic1 partition0 and topic2 partition1
-          long[][] expectedOffsets = new long[numTopics][numPartitions];
-          expectedOffsets[0][0] = 3;
-          expectedOffsets[1][1] = 3;
-          // all other values default to 0L
 
           Response response =
               request("/v3/clusters/" + clusterId + "/consumer-groups/" + group1 + "/lags")
@@ -216,6 +216,13 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
     produce(topic1, 0, request1);
     produce(topic2, 1, request1);
 
+    // stores expected currentOffsets and logEndOffsets for each topic partition after sending
+    // 3 records to topic1 partition0 and topic2 partition1
+    long[][] expectedOffsets = new long[numTopics][numPartitions];
+    expectedOffsets[0][0] = 3;
+    expectedOffsets[1][1] = 3;
+    // all other values default to 0L
+
     KafkaConsumer<?, ?> consumer = createConsumer(group1, "client-1");
     testWithRetry(
         () -> {
@@ -223,13 +230,6 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
           // consume from subscribed topics (zero lag)
           consumer.poll(Duration.ofSeconds(1));
           consumer.commitSync();
-
-          // stores expected currentOffsets and logEndOffsets for each topic partition after sending
-          // 3 records to topic1 partition0 and topic2 partition1
-          long[][] expectedOffsets = new long[numTopics][numPartitions];
-          expectedOffsets[0][0] = 3;
-          expectedOffsets[1][1] = 3;
-          // all other values default to 0L
 
           for (int t = 0; t < numTopics; t++) {
             for (int p = 0; p < numPartitions; p++) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
@@ -96,12 +96,12 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
 
     consumer1.subscribe(Collections.singletonList(topic1));
     consumer2.subscribe(Collections.singletonList(topic2));
-    consumer1.poll(Duration.ofSeconds(1));
-    consumer2.poll(Duration.ofSeconds(1));
+    consumer1.poll(Duration.ofSeconds(5));
+    consumer2.poll(Duration.ofSeconds(5));
     // After polling once, only one of the consumers will be member of the group, so we poll again
     // to force the other consumer to join the group.
-    consumer1.poll(Duration.ofSeconds(1));
-    consumer2.poll(Duration.ofSeconds(1));
+    consumer1.poll(Duration.ofSeconds(5));
+    consumer2.poll(Duration.ofSeconds(5));
     // commit offsets from consuming from subscribed topics
     consumer1.commitSync();
     consumer2.commitSync();


### PR DESCRIPTION
Wrapping consumer subscribes and polls in retry block to remove flakiness and address the following test failures

https://confluentinc.atlassian.net/browse/KREST-625?atlOrigin=eyJpIjoiMzVjMzg2Njc5MDQxNDUzYWI2NjVjMWY1YzRhYmJjNmMiLCJwIjoiaiJ9
https://confluentinc.atlassian.net/browse/KREST-616?atlOrigin=eyJpIjoiOGJkYTcxNjZmMjFjNGNkOThhZTM0ZDgxMTBhMTk4ZGIiLCJwIjoiaiJ9