### PR TITLE
KREST-600: Fix KafkaConsumerManagerTest.testBackoffMsControlsPollCalls flaky test.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -427,7 +427,8 @@ public class KafkaConsumerManagerTest {
       long actualNanos = pollTimestamps.get(i) - pollTimestamps.get(i-1);
       assertTrue(
           String.format(
-              "Expected time between poll calls to be at least 50ms, but was %sms.",
+              "Expected time between poll calls to be at least %dms, but was %sms.",
+              backoffMillis,
               TimeUnit.NANOSECONDS.toMillis(actualNanos)),
           actualNanos >= TimeUnit.MILLISECONDS.toNanos(backoffMillis));
     }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -32,8 +32,6 @@ import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.kafkarest.entities.v2.ConsumerOffsetCommitRequest;
 import io.confluent.kafkarest.entities.v2.ConsumerSubscriptionRecord;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,7 +89,7 @@ public class KafkaConsumerManagerTest {
 
     @Before
     public void setUp() {
-      setUpConsumer(setUpProperties());
+        setUpConsumer(setUpProperties());
     }
 
     private void setUpConsumer(Properties properties) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -33,7 +33,6 @@ import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.kafkarest.entities.v2.ConsumerOffsetCommitRequest;
 import io.confluent.kafkarest.entities.v2.ConsumerSubscriptionRecord;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Current way it is being tested, it relies on Thread.sleep to try to peek into the KafkaConsumerManager at right time. Problem is, 1. it is using the wrong time (it assumes the backoff is 250ms, when actually it is 50ms), and 2. it is peeking the wrong thing. I just looks if there's a delayed task, but that gives no guarantees the task is being retried at the given backoff. So I rewrote it to actually the backoff.

It was previously consistently failing 5% of time (out of 1000 runs). Now it fails 0%. :)

Example failure: https://jenkins.confluent.io/job/confluentinc/job/kafka-rest/job/6.0.x/480/testReport/junit/io.confluent.kafkarest.v2/KafkaConsumerManagerTest/testBackoffMsControlsPollCalls/