### PR TITLE
fix integration test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -96,6 +96,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             .setTopicName(TOPIC_1)
                             .setInternal(false)
                             .setReplicationFactor(1)
+                            .setPartitionsCount(1)
                             .setPartitions(
                                 Resource.Relationship.create(
                                     baseUrl
@@ -129,6 +130,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             .setTopicName(TOPIC_2)
                             .setInternal(false)
                             .setReplicationFactor(1)
+                            .setPartitionsCount(1)
                             .setPartitions(
                                 Resource.Relationship.create(
                                     baseUrl
@@ -162,6 +164,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             .setTopicName(TOPIC_3)
                             .setInternal(false)
                             .setReplicationFactor(1)
+                            .setPartitionsCount(1)
                             .setPartitions(
                                 Resource.Relationship.create(
                                     baseUrl
@@ -224,6 +227,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(TOPIC_1)
                 .setInternal(false)
                 .setReplicationFactor(1)
+                .setPartitionsCount(1)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -288,6 +292,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(topicName)
                 .setInternal(false)
                 .setReplicationFactor(1)
+                .setPartitionsCount(0)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -346,6 +351,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(topicName)
                 .setInternal(false)
                 .setReplicationFactor(2) // As determined by the actual replicas asignments below.
+                .setPartitionsCount(0)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -480,6 +486,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(topicName)
                 .setInternal(false)
                 .setReplicationFactor(0)
+                .setPartitionsCount(0)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -536,6 +543,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(topicName)
                 .setInternal(false)
                 .setReplicationFactor(2)
+                .setPartitionsCount(1)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl


### PR DESCRIPTION
**What**
Fix the integration test failure. The change here though includes more than just the fix for the test. `TopicManager.createTopic` has been changed to return `CreateTopicsResult` instead of void. Few advantages of doing this
1. Caller can decide how it wants to use `CreateTopicsResult` ([example](https://github.com/confluentinc/kafka-rest/pull/845/files#diff-0811689ae333a0789fa5a6c9911332eeb8fb48ebfac0f0401ff329f4d9b6375fR681)). On the flip side, it is the responsibility of the caller now to make sure create has succeeded. This is not a publicly exposed API so no impact on backward compatibility.
2. Allows us to return the correct partition count vs passing back arbitrary value.
