### PR TITLE
KREST-481 Fix a problem with configuring monitoring interceptors

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -357,6 +357,13 @@ public class KafkaRestConfig extends RestConfig {
       "Whether to enable REST Proxy V3 API. Default is true.";
   private static final boolean API_V3_ENABLE_DEFAULT = true;
 
+  // These property names should not be filtered out when determining the allowed properties for
+  // producer and consumer configs. See KREST-481 for more details.
+  private static final String MONITORING_INTERCEPTOR_TOPIC_CONFIG =
+      "confluent.monitoring.interceptor.topic";
+  private static final String MONITORING_INTERCEPTOR_PUBLISH_MS_PERIOD_CONFIG =
+      "confluent.monitoring.interceptor.publishMs";
+
   private static final ConfigDef config;
 
   static {
@@ -833,8 +840,16 @@ public class KafkaRestConfig extends RestConfig {
     return configs;
   }
 
+  private static Set<String> getAllowedProducerConfigNames() {
+    return ImmutableSet.<String>builder()
+        .addAll(ProducerConfig.configNames())
+        .add(MONITORING_INTERCEPTOR_TOPIC_CONFIG)
+        .add(MONITORING_INTERCEPTOR_PUBLISH_MS_PERIOD_CONFIG)
+        .build();
+  }
+
   public Properties getProducerProperties() {
-    Set<String> mask = ProducerConfig.configNames();
+    Set<String> mask = getAllowedProducerConfigNames();
     Map<String, Object> producerConfigs =
         new ConfigsBuilder(mask)
             .addConfig(BOOTSTRAP_SERVERS_CONFIG)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -840,16 +840,13 @@ public class KafkaRestConfig extends RestConfig {
     return configs;
   }
 
-  private static Set<String> getAllowedProducerConfigNames() {
-    return ImmutableSet.<String>builder()
-        .addAll(ProducerConfig.configNames())
-        .add(MONITORING_INTERCEPTOR_TOPIC_CONFIG)
-        .add(MONITORING_INTERCEPTOR_PUBLISH_MS_PERIOD_CONFIG)
-        .build();
-  }
-
   public Properties getProducerProperties() {
-    Set<String> mask = getAllowedProducerConfigNames();
+    Set<String> mask =
+        ImmutableSet.<String>builder()
+            .addAll(ProducerConfig.configNames())
+            .add(MONITORING_INTERCEPTOR_TOPIC_CONFIG)
+            .add(MONITORING_INTERCEPTOR_PUBLISH_MS_PERIOD_CONFIG)
+            .build();
     Map<String, Object> producerConfigs =
         new ConfigsBuilder(mask)
             .addConfig(BOOTSTRAP_SERVERS_CONFIG)


### PR DESCRIPTION
Fully testing this (running the system test with the updated `kafka-rest` sources) is quite laborious and finicky, so I'm still in the process of doing that.
- I'm following https://github.com/confluentinc/muckrake/blob/master/ducker/README.md#creating-your-own-ducker-images and have hit and fixed multiple different problems so far.

Still, I was able to check on a local `kafka-rest` instance that with the following added to the config properties:
```
consumer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
consumer.confluent.monitoring.interceptor.topic=_confluent-monitoring-ddimitrov-consumer
consumer.confluent.monitoring.interceptor.publishMs=1000
producer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
producer.confluent.monitoring.interceptor.topic=_confluent-monitoring-ddimitrov-producer
producer.confluent.monitoring.interceptor.publishMs=1000
```
both the producer and the consumer interceptors had correctly configured topic names and the publish delay.