### PR TITLE
KREST-46: Removed property ${confluent.maven.repo}

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,19 @@ the REST Proxy running using the default settings and some topics already create
 Development
 -----------
 
-To build a development version, you may need a development versions of
+To build a development version, you may need development versions of
 [common](https://github.com/confluentinc/common),
 [rest-utils](https://github.com/confluentinc/rest-utils), and
 [schema-registry](https://github.com/confluentinc/schema-registry).  After
 installing these, you can build the Kafka REST Proxy
 with Maven. All the standard lifecycle phases work.
+
+If your contribution will be a patch or feature and target the latest or earlier
+release version, you can avoid building development versions of dependencies
+by using the latest (or required) `<release>-post` branch, which will
+reference dependencies available pre-built from the
+[public repositor](http://packages.confluent.io/maven/).  For example, branch
+`5.0.0-post` can be used as a base for patches for this version.
 
 Contribute
 ----------

--- a/README.md
+++ b/README.md
@@ -90,11 +90,10 @@ To build a development version, you may need development versions of
 installing these, you can build the Kafka REST Proxy
 with Maven. All the standard lifecycle phases work.
 
-If your contribution will be a patch or feature and target the latest or earlier
-release version, you can avoid building development versions of dependencies
-by using the latest (or required) `<release>-post` branch, which will
-reference dependencies available pre-built from the
-[public repositor](http://packages.confluent.io/maven/).  For example, branch
+You can avoid building development versions of dependencies
+by building on the latest (or earlier) release tag, or `<release>-post` branch,
+which will reference dependencies available pre-built from the
+[public repository](http://packages.confluent.io/maven/).  For example, branch
 `5.0.0-post` can be used as a base for patches for this version.
 
 Contribute

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can avoid building development versions of dependencies
 by building on the latest (or earlier) release tag, or `<release>-post` branch,
 which will reference dependencies available pre-built from the
 [public repository](http://packages.confluent.io/maven/).  For example, branch
-`5.0.0-post` can be used as a base for patches for this version.
+`6.1.1-post` can be used as a base for patches for this version.
 
 Contribute
 ----------

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.kafka-rest.version>6.1.1</io.confluent.kafka-rest.version>
     </properties>
@@ -55,7 +54,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This property was used in repository/url definition.  This causes a problem with resolution of the parent project/pom, since
property-evaluation occurs in Maven after the parent project is resolved.

`Dockerfile` which can be used to test can't/can build-from-source (without external repository configuration):

```
FROM maven:3.6.3-openjdk-8

RUN useradd -m build
USER build
COPY --chown=build . /home/build/src
WORKDIR /home/build/src

RUN mvn package -U
```

Prior to this change:

```
 > [5/5] RUN mvn package -U:
#7 1.995 [INFO] Scanning for projects...
#7 2.343 Downloading from central: https://repo.maven.apache.org/maven2/io/confluent/rest-utils-parent/5.0.0/rest-utils-parent-5.0.0.pom
#7 3.749 [ERROR] [ERROR] Some problems were encountered while processing the POMs:
#7 3.749 [FATAL] Non-resolvable parent POM for io.confluent:kafka-rest-parent:5.0.0: Could not transfer artifact io.confluent:rest-utils-parent:pom:5.0.0 from/to confluent (${confluent.maven.repo}): Cannot access ${confluent.maven.repo} with type default using the available connector factories: BasicRepositoryConnectorFactory and 'parent.relativePath' points at wrong local POM @ line 7, column 13
#7 3.756  @
#7 3.757 [ERROR] The build could not read 1 project -> [Help 1]
#7 3.758 [ERROR]
#7 3.758 [ERROR]   The project io.confluent:kafka-rest-parent:5.0.0 (/home/build/src/pom.xml) has 1 error
#7 3.758 [ERROR]     Non-resolvable parent POM for io.confluent:kafka-rest-parent:5.0.0: Could not transfer artifact io.confluent:rest-utils-parent:pom:5.0.0 from/to confluent (${confluent.maven.repo}): Cannot access ${confluent.maven.repo} with type default using the available connector factories: BasicRepositoryConnectorFactory and 'parent.relativePath' points at wrong local POM @ line 7, column 13: Cannot access ${confluent.maven.repo} using the registered transporter factories: WagonTransporterFactory: Unsupported transport protocol -> [Help 2]
#7 3.759 [ERROR]
#7 3.761 [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
#7 3.762 [ERROR] Re-run Maven using the -X switch to enable full debug logging.
#7 3.762 [ERROR]
#7 3.762 [ERROR] For more information about the errors and possible solutions, please read the following articles:
#7 3.762 [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
#7 3.763 [ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
------
executor failed running [/bin/sh -c mvn package -U]: exit code: 1

```

Fixes #640 .

Revert "Introduce confluent.maven.repo variable so we can customize via CLI if needed"

This reverts commit 2e1231c46bf13e6bfcc9b0e13588d85eb8f8dae5.

This is needed, to-be-merged down to 6.1.1-post/master

Related:
- https://github.com/confluentinc/schema-registry/pull/1668
- https://github.com/confluentinc/kafka-connect-jdbc/pull/942
- https://github.com/confluentinc/kafka-connect-elasticsearch/pull/419