### PR TITLE
MMA-10143 added support for isolation levels to consumer offset resources

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConsumerLagManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConsumerLagManager.java
@@ -36,7 +36,6 @@ import org.apache.kafka.common.TopicPartition;
 abstract class AbstractConsumerLagManager {
 
   private final Admin kafkaAdminClient;
-  private static final IsolationLevel ISOLATION_LEVEL = IsolationLevel.READ_COMMITTED;
 
   AbstractConsumerLagManager(Admin kafkaAdminClient) {
     this.kafkaAdminClient = requireNonNull(kafkaAdminClient);
@@ -52,7 +51,7 @@ abstract class AbstractConsumerLagManager {
   }
 
   final CompletableFuture<Map<TopicPartition, ListOffsetsResultInfo>> getLatestOffsets(
-      Map<TopicPartition, OffsetAndMetadata> currentOffsets
+      Map<TopicPartition, OffsetAndMetadata> currentOffsets, IsolationLevel isolationLevel
   ) {
     Map<TopicPartition, OffsetSpec> latestOffsetSpecs =
         currentOffsets.keySet()
@@ -62,7 +61,7 @@ abstract class AbstractConsumerLagManager {
     return KafkaFutures.toCompletableFuture(
         kafkaAdminClient.listOffsets(
             latestOffsetSpecs,
-            new ListOffsetsOptions(ISOLATION_LEVEL)).all());
+            new ListOffsetsOptions(isolationLevel)).all());
   }
 
   static final Optional<Long> getCurrentOffset(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManager.java
@@ -16,6 +16,8 @@
 package io.confluent.kafkarest.controllers;
 
 import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
+import org.apache.kafka.common.IsolationLevel;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,5 +30,5 @@ public interface ConsumerGroupLagSummaryManager {
    * Returns the Kafka {@link ConsumerGroupLagSummary} with the given {@code consumerGroupId}.
    */
   CompletableFuture<Optional<ConsumerGroupLagSummary>> getConsumerGroupLagSummary(
-      String clusterId, String consumerGroupId);
+      String clusterId, String consumerGroupId, IsolationLevel isolationLevel);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImpl.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,8 @@ final class ConsumerGroupLagSummaryManagerImpl
   @Override
   public CompletableFuture<Optional<ConsumerGroupLagSummary>> getConsumerGroupLagSummary(
       String clusterId,
-      String consumerGroupId
+      String consumerGroupId,
+      IsolationLevel isolationLevel
   ) {
     return consumerGroupManager.getConsumerGroup(clusterId, consumerGroupId)
         .thenApply(
@@ -69,7 +71,7 @@ final class ConsumerGroupLagSummaryManagerImpl
                                 "Consumer group offsets could not be found."))
                     .thenCompose(
                         fetchedCurrentOffsets ->
-                            getLatestOffsets(fetchedCurrentOffsets)
+                            getLatestOffsets(fetchedCurrentOffsets, isolationLevel)
                                 .thenApply(
                                     latestOffsets ->
                                        Optional.of(createConsumerGroupLagSummary(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerLagManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerLagManager.java
@@ -16,6 +16,8 @@
 package io.confluent.kafkarest.controllers;
 
 import io.confluent.kafkarest.entities.ConsumerLag;
+import org.apache.kafka.common.IsolationLevel;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -30,11 +32,15 @@ public interface ConsumerLagManager {
    * {@link io.confluent.kafkarest.entities.ConsumerGroup} with the given {@code consumerGroupId}.
    */
   CompletableFuture<List<ConsumerLag>> listConsumerLags(
-      String clusterId, String consumerGroupId);
+      String clusterId, String consumerGroupId, IsolationLevel isolationLevel);
 
   /**
    * Returns the Kafka {@link ConsumerLag} with the given {@code consumerId}.
    */
   CompletableFuture<Optional<ConsumerLag>> getConsumerLag(
-      String clusterId, String consumerGroupId, String topicName, Integer partitionId);
+      String clusterId,
+      String consumerGroupId,
+      String topicName,
+      Integer partitionId,
+      IsolationLevel isolationLevel);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerLagManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerLagManagerImpl.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,7 @@ final class ConsumerLagManagerImpl
 
   @Override
   public CompletableFuture<List<ConsumerLag>> listConsumerLags(
-      String clusterId, String consumerGroupId) {
+      String clusterId, String consumerGroupId, IsolationLevel isolationLevel) {
     return consumerGroupManager.getConsumerGroup(clusterId, consumerGroupId)
         .thenApply(
             consumerGroup ->
@@ -69,7 +70,7 @@ final class ConsumerLagManagerImpl
                                 "Consumer group offsets could not be found."))
                     .thenCompose(
                         fetchedCurrentOffsets ->
-                            getLatestOffsets(fetchedCurrentOffsets)
+                            getLatestOffsets(fetchedCurrentOffsets, isolationLevel)
                                 .thenApply(
                                     latestOffsets ->
                                         createConsumerLagList(
@@ -81,8 +82,12 @@ final class ConsumerLagManagerImpl
 
   @Override
   public CompletableFuture<Optional<ConsumerLag>> getConsumerLag(
-      String clusterId, String consumerGroupId, String topicName, Integer partitionId) {
-    return listConsumerLags(clusterId, consumerGroupId)
+      String clusterId,
+      String consumerGroupId,
+      String topicName,
+      Integer partitionId,
+      IsolationLevel isolationLevel) {
+    return listConsumerLags(clusterId, consumerGroupId, isolationLevel)
         .thenApply(
             lags ->
                 lags.stream()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResource.java
@@ -28,14 +28,18 @@ import io.confluent.kafkarest.resources.AsyncResponses;
 import io.confluent.kafkarest.response.CrnFactory;
 import io.confluent.kafkarest.response.UrlFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
+import org.apache.kafka.common.IsolationLevel;
+
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
@@ -66,11 +70,13 @@ public final class ConsumerGroupLagSummariesResource {
   public void getConsumerGroupLagSummary(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
-      @PathParam("consumerGroupId") String consumerGroupId
+      @PathParam("consumerGroupId") String consumerGroupId,
+      @QueryParam("isolationLevel") @DefaultValue(ConsumerLagsResource.DEFAULT_ISOLATION_LEVEL)
+          IsolationLevel isolationLevel
   ) {
     CompletableFuture<GetConsumerGroupLagSummaryResponse> response =
         consumerGroupLagSummaryManager.get()
-            .getConsumerGroupLagSummary(clusterId, consumerGroupId)
+            .getConsumerGroupLagSummary(clusterId, consumerGroupId,isolationLevel)
             .thenApply(groupLagSummary -> groupLagSummary.orElseThrow(NotFoundException::new))
             .thenApply(
                 groupLagSummary ->

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImplTest.java
@@ -207,7 +207,7 @@ public class ConsumerGroupLagSummaryManagerImplTest {
         .andReturn(new ListOffsetsResult(LATEST_OFFSETS_MAP));
     replay(consumerGroupManager, kafkaAdminClient, listConsumerGroupOffsetsResult);
     ConsumerGroupLagSummary consumerGroupLagSummary =
-        consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID).get().get();
+        consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED).get().get();
     assertEquals(OFFSET_AND_METADATA_MAP.keySet(), capturedOffsetSpec.getValue().keySet());
     assertEquals(
         IsolationLevel.READ_COMMITTED,
@@ -222,7 +222,7 @@ public class ConsumerGroupLagSummaryManagerImplTest {
     replay(consumerGroupManager);
 
     try {
-      consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID).get();
+      consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerLagManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerLagManagerImplTest.java
@@ -249,7 +249,7 @@ public class ConsumerLagManagerImplTest {
         .andReturn(new ListOffsetsResult(LATEST_OFFSETS_MAP));
     replay(consumerGroupManager, kafkaAdminClient, listConsumerGroupOffsetsResult);
     List<ConsumerLag> consumerLagList =
-        consumerLagManager.listConsumerLags(CLUSTER_ID, CONSUMER_GROUP_ID).get();
+        consumerLagManager.listConsumerLags(CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED).get();
     assertEquals(OFFSET_AND_METADATA_MAP.keySet(), capturedOffsetSpec.getValue().keySet());
     assertEquals(
         IsolationLevel.READ_COMMITTED,
@@ -277,7 +277,7 @@ public class ConsumerLagManagerImplTest {
 
     ConsumerLag consumerLag =
         consumerLagManager.getConsumerLag(
-            CLUSTER_ID, CONSUMER_GROUP_ID, "topic-2", 2)
+            CLUSTER_ID, CONSUMER_GROUP_ID, "topic-2", 2, IsolationLevel.READ_COMMITTED)
             .get()
             .get();
 
@@ -347,7 +347,7 @@ public class ConsumerLagManagerImplTest {
 
     ConsumerLag consumerLag =
         consumerLagManager.getConsumerLag(
-            CLUSTER_ID, CONSUMER_GROUP_ID, "topic-1", 1)
+            CLUSTER_ID, CONSUMER_GROUP_ID, "topic-1", 1, IsolationLevel.READ_COMMITTED)
             .get()
             .get();
 
@@ -378,7 +378,7 @@ public class ConsumerLagManagerImplTest {
 
     Optional<ConsumerLag> consumerLag =
         consumerLagManager.getConsumerLag(
-            CLUSTER_ID, CONSUMER_GROUP_ID, "topic-1", 2)
+            CLUSTER_ID, CONSUMER_GROUP_ID, "topic-1", 2, IsolationLevel.READ_COMMITTED)
             .get();
     assertEquals(OFFSET_AND_METADATA_MAP.keySet(), capturedOffsetSpec.getValue().keySet());
     assertEquals(
@@ -394,7 +394,7 @@ public class ConsumerLagManagerImplTest {
     replay(consumerGroupManager);
 
     try {
-      consumerLagManager.getConsumerLag(CLUSTER_ID, "foo", "topic-1", 1).get();
+      consumerLagManager.getConsumerLag(CLUSTER_ID, "foo", "topic-1", 1, IsolationLevel.READ_COMMITTED).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());
@@ -408,7 +408,7 @@ public class ConsumerLagManagerImplTest {
     replay(consumerGroupManager);
 
     try {
-      consumerLagManager.listConsumerLags(CLUSTER_ID, "foo").get();
+      consumerLagManager.listConsumerLags(CLUSTER_ID, "foo", IsolationLevel.READ_COMMITTED).get();
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupLagSummariesResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupLagSummariesResourceIntegrationTest.java
@@ -84,8 +84,8 @@ public class ConsumerGroupLagSummariesResourceIntegrationTest extends ClusterTes
 
   @Override
   public Properties overrideBrokerProperties(int i, Properties props) {
-    props.put(KafkaConfig.TransactionsTopicMinISRProp(),"1");
-    props.put(KafkaConfig.TransactionsTopicReplicationFactorProp(),"1");
+    props.put(KafkaConfig.TransactionsTopicMinISRProp(), "1");
+    props.put(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1");
     return props;
   }
 
@@ -188,19 +188,19 @@ public class ConsumerGroupLagSummariesResourceIntegrationTest extends ClusterTes
     producer.beginTransaction();
     producer.send(new ProducerRecord<>(topic3, "someKey", "someVal")).get();
 
-    executeAndVerifyLag(Optional.of("read_committed"),0);
-    executeAndVerifyLag(Optional.of("read_uncommitted"),1);
+    executeAndVerifyLag(Optional.of("read_committed"), 0);
+    executeAndVerifyLag(Optional.of("read_uncommitted"), 1);
     // default = read committed = 0 lag
-    executeAndVerifyLag(Optional.empty(),0);
+    executeAndVerifyLag(Optional.empty(), 0);
 
     // close the transaction
     producer.commitTransaction();
     producer.close();
 
     // verify the isolation levels are now consistent (lag has increased because of the transaction marker)
-    executeAndVerifyLag(Optional.of("read_committed"),2);
-    executeAndVerifyLag(Optional.of("read_uncommitted"),2);
-    executeAndVerifyLag(Optional.empty(),2);
+    executeAndVerifyLag(Optional.of("read_committed"), 2);
+    executeAndVerifyLag(Optional.of("read_uncommitted"), 2);
+    executeAndVerifyLag(Optional.empty(), 2);
 
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
@@ -78,8 +78,8 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
 
   @Override
   public Properties overrideBrokerProperties(int i, Properties props) {
-    props.put(KafkaConfig.TransactionsTopicMinISRProp(),"1");
-    props.put(KafkaConfig.TransactionsTopicReplicationFactorProp(),"1");
+    props.put(KafkaConfig.TransactionsTopicMinISRProp(), "1");
+    props.put(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1");
     return props;
   }
 
@@ -232,18 +232,18 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
     producer.beginTransaction();
     producer.send(new ProducerRecord<>(topic3, "someKey", "someVal")).get();
 
-    executeAndVerifyOffsets(Optional.of("read_committed"),3L,3L,0L);
-    executeAndVerifyOffsets(Optional.of("read_uncommitted"),3L,4L,1L);
-    executeAndVerifyOffsets(Optional.empty(),3L,3L,0L);
+    executeAndVerifyOffsets(Optional.of("read_committed"), 3L, 3L, 0L);
+    executeAndVerifyOffsets(Optional.of("read_uncommitted"), 3L, 4L, 1L);
+    executeAndVerifyOffsets(Optional.empty(), 3L, 3L, 0L);
 
     // close the transaction
     producer.commitTransaction();
     producer.close();
 
     // verify the isolation levels are now consistent (end offset has increased because of the transaction marker)
-    executeAndVerifyOffsets(Optional.of("read_committed"),3L,5L,2L);
-    executeAndVerifyOffsets(Optional.of("read_uncommitted"),3L,5L,2L);
-    executeAndVerifyOffsets(Optional.empty(),3L,5L,2L);
+    executeAndVerifyOffsets(Optional.of("read_committed"), 3L, 5L, 2L);
+    executeAndVerifyOffsets(Optional.of("read_uncommitted"), 3L, 5L, 2L);
+    executeAndVerifyOffsets(Optional.empty(), 3L, 5L, 2L);
 
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupLagSummariesResourceTest.java
@@ -31,6 +31,8 @@ import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
 import java.util.Optional;
 import javax.ws.rs.NotFoundException;
+
+import org.apache.kafka.common.IsolationLevel;
 import org.easymock.EasyMockRule;
 import org.easymock.Mock;
 import org.junit.Before;
@@ -76,12 +78,12 @@ public class ConsumerGroupLagSummariesResourceTest {
 
   @Test
   public void getConsumerGroupLagSummary_returnsConsumerGroupLagSummary() {
-    expect(consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID))
+    expect(consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED))
         .andReturn(completedFuture(Optional.of(CONSUMER_GROUP_LAG_1)));
     replay(consumerGroupLagSummaryManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerGroupLagSummariesResource.getConsumerGroupLagSummary(response, CLUSTER_ID, CONSUMER_GROUP_ID);
+    consumerGroupLagSummariesResource.getConsumerGroupLagSummary(response, CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED);
 
     GetConsumerGroupLagSummaryResponse expected =
         GetConsumerGroupLagSummaryResponse.create(
@@ -104,12 +106,12 @@ public class ConsumerGroupLagSummariesResourceTest {
 
   @Test
   public void getConsumerGroupLagSummary_nonExistingConsumerGroupLagSummary_throwsNotFound() {
-    expect(consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID))
+    expect(consumerGroupLagSummaryManager.getConsumerGroupLagSummary(CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED))
         .andReturn(completedFuture(Optional.empty()));
     replay(consumerGroupLagSummaryManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerGroupLagSummariesResource.getConsumerGroupLagSummary(response, CLUSTER_ID, CONSUMER_GROUP_ID);
+    consumerGroupLagSummariesResource.getConsumerGroupLagSummary(response, CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED);
 
     assertEquals(NotFoundException.class, response.getException().getClass());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerLagsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerLagsResourceTest.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.NotFoundException;
+
+import org.apache.kafka.common.IsolationLevel;
 import org.easymock.EasyMockRule;
 import org.easymock.Mock;
 import org.junit.Before;
@@ -96,12 +98,12 @@ public class ConsumerLagsResourceTest {
 
   @Test
   public void listConsumerLags_returnsConsumerLags() {
-    expect(consumerLagManager.listConsumerLags(CLUSTER_ID, CONSUMER_GROUP_ID))
+    expect(consumerLagManager.listConsumerLags(CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED))
         .andReturn(completedFuture(CONSUMER_LAG_LIST));
     replay(consumerLagManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerLagsResource.listConsumerLags(response, CLUSTER_ID, CONSUMER_GROUP_ID);
+    consumerLagsResource.listConsumerLags(response, CLUSTER_ID, CONSUMER_GROUP_ID, IsolationLevel.READ_COMMITTED);
 
     ListConsumerLagsResponse expected =
         ListConsumerLagsResponse.create(
@@ -142,12 +144,12 @@ public class ConsumerLagsResourceTest {
 
   @Test
   public void getConsumerLag_returnsConsumerLag() {
-    expect(consumerLagManager.getConsumerLag(CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1))
+    expect(consumerLagManager.getConsumerLag(CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1, IsolationLevel.READ_COMMITTED))
         .andReturn(completedFuture(Optional.of(CONSUMER_LAG_1)));
     replay(consumerLagManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerLagsResource.getConsumerLag(response, CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1);
+    consumerLagsResource.getConsumerLag(response, CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1, IsolationLevel.READ_COMMITTED);
 
     GetConsumerLagResponse expected =
         GetConsumerLagResponse.create(
@@ -167,12 +169,12 @@ public class ConsumerLagsResourceTest {
   @Test
   public void getConsumerLag_nonExistingConsumerLag_throwsNotFound() {
     expect(consumerLagManager.getConsumerLag(
-        CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1))
+        CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1, IsolationLevel.READ_COMMITTED))
         .andReturn(completedFuture(Optional.empty()));
     replay(consumerLagManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    consumerLagsResource.getConsumerLag(response, CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1);
+    consumerLagsResource.getConsumerLag(response, CLUSTER_ID, CONSUMER_GROUP_ID, TOPIC, 1, IsolationLevel.READ_COMMITTED);
 
     assertEquals(NotFoundException.class, response.getException().getClass());
   }


### PR DESCRIPTION
This PR adds the ability to produce isolation levels to resources that fetch latest offsets. These are passed as options queryparms and if unspecified will default to the previously hardcoded read_committed. 

Tested with new integration tests.