### PR TITLE
MMA-10490: include count of partitions in topic(s) response

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1560,6 +1560,7 @@ components:
             - topic_name
             - is_internal
             - replication_factor
+            - partitions_count
             - partitions
             - configs
             - partition_reassignments
@@ -1572,6 +1573,8 @@ components:
               type: boolean
             replication_factor:
               type: integer
+            partitions_count:
+                type: integer
             partitions:
               $ref: '#/components/schemas/Relationship'
             configs:
@@ -1738,6 +1741,7 @@ components:
             topic_name: 'topic-X'
             is_internal: false
             replication_factor: 3
+            partitions_count: 1
             partitions:
               related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-X/partitions'
             configs:
@@ -2099,6 +2103,7 @@ components:
             topic_name: 'topic-1'
             is_internal: false
             replication_factor: 3
+            partitions_count: 1
             partitions:
               related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions'
             configs:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -2732,6 +2732,7 @@ components:
                 topic_name: 'topic-1'
                 is_internal: false
                 replication_factor: 3
+                partitions_count: 1
                 partitions:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions'
                 configs:
@@ -2746,6 +2747,7 @@ components:
                 topic_name: 'topic-2'
                 is_internal: true
                 replication_factor: 4
+                partitions_count: 1
                 partitions:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions'
                 configs:
@@ -2760,6 +2762,7 @@ components:
                 topic_name: 'topic-3'
                 is_internal: false
                 replication_factor: 5
+                partitions_count: 1
                 partitions:
                   related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions'
                 configs:

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -38,6 +38,9 @@ public abstract class TopicData extends Resource {
   @JsonProperty("replication_factor")
   public abstract int getReplicationFactor();
 
+  @JsonProperty("partitions_count")
+  public abstract int getPartitionsCount();
+
   @JsonProperty("partitions")
   public abstract Relationship getPartitions();
 
@@ -56,7 +59,8 @@ public abstract class TopicData extends Resource {
         .setClusterId(topic.getClusterId())
         .setTopicName(topic.getName())
         .setInternal(topic.isInternal())
-        .setReplicationFactor(topic.getReplicationFactor());
+        .setReplicationFactor(topic.getReplicationFactor())
+        .setPartitionsCount(topic.getPartitions().size());
   }
 
   @JsonCreator
@@ -97,6 +101,8 @@ public abstract class TopicData extends Resource {
     public abstract Builder setInternal(boolean isInternal);
 
     public abstract Builder setReplicationFactor(int replicationFactor);
+
+    public abstract Builder setPartitionsCount(int partitionsCount);
 
     public abstract Builder setPartitions(Relationship partitions);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -71,6 +71,7 @@ public abstract class TopicData extends Resource {
       @JsonProperty("topic_name") String topicName,
       @JsonProperty("is_internal") boolean isInternal,
       @JsonProperty("replication_factor") int replicationFactor,
+      @JsonProperty("partitions_count") int partitionsCount,
       @JsonProperty("partitions") Relationship partitions,
       @JsonProperty("configs") Relationship configs,
       @JsonProperty("partition_reassignments") Relationship partitionReassignments
@@ -82,6 +83,7 @@ public abstract class TopicData extends Resource {
         .setTopicName(topicName)
         .setInternal(isInternal)
         .setReplicationFactor(replicationFactor)
+        .setPartitionsCount(partitionsCount)
         .setPartitions(partitions)
         .setConfigs(configs)
         .setPartitionReassignments(partitionReassignments)

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -334,7 +334,8 @@ public class TopicsResourceTest {
   private static TopicData newTopicData(
       String topicName,
       boolean isInternal,
-      int replicationFactor) {
+      int replicationFactor,
+      int partitionsCount) {
     return TopicData.builder()
         .setMetadata(
             Resource.Metadata.builder()
@@ -355,6 +356,7 @@ public class TopicsResourceTest {
             Resource.Relationship.create(
                 String.format("/v3/clusters/cluster-1/topics/%s/partitions/-/reassignment",
                     topicName)))
+        .setPartitionsCount(partitionsCount)
         .build();
   }
 
@@ -385,9 +387,9 @@ public class TopicsResourceTest {
                         .build())
                 .setData(
                     Arrays.asList(
-                        newTopicData("topic-1", true, 3),
-                        newTopicData("topic-2", true, 3),
-                        newTopicData("topic-3", false, 3)))
+                        newTopicData("topic-1", true, 3, 3),
+                        newTopicData("topic-2", true, 3, 3),
+                        newTopicData("topic-3", false, 3, 3)))
                 .build());
 
     assertEquals(expected, response.getValue());
@@ -427,7 +429,7 @@ public class TopicsResourceTest {
     topicsResource.getTopic(response, TOPIC_1.getClusterId(), TOPIC_1.getName());
 
     GetTopicResponse expected =
-        GetTopicResponse.create(newTopicData("topic-1", true, 3));
+        GetTopicResponse.create(newTopicData("topic-1", true, 3, 3));
 
     assertEquals(expected, response.getValue());
   }
@@ -482,7 +484,7 @@ public class TopicsResourceTest {
             .build());
 
     CreateTopicResponse expected =
-        CreateTopicResponse.create(newTopicData("topic-1", false, 3));
+        CreateTopicResponse.create(newTopicData("topic-1", false, 3, 0));
 
     assertEquals(expected, response.getValue());
   }
@@ -512,7 +514,7 @@ public class TopicsResourceTest {
             .build());
 
     CreateTopicResponse expected =
-        CreateTopicResponse.create(newTopicData("topic-1", false, 3));
+        CreateTopicResponse.create(newTopicData("topic-1", false, 3, 0));
 
     assertEquals(expected, response.getValue());
   }
@@ -542,7 +544,7 @@ public class TopicsResourceTest {
             .build());
 
     CreateTopicResponse expected =
-        CreateTopicResponse.create(newTopicData("topic-1", false, 0));
+        CreateTopicResponse.create(newTopicData("topic-1", false, 0, 0));
 
     assertEquals(expected, response.getValue());
   }
@@ -585,7 +587,7 @@ public class TopicsResourceTest {
 
     short expectedReplicationFactor = (short) (TOPIC_1.getReplicationFactor() - 1);
     CreateTopicResponse expected = CreateTopicResponse.create(
-        newTopicData("topic-1", false, expectedReplicationFactor));
+        newTopicData("topic-1", false, expectedReplicationFactor, 0));
 
     assertEquals(expected, response.getValue());
   }


### PR DESCRIPTION
**What**
Get useful meta info without making an additional call to fetch the full partition data. 

**Why**
For the web clients that show topic data in a single view (e.g. table), making an additional call to get and display partition count leads to an inefficient fetch pattern. 