### PR TITLE
KREST-1029 Fix SLF4J versioning in 5.3.x.

### DIFF
--- a/kafka-rest-scala-consumer/pom.xml
+++ b/kafka-rest-scala-consumer/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${log4j.version}</version>
         </dependency>
         <!--
             This is a workaround for IntelliJ which seems to have a problem including junit + hamcrest

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${log4j.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
 
     <properties>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <log4j.version>1.7.25</log4j.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 


### PR DESCRIPTION
See #851.

This is a follow-up to the KREST-1029 fix which removes an unnecessary SLF4J versioning from `kafka-rest`. Here we also have to remove the version from one other place where it's being used. After #851 is merged (ideally with "Rebase and merge"), and this PR follows it, we should be able to `pint merge` the change up to `6.0.x`, and after a conflict fix there, again up to `master`.