### PR TITLE
KREST-865 Remove usage of a deprecated Admin Client ConfigEntry constructor

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConfigSource.java
@@ -74,4 +74,12 @@ public enum ConfigSource {
       return UNKNOWN;
     }
   }
+
+  public static ConfigEntry.ConfigSource toAdminConfigSource(ConfigSource source) {
+    try {
+      return ConfigEntry.ConfigSource.valueOf(source.name());
+    } catch (IllegalArgumentException e) {
+      return ConfigEntry.ConfigSource.UNKNOWN;
+    }
+  }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/OpenConfigEntry.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/OpenConfigEntry.java
@@ -1,0 +1,51 @@
+package io.confluent.kafkarest;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.entities.AbstractConfig;
+import org.apache.kafka.clients.admin.ConfigEntry;
+
+/**
+ * A {@link ConfigEntry} that works around an unavailable public constructor for some fields that
+ * we expect to be able to configure in tests. We need to be able to do that as there are accessors
+ * for these fields in {@link ConfigEntry} and we use these to build {@link AbstractConfig}
+ * entities. So to set up tests correctly, it's most convenient to be able to set these fields too.
+ */
+public final class OpenConfigEntry extends ConfigEntry {
+
+  private final ConfigEntry.ConfigSource source;
+  private final boolean isSensitive;
+  private final boolean isReadOnly;
+
+  public OpenConfigEntry(
+      String name,
+      String value,
+      ConfigEntry.ConfigSource source,
+      boolean isSensitive,
+      boolean isReadOnly) {
+    super(name, value);
+    this.source = requireNonNull(source);
+    this.isSensitive = isSensitive;
+    this.isReadOnly = isReadOnly;
+  }
+
+  @Override
+  public ConfigSource source() {
+    return source;
+  }
+
+  @Override
+  public boolean isDefault() {
+    return source == ConfigSource.DEFAULT_CONFIG;
+  }
+
+  @Override
+  public boolean isSensitive() {
+    return isSensitive;
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return isReadOnly;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/BrokerConfigManagerImplTest.java
@@ -28,6 +28,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
+import io.confluent.kafkarest.OpenConfigEntry;
 import io.confluent.kafkarest.common.KafkaFutures;
 import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.BrokerConfig;
@@ -102,22 +103,22 @@ public class BrokerConfigManagerImplTest {
   private static final Config CONFIG =
       new Config(
           Arrays.asList(
-              new ConfigEntry(
+              new OpenConfigEntry(
                   CONFIG_1.getName(),
                   CONFIG_1.getValue(),
-                  CONFIG_1.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_1.getSource()),
                   CONFIG_1.isSensitive(),
                   CONFIG_1.isReadOnly()),
-              new ConfigEntry(
+              new OpenConfigEntry(
                   CONFIG_2.getName(),
                   CONFIG_2.getValue(),
-                  CONFIG_2.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_2.getSource()),
                   CONFIG_2.isSensitive(),
                   CONFIG_2.isReadOnly()),
-              new ConfigEntry(
+              new OpenConfigEntry(
                   CONFIG_3.getName(),
                   CONFIG_3.getValue(),
-                  CONFIG_3.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_3.getSource()),
                   CONFIG_3.isSensitive(),
                   CONFIG_3.isReadOnly())));
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ClusterConfigManagerImplTest.java
@@ -29,6 +29,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
+import io.confluent.kafkarest.OpenConfigEntry;
 import io.confluent.kafkarest.common.KafkaFutures;
 import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.Cluster;
@@ -105,22 +106,19 @@ public class ClusterConfigManagerImplTest {
               new OpenConfigEntry(
                   CONFIG_1.getName(),
                   CONFIG_1.getValue(),
-                  ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
-                  CONFIG_1.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_1.getSource()),
                   CONFIG_1.isSensitive(),
                   CONFIG_1.isReadOnly()),
               new OpenConfigEntry(
                   CONFIG_2.getName(),
                   CONFIG_2.getValue(),
-                  ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
-                  CONFIG_2.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_2.getSource()),
                   CONFIG_2.isSensitive(),
                   CONFIG_2.isReadOnly()),
               new OpenConfigEntry(
                   CONFIG_3.getName(),
                   CONFIG_3.getValue(),
-                  ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG,
-                  CONFIG_3.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_3.getSource()),
                   CONFIG_3.isSensitive(),
                   CONFIG_3.isReadOnly())));
 
@@ -393,27 +391,6 @@ public class ClusterConfigManagerImplTest {
       fail();
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());
-    }
-  }
-
-  private static final class OpenConfigEntry extends ConfigEntry {
-
-    private final ConfigEntry.ConfigSource source;
-
-    public OpenConfigEntry(
-        String name,
-        String value,
-        ConfigEntry.ConfigSource source,
-        boolean isDefault,
-        boolean isReadOnly,
-        boolean isSensitive) {
-      super(name, value, isDefault, isReadOnly, isSensitive);
-      this.source = requireNonNull(source);
-    }
-
-    @Override
-    public ConfigSource source() {
-      return source;
     }
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
+import io.confluent.kafkarest.OpenConfigEntry;
 import io.confluent.kafkarest.common.KafkaFutures;
 import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.Cluster;
@@ -103,22 +104,22 @@ public class TopicConfigManagerImplTest {
   private static final Config CONFIG =
       new Config(
           Arrays.asList(
-              new ConfigEntry(
+              new OpenConfigEntry(
                   CONFIG_1.getName(),
                   CONFIG_1.getValue(),
-                  CONFIG_1.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_1.getSource()),
                   CONFIG_1.isSensitive(),
                   CONFIG_1.isReadOnly()),
-              new ConfigEntry(
+              new OpenConfigEntry(
                   CONFIG_2.getName(),
                   CONFIG_2.getValue(),
-                  CONFIG_2.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_2.getSource()),
                   CONFIG_2.isSensitive(),
                   CONFIG_2.isReadOnly()),
-              new ConfigEntry(
+              new OpenConfigEntry(
                   CONFIG_3.getName(),
                   CONFIG_3.getValue(),
-                  CONFIG_3.isDefault(),
+                  ConfigSource.toAdminConfigSource(CONFIG_3.getSource()),
                   CONFIG_3.isSensitive(),
                   CONFIG_3.isReadOnly())));
 


### PR DESCRIPTION
That constructor was actually used a lot throughout the configuration management tests.
Because there's no good alternative for that constructor, a subtype mimicking the old constructor was added.

As the deprecated constructor is actually being removed in the most recent AK version, I'll go ahead and merge this once CI looks good. The PR will be available for post-merge reviews and for posterity.

Tested locally, by ensuring that the affected tests still pass, and that IntelliJ doesn't find any other usages of the deprecated constructor.

P.S. Moving away from this constructor also means it's better to change our `AbstractConfig` concept, so that it relies on the config source to determine whether the related config is default or not. That change however affects many classes, so it should come in a separate PR.