### PR TITLE
KREST-1458: Always allow OPTIONS requests.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/accesslist/ResourceAccesslistTestBase.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/accesslist/ResourceAccesslistTestBase.java
@@ -45,6 +45,10 @@ public class ResourceAccesslistTestBase extends ClusterTestHarness {
         .get();
   }
 
+  Response topicsOptions() {
+    return request("/v3/clusters/" + getClusterId() + "/topics").options();
+  }
+
   Response createTopic() {
     return request("/v3/clusters/" + getClusterId() + "/topics")
         .accept(MediaType.APPLICATION_JSON)
@@ -72,6 +76,10 @@ public class ResourceAccesslistTestBase extends ClusterTestHarness {
 
   Response listClusters() {
     return request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
+  }
+
+  Response clustersOptions() {
+    return request("/v3/clusters/").options();
   }
 
   Response getCluster() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/accesslist/ResourceAllowlistAndBlocklistTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/accesslist/ResourceAllowlistAndBlocklistTest.java
@@ -42,6 +42,7 @@ public class ResourceAllowlistAndBlocklistTest extends ResourceAccesslistTestBas
     allowlistEnablesResourceClassExceptForBlocklistedMethods();
     blocklistDisablesResourceMethod();
     nonAllowlistAndNonBlocklistResourcesDisabled();
+    optionsIsAlwaysAllowed();
   }
 
   private void allowlistEnablesResourceClassExceptForBlocklistedMethods() {
@@ -58,5 +59,10 @@ public class ResourceAllowlistAndBlocklistTest extends ResourceAccesslistTestBas
   private void nonAllowlistAndNonBlocklistResourcesDisabled() {
     assertEquals(Status.NOT_FOUND.getStatusCode(), getCluster().getStatus());
     assertEquals(Status.METHOD_NOT_ALLOWED.getStatusCode(), updateClusterConfig().getStatus());
+  }
+
+  private void optionsIsAlwaysAllowed() {
+    assertEquals(Status.OK.getStatusCode(), clustersOptions().getStatus());
+    assertEquals(Status.OK.getStatusCode(), topicsOptions().getStatus());
   }
 }


### PR DESCRIPTION
Because OPTIONS requests are handled by the default jersey
OptionsMethodProcessor, the allowlist feature does not play nice with
it, as it will block anything that is not annotated with something
that is in the allowlist, and the jersey processor is clearly not. We
also have the problem that this processor handles OPTIONS requests for
all endpoints, and we don't have a good way on intercepting it making
it work nice with the allowlist.

The current stop gap solution is to allow OPTIONS for all
endpoints. We can investigate better solutions afterwards.