### PR TITLE
KREST-865 Remove string usages of the class name of the deprecated SimpleAclAuthorizer

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SecureTestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SecureTestUtils.java
@@ -27,7 +27,7 @@ public class SecureTestUtils {
   public static void setProduceAcls(String zkConnect, String topic, String user) {
     List<String> aclArgs = new ArrayList<>();
 
-    Collections.addAll(aclArgs, ("--authorizer kafka.security.auth.SimpleAclAuthorizer "
+    Collections.addAll(aclArgs, ("--authorizer kafka.security.authorizer.AclAuthorizer "
                                  + "--authorizer-properties  zookeeper.connect=" + zkConnect
                                  + " --topic " + topic + " --add --producer "
                                  + " --allow-principal ").split("\\s+"));
@@ -38,7 +38,7 @@ public class SecureTestUtils {
   public static void removeProduceAcls(String zkConnect, String topic, String user) {
     List<String> aclArgs = new ArrayList<>();
 
-    Collections.addAll(aclArgs, ("--authorizer kafka.security.auth.SimpleAclAuthorizer "
+    Collections.addAll(aclArgs, ("--authorizer kafka.security.authorizer.AclAuthorizer "
                                  + "--authorizer-properties  zookeeper.connect=" + zkConnect
                                  + " --topic " + topic + " --remove --producer "
                                  + " --allow-principal ").split("\\s+"));
@@ -52,7 +52,7 @@ public class SecureTestUtils {
   ) {
     List<String> aclArgs = new ArrayList<>();
 
-    Collections.addAll(aclArgs, ("--authorizer kafka.security.auth.SimpleAclAuthorizer "
+    Collections.addAll(aclArgs, ("--authorizer kafka.security.authorizer.AclAuthorizer "
                                  + "--authorizer-properties  zookeeper.connect=" + zkConnect
                                  + " --topic " + topic + " --add --consumer "
                                  + " --allow-principal ").split("\\s+"));

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
@@ -75,7 +75,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
 
   @Override
   public Properties overrideBrokerProperties(int i, Properties props) {
-    props.put("authorizer.class.name", "kafka.security.auth.SimpleAclAuthorizer");
+    props.put("authorizer.class.name", "kafka.security.authorizer.AclAuthorizer");
     props.put(
         "listener.name.sasl_plaintext.plain.sasl.jaas.config",
         "org.apache.kafka.common.security.plain.PlainLoginModule required "

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
@@ -122,7 +122,7 @@ public final class KafkaBrokerFixture extends ExternalResource {
           "listener.name.internal.plain.sasl.jaas.config", getBrokerPlainSaslJaasConfig());
       properties.setProperty("sasl.enabled.mechanisms", "PLAIN");
       properties.setProperty("sasl.mechanism.inter.broker.protocol", "PLAIN");
-      properties.setProperty("authorizer.class.name", "kafka.security.auth.SimpleAclAuthorizer");
+      properties.setProperty("authorizer.class.name", "kafka.security.authorizer.AclAuthorizer");
     }
     properties.setProperty("super.users", getSuperUsers());
     return properties;

--- a/testing/environments/sasl_plain/docker-compose.yml
+++ b/testing/environments/sasl_plain/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - ./kafka-jaas.conf:/etc/kafka/kafka-jaas.conf
     environment:
       KAFKA_ADVERTISED_LISTENERS: "SASL_PLAINTEXT://kafka-1:9191,EXTERNAL://localhost:9291"
-      KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.auth.SimpleAclAuthorizer"
+      KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.authorizer.AclAuthorizer"
       KAFKA_BROKER_ID: 1
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_INTER_BROKER_LISTENER_NAME: "SASL_PLAINTEXT"
@@ -62,7 +62,7 @@ services:
       - ./kafka-jaas.conf:/etc/kafka/kafka-jaas.conf
     environment:
       KAFKA_ADVERTISED_LISTENERS: "SASL_PLAINTEXT://kafka-2:9192,EXTERNAL://localhost:9292"
-      KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.auth.SimpleAclAuthorizer"
+      KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.authorizer.AclAuthorizer"
       KAFKA_BROKER_ID: 2
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_INTER_BROKER_LISTENER_NAME: "SASL_PLAINTEXT"
@@ -86,7 +86,7 @@ services:
       - ./kafka-jaas.conf:/etc/kafka/kafka-jaas.conf
     environment:
       KAFKA_ADVERTISED_LISTENERS: "SASL_PLAINTEXT://kafka-3:9193,EXTERNAL://localhost:9293"
-      KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.auth.SimpleAclAuthorizer"
+      KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.authorizer.AclAuthorizer"
       KAFKA_BROKER_ID: 3
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_INTER_BROKER_LISTENER_NAME: "SASL_PLAINTEXT"


### PR DESCRIPTION
There are various test files and utilities that use the deprecated class by having it set as a string property that gets loaded at runtime.
Because of them, the latest CI runs of `kafka-rest` on `master` fail spectacularly with tons of failures.

That problem wasn't visible in the downstream validation of the Kafka PR, where the `kafka-rest` validation seemed to have completed successfully.
- We need to figure out if the downstream validation did run the tests, but the report is just hidden somewhere in the full stage view of the CI job.

Like with #834, I'll go ahead and merge this once CI looks good.

Tested locally by running all tests in IntelliJ (all successful, except the flaky `KafkaConsumerManagerTest.testBackoffMsControlsPollCalls`), and by verifying that the `sasl_plain` environment can be started successfully, and that it can serve an `api.v3.clusters.list` call.