### PR TITLE
fix: resolve ProduceController early/outside of lambda

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -90,13 +90,14 @@ public final class ProduceAction {
       @PathParam("clusterId") String clusterId,
       @PathParam("topicName") String topicName,
       MappingIterator<ProduceRequest> requests) throws Exception {
+    ProduceController controller = produceController.get();
     StreamingResponse.from(requests)
-        .compose(request -> produce(clusterId, topicName, request))
+        .compose(request -> produce(clusterId, topicName, request, controller))
         .resume(asyncResponse);
   }
 
   private CompletableFuture<ProduceResponse> produce(
-      String clusterId, String topicName, ProduceRequest request) {
+      String clusterId, String topicName, ProduceRequest request, ProduceController controller) {
     Optional<RegisteredSchema> keySchema =
         request.getKey().flatMap(key -> getSchema(topicName, /* isKey= */ true, key));
     Optional<EmbeddedFormat> keyFormat =
@@ -114,7 +115,7 @@ public final class ProduceAction {
         serialize(topicName, valueFormat, valueSchema, request.getValue(), /* isKey= */ false);
 
     CompletableFuture<ProduceResult> produceResult =
-        produceController.get().produce(
+        controller.produce(
             clusterId,
             topicName,
             request.getPartitionId(),


### PR DESCRIPTION
There is a subtle bug in `produce` logic where KafkaRestCleanupFilter is called before the lambda function (passed to StreamingResponse) is executed. This has got to do with how jersey handles(or lack of thereof) `ChunkedOutput` during a request's lifecycle. Basically, once `AsyncResponse` is resumed the subsequent Filters are executed. This leads to `KafkaRestContextProvider` getting reset before the `produceController` can be resolved. As a result, the `KafkaRestContext` is not the one that is set by the client but instead is `DefaultKafkaRestContext`.

The fix in this PR is to resolve `produceController` outside of the lambda function.  A better fix, however, would be to 
1. Call `KafkaRestContextProvider.clearCurrentContext()` inside one of the lifecycle event listeners. 
2. If 1. is not possible then create a custom ListenableChunkedOuput class, register a close listener in `KafkaRestCleanupFilter`, and clear context once chunked response has finished.