### PR TITLE
KREST-638 Some small deployment improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,21 @@ To install from source, follow the instructions in the Development section below
 Deployment
 ----------
 
-The REST proxy includes a built-in Jetty server. The wrapper scripts
-``bin/kafka-rest-start`` and ``bin/kafka-rest-stop`` are the recommended method of
-starting and stopping the service.
+The REST proxy includes a built-in Jetty server and can be deployed after
+being configured to connect to an existing Kafka cluster.
+
+Running ``mvn clean package`` runs all 3 of its assembly targets.
+- The ``development`` target assembles all necessary dependencies in a ``kafka-rest/target``
+  subfolder without packaging them in a distributable format. The wrapper scripts
+  ``bin/kafka-rest-start`` and ``bin/kafka-rest-stop`` can then be used to start and stop the
+  service.
+- The ``package`` target is meant to be used in shared dependency environments and omits some
+  dependencies expected to be provided externally. It assembles the other dependencies in a
+  ``kafka-rest/target`` subfolder as well as in distributable archives. The wrapper scripts
+  ``bin/kafka-rest-start`` and ``bin/kafka-rest-stop`` can then be used to start and stop the
+  service.
+- The ``standalone`` target packages all necessary dependencies as a distributable JAR that can
+  be run as standard (``java -jar $base-dir/kafka-rest/target/kafka-rest-X.Y.Z-standalone.jar``).
 
 Quickstart
 ----------
@@ -83,7 +95,7 @@ the REST Proxy running using the default settings and some topics already create
 Development
 -----------
 
-To build a development version, you may need a development versions of
+To build a development version, you may need development versions of
 [common](https://github.com/confluentinc/common),
 [rest-utils](https://github.com/confluentinc/rest-utils), and
 [schema-registry](https://github.com/confluentinc/schema-registry).  After

--- a/bin/kafka-rest-run-class
+++ b/bin/kafka-rest-run-class
@@ -18,7 +18,7 @@ base_dir=$(dirname $0)/..
 
 # Development jars. `mvn package` should collect all the required dependency jars here
 for dir in $base_dir/kafka-rest/target/kafka-rest-*-development; do
-  CLASSPATH=$CLASSPATH:$dir/share/java/kafka-rest-bin/*:$dir/share/java/kafka-rest-lib/*
+  CLASSPATH=$CLASSPATH:$dir/share/java/kafka-rest/*
 done
 
 # Production jars

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -167,6 +167,7 @@
                     <descriptors>
                         <descriptor>src/assembly/development.xml</descriptor>
                         <descriptor>src/assembly/package.xml</descriptor>
+                        <descriptor>src/assembly/standalone.xml</descriptor>
                     </descriptors>
                     <archive>
                         <manifest>
@@ -202,23 +203,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>standalone</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/assembly/standalone.xml</descriptor>
-                            </descriptors>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/kafka-rest/src/assembly/package.xml
+++ b/kafka-rest/src/assembly/package.xml
@@ -3,7 +3,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
           http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <!-- Assembles a package that can run kafka-rest given dependency packages. This is used to
-         construct packages OS packages where underlying libraries, like rest-utils, can be shared
+         construct distributables where underlying libraries, like rest-utils, can be shared
          -->
     <id>package</id>
     <formats>


### PR DESCRIPTION
Fixes the `kafka-rest-run-class` script to correctly work with the `development` assembly target, moves the `standalone` assembly target into the main profile, and beefs up a bit the Deployment section of the README.

Tested by ensuring that after a `mvn clean package`:
- the `kafka-rest-start` script now can be used to deploy the local changes.
    - We still need to pass valid configuration. I didn't default to the `./config/kafka-rest.properties` ones to avoid side effects to the `package` use-cases.
- ` java -jar ./kafka-rest/target/kafka-rest-6.2.0.0-standalone.jar ./config/kafka-rest.properties` correctly starts a server with the local changes if `kafka-rest.properties` is valid.