### PR TITLE
Move slack build messages to #rest-proxy-warn.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
 common {
-  slackChannel = '#rest-proxy-eng'
+  slackChannel = '#rest-proxy-warn'
   upstreamProjects = 'confluentinc/schema-registry'
 }


### PR DESCRIPTION
This change serves to address the issue of noisiness in #rest-proxy-eng which will serve human communication and all machine chatter will move to #rest-proxy-warn.

Slack thread: https://confluent.slack.com/archives/C2MCH5QJE/p1614850839024400