### PR TITLE
KREST-1187: Propagate client.sasl.jaas.config to Schema Registry.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -49,6 +49,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Range;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -742,7 +743,13 @@ public class KafkaRestConfig extends RestConfig {
   }
 
   public Map<String, Object> getSchemaRegistryConfigs() {
-    Set<String> mask = AbstractKafkaSchemaSerDeConfig.baseConfigDef().names();
+    ImmutableSet<String> mask =
+        ImmutableSet.<String>builder()
+            .addAll(AbstractKafkaSchemaSerDeConfig.baseConfigDef().names())
+            // If schema.registry.basic.auth.credentials.source=SASL_INHERIT, then SR credentials
+            // come from client.sasl.jaas.config.
+            .add(SaslConfigs.SASL_JAAS_CONFIG)
+            .build();
     Map<String, Object> configs =
         new HashMap<>(
             new ConfigsBuilder(mask)

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/JsonParsingErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/JsonParsingErrorTest.java
@@ -15,25 +15,18 @@
 
 package io.confluent.kafkarest.integration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class JsonParsingErrorTest extends ClusterTestHarness {
 
   public JsonParsingErrorTest() {
     super(/* numBrokers= */ 1, /* withSchemaRegistry= */ false);
-  }
-
-  @BeforeEach
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.kafkarest.entities.v3.ProduceRequest;
+import io.confluent.kafkarest.entities.v3.ProduceRequest.ProduceRequestData;
+import io.confluent.kafkarest.entities.v3.ProduceResponse;
+import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
+import io.confluent.kafkarest.testing.*;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SchemaRegistrySaslInheritTest {
+  private static final String TOPIC_NAME = "topic-1";
+
+  private final JvmPropertyFileLoginModuleFixture jaasConfig =
+      JvmPropertyFileLoginModuleFixture.builder()
+          .setName("SchemaRegistryServer")
+          .addUser("kafka-rest", "kafka-rest-pass", "user")
+          .addUser("schema-registry", "schema-registry-pass", "user")
+          .build();
+
+  private final ZookeeperFixture zookeeper = ZookeeperFixture.create();
+
+  private final KafkaClusterFixture kafkaCluster =
+      KafkaClusterFixture.builder()
+          .addUser("kafka-rest", "kafka-rest-pass")
+          .addUser("schema-registry", "schema-registry-pass")
+          .addSuperUser("kafka-rest")
+          .addSuperUser("schema-registry")
+          .setNumBrokers(3)
+          .setSecurityProtocol(SecurityProtocol.SASL_PLAINTEXT)
+          .setZookeeper(zookeeper)
+          .build();
+
+  private final SchemaRegistryFixture schemaRegistry =
+      SchemaRegistryFixture.builder()
+          .setConfig("authentication.method", "BASIC")
+          .setClientConfig("basic.auth.credentials.source", "USER_INFO")
+          .setClientConfig("basic.auth.user.info", "schema-registry:schema-registry-pass")
+          .setConfig("authentication.realm", "SchemaRegistryServer")
+          .setConfig("authentication.roles", "user")
+          .setKafkaCluster(kafkaCluster)
+          .setKafkaUser("schema-registry", "schema-registry-pass")
+          .build();
+
+  private final KafkaRestFixture kafkaRest =
+      KafkaRestFixture.builder()
+          .setConfig("producer.max.block.ms", "5000")
+          .setConfig("schema.registry.basic.auth.credentials.source", "SASL_INHERIT")
+          .setKafkaCluster(kafkaCluster)
+          .setKafkaUser("kafka-rest", "kafka-rest-pass")
+          .setSchemaRegistry(schemaRegistry)
+          .build();
+
+  @Rule
+  public final TestRule rules =
+      RuleChain.outerRule(jaasConfig)
+          .around(zookeeper)
+          .around(kafkaCluster)
+          .around(schemaRegistry)
+          .around(kafkaRest);
+
+  @Before
+  public void setUp() throws Exception {
+    kafkaCluster.createTopic(TOPIC_NAME, 3, (short) 1);
+  }
+
+  @Test
+  public void produceAvroWithRawSchema() throws Exception {
+    String clusterId = kafkaCluster.getClusterId();
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.AVRO)
+                    .setRawSchema("{\"type\": \"string\"}")
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.AVRO)
+                    .setRawSchema("{\"type\": \"string\"}")
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .build();
+
+    Response response =
+        kafkaRest
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .request()
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    ProduceResponse actual = readProduceResponse(response);
+    ConsumerRecord<Object, Object> produced =
+        kafkaCluster
+            .getRecord(
+                TOPIC_NAME,
+                actual.getPartitionId(),
+                actual.getOffset(),
+                schemaRegistry.createAvroDeserializer(),
+                schemaRegistry.createAvroDeserializer());
+    assertEquals(key, produced.key());
+    assertEquals(value, produced.value());
+  }
+
+  private static ProduceResponse readProduceResponse(Response response) {
+    response.bufferEntity();
+    try {
+      return response.readEntity(ProduceResponse.class);
+    } catch (ProcessingException e) {
+      throw new RuntimeException(response.readEntity(ErrorResponse.class).toString(), e);
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
@@ -64,9 +64,9 @@ public class SchemaRegistrySaslInheritTest {
 
   private final SchemaRegistryFixture schemaRegistry =
       SchemaRegistryFixture.builder()
-          .setConfig("authentication.method", "BASIC")
           .setClientConfig("basic.auth.credentials.source", "USER_INFO")
           .setClientConfig("basic.auth.user.info", "schema-registry:schema-registry-pass")
+          .setConfig("authentication.method", "BASIC")
           .setConfig("authentication.realm", "SchemaRegistryServer")
           .setConfig("authentication.roles", "user")
           .setKafkaCluster(kafkaCluster)

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/JvmPropertyFileLoginModuleFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/JvmPropertyFileLoginModuleFixture.java
@@ -28,10 +28,22 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.security.JaasUtils;
 import org.junit.rules.ExternalResource;
 
+/**
+ * An {@link ExternalResource} that creates and sets a {@link
+ * org.eclipse.jetty.jaas.spi.PropertyFileLoginModule} as the default Java Login Module.
+ *
+ * <p>This fixture should be used only when you don't have any other option, for example, when
+ * configuring Kafka REST or Schema Registry Basic Authentication. Using it might cause unforeseen
+ * side-effects. For example, any Kafka client that does not set {@code sasl.jaas.config} will use
+ * the JAAS file created instead, and fail since it has no section named {@code KafkaClient}.
+ * Instead of using this fixture, you should use the respective {@code sasl.jaas.config} config
+ * whenever possible, for example, {@code client.sasl.jaas.config} in Kafka REST.
+ */
 public final class JvmPropertyFileLoginModuleFixture extends ExternalResource {
 
   private final String name;
@@ -100,11 +112,17 @@ public final class JvmPropertyFileLoginModuleFixture extends ExternalResource {
     private Builder() {
     }
 
+    /**
+     * Adds a {@code username: password,role1,role2,...} line in the users properties file.
+     */
     public Builder addUser(String username, String password, String... roles) {
       users.put(username, PasswordAndRoles.create(password, Arrays.asList(roles)));
       return this;
     }
 
+    /**
+     * Sets the name of the section in the JAAS file.
+     */
     public Builder setName(String name) {
       this.name = name;
       return this;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/JvmPropertyFileLoginModuleFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/JvmPropertyFileLoginModuleFixture.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nullable;
+import javax.security.auth.login.Configuration;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.security.JaasUtils;
+import org.junit.rules.ExternalResource;
+
+public final class JvmPropertyFileLoginModuleFixture extends ExternalResource {
+
+  private final String name;
+  private final ImmutableMap<String, PasswordAndRoles> users;
+
+  @Nullable private Path jaasConfig;
+  @Nullable private Path passConfig;
+
+  public JvmPropertyFileLoginModuleFixture(String name, Map<String, PasswordAndRoles> users) {
+    this.name = requireNonNull(name);
+    this.users = ImmutableMap.copyOf(users);
+  }
+
+  @Override
+  protected void before() throws Exception {
+    jaasConfig = Files.createTempFile("jaas-config-", ".conf");
+    passConfig = Files.createTempFile("pass-config-", ".properties");
+    Files.write(
+        jaasConfig,
+        ImmutableList.of(
+            name + " {",
+            "  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required",
+            "  file=\"" + passConfig + "\"",
+            "  debug=\"true\";",
+            "};"));
+    Files.write(
+        passConfig,
+        users.entrySet()
+            .stream()
+            .map(entry -> entry.getKey() + ": " + entry.getValue().toString())
+            .collect(Collectors.toList()));
+    System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, jaasConfig.toString());
+    Configuration.setConfiguration(null);
+  }
+
+  @Override
+  protected void after() {
+    System.clearProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM);
+    Configuration.setConfiguration(null);
+    if (jaasConfig != null) {
+      try {
+        Files.delete(jaasConfig);
+      } catch (IOException e) {
+        // Do nothing.
+      }
+      jaasConfig = null;
+    }
+    if (passConfig != null) {
+      try {
+        Files.delete(passConfig);
+      } catch (IOException e) {
+        // Do nothing.
+      }
+      passConfig = null;
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    @Nullable private String name;
+    private ImmutableMap.Builder<String, PasswordAndRoles> users = ImmutableMap.builder();
+
+    private Builder() {
+    }
+
+    public Builder addUser(String username, String password, String... roles) {
+      users.put(username, PasswordAndRoles.create(password, Arrays.asList(roles)));
+      return this;
+    }
+
+    public Builder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public JvmPropertyFileLoginModuleFixture build() {
+      return new JvmPropertyFileLoginModuleFixture(name, users.build());
+    }
+  }
+
+  @AutoValue
+  abstract static class PasswordAndRoles {
+
+    PasswordAndRoles() {
+    }
+
+    abstract String getPassword();
+
+    abstract ImmutableList<String> getRoles();
+
+    @Override
+    public final String toString() {
+      return getPassword() + (getRoles().isEmpty() ? "" : ("," + String.join(",", getRoles())));
+    }
+
+    private static PasswordAndRoles create(String password, List<String> roles) {
+      return new AutoValue_JvmPropertyFileLoginModuleFixture_PasswordAndRoles(
+          password, ImmutableList.copyOf(roles));
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
@@ -40,6 +40,9 @@ import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.rules.ExternalResource;
 
+/**
+ * An {@link ExternalResource} that runs a Kafka broker.
+ */
 public final class KafkaBrokerFixture extends ExternalResource {
 
   private static final ImmutableMap<String, String> CONFIG_TEMPLATE =
@@ -239,50 +242,81 @@ public final class KafkaBrokerFixture extends ExternalResource {
     private Builder() {
     }
 
+    /**
+     * Adds a SASL PLAIN user.
+     */
     public Builder addUser(String username, String password) {
       users.put(username, password);
       return this;
     }
 
+    /**
+     * @see #addUser(String, String)
+     */
     public Builder addUsers(Map<String, String> users) {
       this.users.putAll(users);
       return this;
     }
 
+    /**
+     * Sets the given SASL PLAIN user as a super-user.
+     */
     public Builder addSuperUser(String username) {
       checkArgument(users.build().containsKey(username));
       superUsers.add(username);
       return this;
     }
 
+    /**
+     * @see #addSuperUser(String)
+     */
     public Builder addSuperUsers(Set<String> superUsers) {
       checkArgument(users.build().keySet().containsAll(superUsers));
       this.superUsers.addAll(superUsers);
       return this;
     }
 
+    /**
+     * Sets the broker ID.
+     */
     public Builder setBrokerId(int brokerId) {
       checkArgument(brokerId >= 0);
       this.brokerId = brokerId;
       return this;
     }
 
+    /**
+     * Sets the SSL certificate store, and the name of the certificate to use as the broker
+     * certificate.
+     */
     public Builder setCertificate(SslFixture certificates, String keyName) {
       this.certificates = requireNonNull(certificates);
       this.keyName = requireNonNull(keyName);
       return this;
     }
 
+    /**
+     * Sets the given broker config.
+     */
     public Builder setConfig(String name, String value) {
       configs.put(name, value);
       return this;
     }
 
+    /**
+     * @see #setConfig(String, String)
+     */
     public Builder setConfigs(Map<String, String> configs) {
       this.configs.putAll(configs);
       return this;
     }
 
+    /**
+     * Sets the broker security protocol.
+     *
+     * <p>For the {@link SecurityProtocol#SASL_PLAINTEXT} or {@link SecurityProtocol#SASL_SSL}
+     * protocols, only the PLAIN mechanism is supported.
+     */
     public Builder setSecurityProtocol(SecurityProtocol securityProtocol) {
       this.securityProtocol = requireNonNull(securityProtocol);
       return this;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaClusterFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaClusterFixture.java
@@ -43,6 +43,9 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.junit.rules.ExternalResource;
 
+/**
+ * An {@link ExternalResource} that runs a {@link KafkaBrokerFixture Kafka} cluster.
+ */
 public final class KafkaClusterFixture extends ExternalResource {
 
   private final ImmutableList<KafkaBrokerFixture> brokers;
@@ -183,11 +186,17 @@ public final class KafkaClusterFixture extends ExternalResource {
     private Builder() {
     }
 
+    /**
+     * @see KafkaBrokerFixture.Builder#addUser(String, String)
+     */
     public Builder addUser(String username, String password) {
       users.put(username, password);
       return this;
     }
 
+    /**
+     * @see KafkaBrokerFixture.Builder#addSuperUser(String)
+     */
     public Builder addSuperUser(String username) {
       checkArgument(users.build().containsKey(username));
       superUsers.add(username);
@@ -200,6 +209,9 @@ public final class KafkaClusterFixture extends ExternalResource {
       return this;
     }
 
+    /**
+     * @see KafkaBrokerFixture.Builder#setConfig(String, String)
+     */
     public Builder setConfig(String name, String value) {
       configs.put(name, value);
       return this;
@@ -211,6 +223,9 @@ public final class KafkaClusterFixture extends ExternalResource {
       return this;
     }
 
+    /**
+     * @see KafkaBrokerFixture.Builder#setSecurityProtocol(SecurityProtocol)
+     */
     public Builder setSecurityProtocol(SecurityProtocol securityProtocol) {
       this.securityProtocol = requireNonNull(securityProtocol);
       return this;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaRestFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaRestFixture.java
@@ -33,6 +33,9 @@ import javax.ws.rs.client.WebTarget;
 import org.eclipse.jetty.server.Server;
 import org.junit.rules.ExternalResource;
 
+/**
+ * An {@link ExternalResource} that runs a Kafka REST server.
+ */
 public final class KafkaRestFixture extends ExternalResource {
 
   @Nullable private final SslFixture certificates;
@@ -185,12 +188,19 @@ public final class KafkaRestFixture extends ExternalResource {
     private Builder() {
     }
 
+    /**
+     * Sets the SSL certificate store, and the name of the certificate to use as the Kafka REST
+     * certificate.
+     */
     public Builder setCertificates(SslFixture certificates, String keyName) {
       this.certificates = requireNonNull(certificates);
       this.keyName = requireNonNull(keyName);
       return this;
     }
 
+    /**
+     * Sets a Kafka REST config.
+     */
     public Builder setConfig(String name, String value) {
       configs.put(name, value);
       return this;
@@ -201,6 +211,9 @@ public final class KafkaRestFixture extends ExternalResource {
       return this;
     }
 
+    /**
+     * Sets the Kafka SASL PLAIN credentials.
+     */
     public Builder setKafkaUser(String username, String password) {
       this.kafkaUser = requireNonNull(username);
       this.kafkaPassword = requireNonNull(password);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
@@ -43,6 +43,9 @@ import javax.annotation.Nullable;
 import org.eclipse.jetty.server.Server;
 import org.junit.rules.ExternalResource;
 
+/**
+ * An {@link ExternalResource} that runs a Schema Registry server.
+ */
 public final class SchemaRegistryFixture extends ExternalResource {
 
   @Nullable private final SslFixture certificates;
@@ -198,17 +201,29 @@ public final class SchemaRegistryFixture extends ExternalResource {
     private Builder() {
     }
 
+    /**
+     * Sets the SSL certificate store, and the name of the certificate to use as the schema registry
+     * certificate.
+     */
     public Builder setCertificates(SslFixture certificates, String keyName) {
       this.certificates = requireNonNull(certificates);
       this.keyName = requireNonNull(keyName);
       return this;
     }
 
+    /**
+     * Sets a {@link SchemaRegistryClient client} config.
+     *
+     * @see SchemaRegistryFixture#getClient()
+     */
     public Builder setClientConfig(String name, String value) {
       clientConfigs.put(name, value);
       return this;
     }
 
+    /**
+     * Sets a Schema Registry server config.
+     */
     public Builder setConfig(String name, String value) {
       configs.put(name, value);
       return this;
@@ -219,12 +234,14 @@ public final class SchemaRegistryFixture extends ExternalResource {
       return this;
     }
 
+    /**
+     * Sets the Kafka SASL PLAIN credentials.
+     */
     public Builder setKafkaUser(String username, String password) {
       this.kafkaUser = requireNonNull(username);
       this.kafkaPassword = requireNonNull(password);
       return this;
     }
-
 
     public SchemaRegistryFixture build() {
       return new SchemaRegistryFixture(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
@@ -46,6 +46,7 @@ import org.junit.rules.ExternalResource;
 public final class SchemaRegistryFixture extends ExternalResource {
 
   @Nullable private final SslFixture certificates;
+  private final ImmutableMap<String, String> clientConfigs;
   private final ImmutableMap<String, String> configs;
   private final KafkaClusterFixture kafkaCluster;
   @Nullable private final String kafkaPassword;
@@ -58,6 +59,7 @@ public final class SchemaRegistryFixture extends ExternalResource {
 
   private SchemaRegistryFixture(
       @Nullable SslFixture certificates,
+      Map<String, String> clientConfigs,
       Map<String, String> configs,
       KafkaClusterFixture kafkaCluster,
       @Nullable String kafkaPassword,
@@ -66,6 +68,7 @@ public final class SchemaRegistryFixture extends ExternalResource {
     checkArgument(kafkaUser != null ^ kafkaPassword == null);
     checkArgument(certificates != null ^ keyName == null);
     this.certificates = certificates;
+    this.clientConfigs = ImmutableMap.copyOf(clientConfigs);
     this.configs = ImmutableMap.copyOf(configs);
     this.kafkaCluster = requireNonNull(kafkaCluster);
     this.kafkaPassword = kafkaPassword;
@@ -134,6 +137,7 @@ public final class SchemaRegistryFixture extends ExternalResource {
     if (certificates != null) {
       configs.putAll(certificates.getSslConfigs(keyName, "schema.registry."));
     }
+    configs.putAll(clientConfigs);
     return configs.build();
   }
 
@@ -184,6 +188,7 @@ public final class SchemaRegistryFixture extends ExternalResource {
 
   public static final class Builder {
     private SslFixture certificates = null;
+    private final ImmutableMap.Builder<String, String> clientConfigs = ImmutableMap.builder();
     private final ImmutableMap.Builder<String, String> configs = ImmutableMap.builder();
     private KafkaClusterFixture kafkaCluster;
     private String kafkaPassword = null;
@@ -196,6 +201,11 @@ public final class SchemaRegistryFixture extends ExternalResource {
     public Builder setCertificates(SslFixture certificates, String keyName) {
       this.certificates = requireNonNull(certificates);
       this.keyName = requireNonNull(keyName);
+      return this;
+    }
+
+    public Builder setClientConfig(String name, String value) {
+      clientConfigs.put(name, value);
       return this;
     }
 
@@ -218,7 +228,13 @@ public final class SchemaRegistryFixture extends ExternalResource {
 
     public SchemaRegistryFixture build() {
       return new SchemaRegistryFixture(
-          certificates, configs.build(), kafkaCluster, kafkaPassword, kafkaUser, keyName);
+          certificates,
+          clientConfigs.build(),
+          configs.build(),
+          kafkaCluster,
+          kafkaPassword,
+          kafkaUser,
+          keyName);
     }
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/ZookeeperFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/ZookeeperFixture.java
@@ -21,6 +21,11 @@ import javax.annotation.Nullable;
 import kafka.zk.EmbeddedZookeeper;
 import org.junit.rules.ExternalResource;
 
+/**
+ * An {@link ExternalResource} that runs a Zookeeper server.
+ *
+ * <p>This fixture currently does not support SSL and/or SASL.
+ */
 public final class ZookeeperFixture extends ExternalResource {
 
   @Nullable private EmbeddedZookeeper zookeeper;


### PR DESCRIPTION
Schema Registry client needs `sasl.jaas.config` when `basic.auth.credentials.source=SASL_INHERIT`.