### PR TITLE
KREST-771 Fix build breakage by also updating ProduceAction.java

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -33,7 +33,7 @@ import io.confluent.kafkarest.entities.v3.ProduceRequest.ProduceRequestHeader;
 import io.confluent.kafkarest.entities.v3.ProduceResponse;
 import io.confluent.kafkarest.entities.v3.ProduceResponse.ProduceResponseData;
 import io.confluent.kafkarest.exceptions.BadRequestException;
-import io.confluent.kafkarest.extension.ResourceBlocklistFeature.ResourceName;
+import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
 import io.confluent.kafkarest.response.StreamingResponse;
 import io.confluent.rest.annotations.PerformanceMetric;
 import java.time.Instant;


### PR DESCRIPTION
Due to my last rebase for [the KREST-771 changes](https://github.com/confluentinc/kafka-rest/pull/823) not being recent enough, I have missed to update `ProduceAction` accordingly.

This breaks `kafka-rest`, so this change fixes that breakage.