### PR TITLE
KREST-1263 Exclude a vulnerable jackson-mapper-asl dependency from avro 1.8.2 in 5.3.x.

### DIFF
--- a/kafka-rest-common/pom.xml
+++ b/kafka-rest-common/pom.xml
@@ -9,6 +9,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <repositories>
+        <repository>
+            <id>redhat-repo</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
+    </repositories>
+
     <artifactId>kafka-rest-common</artifactId>
     <packaging>jar</packaging>
     <name>kafka-rest-common</name>
@@ -22,6 +29,17 @@
             <artifactId>avro</artifactId>
             <version>1.8.2</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.14.jdk17-redhat-00001</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Our `5.3.x` branch peculiarly includes a vulnerable transitive dependency to `jackson-mapper-asl:1.9.13` which is not present in `5.2.x` or `5.4.x`. This dependency comes via a direct dependency to `avro:1.8.2` that we specify in the `kafka-rest-common` module.
- In `5.2.x` there's no `kafka-rest-common` module;
- In `5.4.x` the `avro` dependency has been bumped to `1.9.1`;

This change specifically excludes `jackson-mapper-asl` from `avro` in `kafka-rest-common` on `5.3.x`.

I'm still hesitating whether to merge this upwards to `5.5.x`, as like previously explained `5.4.x` (and `5.5.x`) use newer versions of `avro`, and on `6.0.x` and upwards, there's no `kafka-rest-common` module again.
- On one hand, excluding it will also prevent vulnerabilities from future versions of `jackson-mapper-asl` affecting `5.4.x` and `5.5.x`.
- On the other hand, ideally such problems should be resolved by `avro` dumping on their side, and us bumping `avro` on our side. Also while I did some exploratory testing of `5.3.x`, I will have to invest 3x the time to do the same for `5.4.x` and `5.5.x`.

Finally, the `avro` we specify in `kafka-rest-common` uses an explicit version, and not the `avro.version` variable. It's probably a good idea to use the latter, but this should be done in a separate change.