### PR TITLE
KREST-1029 Remove SLF4J versioning from kafka-rest.

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${log4j.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
 
     <properties>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <log4j.version>1.7.25</log4j.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 


### PR DESCRIPTION
#317 fixed a problem with a missing SLF4J dependency - apparently the problem was related to migrating a lot of the dependency management into `common`. Unfortunately the fix also introduced versioning for the dependency in `kafka-rest` while the same SLF4J dependency was already versioned and managed in `common`.

This change removes that versioning, in order to allow that dependency (which is a sensitive one, as it transitively includes a vulnerable version of Log4J) to be entirely managed in `common`.

The change was tested locally, by ensuring that a clean local build passes.
In addition to that, locally I merged the change up to `master` to see what problems should be expected with `pint merge`. It turns out that the version is added to one other subproject in `5.3.x` (so it has to be removed from there too, otherwise the `5.3.x` build fails), and then later in `6.0.x` that subproject is removed (so a conflict will arise and it needs to be handled).

I'll post a separate PR for `5.3.x` which should address the problem if this PR is merged with "Rebase and merge", and reference this PR in it.