### PR TITLE
KREST-865 Remove usage of the deprecated SimpleAclAuthorizer.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -24,7 +24,7 @@ import io.confluent.kafkarest.entities.BinaryTopicProduceRecord;
 import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
 import io.confluent.kafkarest.entities.CreateConsumerInstanceResponse;
 import io.confluent.kafkarest.entities.PartitionOffset;
-import kafka.security.auth.SimpleAclAuthorizer;
+import kafka.security.authorizer.AclAuthorizer;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -91,7 +91,7 @@ import static org.junit.Assert.assertTrue;
         false, 1, (short) 1);
     brokerProps.put(KafkaConfig.BrokerIdProp(), Integer.toString(i));
     brokerProps.put(KafkaConfig.ZkConnectProp(), zkConnect);
-    brokerProps.setProperty("authorizer.class.name", SimpleAclAuthorizer.class.getName());
+    brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");
     brokerProps.setProperty("listener.name.sasl_plaintext.plain.sasl.jaas.config",
         "org.apache.kafka.common.security.plain.PlainLoginModule required "


### PR DESCRIPTION
Starting from `5.4.x`, this will fix the deprecated API usage in `master` that is affected by https://github.com/confluentinc/kafka/pull/544.
- There are other deprecated API usages across the different branches, which should be addressed as soon as possible.

Tested locally with `mvn -f kafka-rest/pom.xml -Dit.test=AuthorizationErrorTest test-compile failsafe:integration-test`. 