### PR TITLE
KREST-1334 Reduce time testing during ce-kafka-images packaging

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -239,16 +239,13 @@
                         </configuration>
                     </plugin>
     
-                    <!-- run integration tests, excluding .../v2 and .../v3 which are numerous and take a long time -->
+                    <!-- skip integration tests because they do not include smoke tests (other components have smoke tests) -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/v2/**</exclude>
-                                <exclude>**/v3/**</exclude>
-                                <exclude>**/*$*</exclude>
-                            </excludes>
+                        <configuration combine.self="override">
+                            <skip>true</skip>
+                            <skipITs>true</skipITs>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -219,4 +219,40 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>cloudPackageSmokeTest</id>
+            <activation>
+                <property>
+                    <name>KAFKA_REST_CLOUD_SMOKE_TESTS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- skip unit tests -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+    
+                    <!-- run integration tests, excluding integration/v3 which are numerous and take a long time -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/integration/v3/**</exclude>
+                                <exclude>**/*$*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -239,13 +239,14 @@
                         </configuration>
                     </plugin>
     
-                    <!-- run integration tests, excluding integration/v3 which are numerous and take a long time -->
+                    <!-- run integration tests, excluding .../v2 and .../v3 which are numerous and take a long time -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>**/integration/v3/**</exclude>
+                                <exclude>**/v2/**</exclude>
+                                <exclude>**/v3/**</exclude>
                                 <exclude>**/*$*</exclude>
                             </excludes>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -146,4 +146,28 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>cloudPackageSmokeTest</id>
+            <activation>
+                <property>
+                    <name>KAFKA_REST_CLOUD_SMOKE_TESTS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- skip checkstyle -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
We want to run sufficient tests to be confident the package is viable, but running tests during packaging is just repeating work done during development. Start by reducing the tests run, with a plan of running just a specific smoke test.