### PR TITLE
KREST-117: Add missing example for create acl

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1618,6 +1618,17 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateAclRequestData'
+          example:
+            kind: 'KafkaAcl'
+            metadata:
+              self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+            resource_type: 'CLUSTER'
+            resource_name: 'cluster-1'
+            pattern_type: 'LITERAL'
+            principal: 'alice'
+            host: '*'
+            operation: 'DESCRIBE'
+            permission: 'DENY'
 
     CreateTopicRequest:
       description: 'The topic creation request.'


### PR DESCRIPTION
### What
Add missing example for `CreateAclRequest` schema.
Docs has `CreateAclRequest` with field `resource_name` missing and values set to `UNKNOWN` that looks like - 
{
    "resource_type": "UNKNOWN",
    "pattern_type": "UNKNOWN",
    "principal": "string",
    "host": "string",
    "operation": "UNKNOWN",
    "permission": "UNKNOWN"
}
Docs link - https://docs.confluent.io/platform/current/kafka-rest/api.html#post--clusters-cluster_id-acls

### Testing
Validated api spec with - 
`swagger-cli validate api/v3/openapi.yaml `
`openapi-examples-validator api/v3/openapi.yaml`
`npx redoc-cli serve api/v3/openapi.yaml`

### References - 
Jira - https://confluentinc.atlassian.net/browse/KREST-117
