### PR TITLE
Use a more lenient test for testBackoffMsControlsPollCalls.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -380,8 +380,8 @@ public class KafkaConsumerManagerTest {
     //   N. wait max(backoffMillis, remainder of timeoutMillis), poll() returns empty
     assertTrue(
         String.format(
-            "Expected at least 3 poll calls, but got %d instead.", pollTimestampsMillis.size()),
-        pollTimestampsMillis.size() >= 3);
+            "Expected at least 2 poll calls, but got %d instead.", pollTimestampsMillis.size()),
+        pollTimestampsMillis.size() >= 2);
 
     // We need to verify that there's no window of size backoffMillis with more than 2 poll calls,
     // and no window of size 2 * backofMillis with no poll call at all.
@@ -409,6 +409,14 @@ public class KafkaConsumerManagerTest {
               pollTimestampsMillis.get(i), pollTimestampsMillis.get(i + 1)),
           pollTimestampsMillis.get(i + 1) - pollTimestampsMillis.get(i) <= 2 * backoffMillis);
     }
+
+    long lastTimestampMillis = pollTimestampsMillis.get(pollTimestampsMillis.size() - 1);
+    long timeoutTimestampMillis = pollTimestampsMillis.get(0) + timeoutMillis;
+    assertTrue(
+        String.format(
+            "Expected at least 1 poll call in window (%d, %d], but got none instead.",
+            lastTimestampMillis, timeoutTimestampMillis),
+        timeoutTimestampMillis - lastTimestampMillis < 2 * backoffMillis);
   }
 
     @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -381,7 +381,7 @@ public class KafkaConsumerManagerTest {
     assertTrue(
         String.format(
             "Expected at least 3 poll calls, but got %d instead.", pollTimestampsMillis.size()),
-        pollTimestampsMillis.size() > 3);
+        pollTimestampsMillis.size() >= 3);
 
     // We need to verify that there's no window of size backoffMillis with more than 2 poll calls,
     // and no window of size 2 * backofMillis with no poll call at all.

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -385,7 +385,7 @@ public class KafkaConsumerManagerTest {
 
     // We need to verify that there's no window of size backoffMillis with more than 2 poll calls,
     // and no window of size 2 * backofMillis with no poll call at all.
-    for (int i = 2; i < pollTimestampsMillis.size() - 1; i++) {
+    for (int i = 1; i < pollTimestampsMillis.size() - 1; i++) {
       int smallWindowCount = 1;
       long lastTimestampMillis = pollTimestampsMillis.get(i);
       for (int j = i + 1; j < pollTimestampsMillis.size(); j++) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -380,8 +380,8 @@ public class KafkaConsumerManagerTest {
     //   N. wait max(backoffMillis, remainder of timeoutMillis), poll() returns empty
     assertTrue(
         String.format(
-            "Expected at least 2 poll calls, but got %d instead.", pollTimestampsMillis.size()),
-        pollTimestampsMillis.size() > 2);
+            "Expected at least 3 poll calls, but got %d instead.", pollTimestampsMillis.size()),
+        pollTimestampsMillis.size() > 3);
 
     // We need to verify that there's no window of size backoffMillis with more than 2 poll calls,
     // and no window of size 2 * backofMillis with no poll call at all.

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -32,10 +32,13 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -341,26 +344,72 @@ public class KafkaConsumerManagerTest {
         consumerManager.deleteConsumer(groupName, consumer.cid());
     }
 
-    @Test
-    public void testBackoffMsControlsPollCalls() throws Exception {
-        bootstrapConsumer(consumer);
-        consumerManager.readRecords(groupName, consumer.cid(), BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
-                new ConsumerReadCallback<byte[], byte[]>() {
-                    @Override
-                    public void onCompletion(List<? extends ConsumerRecord<byte[], byte[]>> records, RestException e) {
-                        actualException = e;
-                        actualRecords = records;
-                        sawCallback = true;
-                    }
-                });
+  @Test
+  public void testBackoffMsControlsPollCalls() throws Exception {
+    long timeoutMillis = 5000L;
+    long backoffMillis = 500L;
+    Properties props = setUpProperties();
+    props.put(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(timeoutMillis));
+    props.put(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG, String.valueOf(backoffMillis));
+    setUpConsumer(props);
+    bootstrapConsumer(consumer);
+    CopyOnWriteArrayList<Long> pollTimestampsMillis = new CopyOnWriteArrayList<>();
+    consumer.schedulePollTask(
+        new Runnable() {
+          @Override
+          public void run() {
+            pollTimestampsMillis.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()));
+            consumer.schedulePollTask(this);
+          }
+        });
+    CountDownLatch latch = new CountDownLatch(1);
+    consumerManager.readRecords(
+        groupName,
+        consumer.cid(),
+        BinaryKafkaConsumerState.class,
+        -1,
+        Long.MAX_VALUE,
+        (records, e) -> latch.countDown());
 
-        // backoff is 250
-        Thread.sleep(100);
-        // backoff should be in place right now. the read task should be delayed and re-ran until the max.bytes or timeout is hit
-        assertEquals(1, consumerManager.delayedReadTasks.size());
-        Thread.sleep(100);
-        assertEquals(1, consumerManager.delayedReadTasks.size());
+    latch.await();
+
+    // Poll calls should look like:
+    //   0. first initial poll() returns messages
+    //   1. second initial poll() returns empty
+    //   2..N-1. wait backoffMillis, poll() returns empty, repeat
+    //   N. wait max(backoffMillis, remainder of timeoutMillis), poll() returns empty
+    assertTrue(
+        String.format(
+            "Expected at least 2 poll calls, but got %d instead.", pollTimestampsMillis.size()),
+        pollTimestampsMillis.size() > 2);
+
+    // We need to verify that there's no window of size backoffMillis with more than 2 poll calls,
+    // and no window of size 2 * backofMillis with no poll call at all.
+    for (int i = 2; i < pollTimestampsMillis.size() - 1; i++) {
+      int smallWindowCount = 1;
+      long lastTimestampMillis = pollTimestampsMillis.get(i);
+      for (int j = i + 1; j < pollTimestampsMillis.size(); j++) {
+        long delta  = pollTimestampsMillis.get(j) - pollTimestampsMillis.get(i);
+        if (delta <= backoffMillis) {
+          smallWindowCount++;
+          lastTimestampMillis = pollTimestampsMillis.get(j);
+        } else {
+          break;
+        }
+      }
+      assertTrue(
+          String.format(
+              "Expected at most 2 poll calls in window [%d, %d], but got %d instead.",
+              pollTimestampsMillis.get(i), lastTimestampMillis, smallWindowCount),
+          smallWindowCount <= 2);
+
+      assertTrue(
+          String.format(
+              "Expected at least 1 poll call in window (%d, %d), but got none instead.",
+              pollTimestampsMillis.get(i), pollTimestampsMillis.get(i + 1)),
+          pollTimestampsMillis.get(i + 1) - pollTimestampsMillis.get(i) <= 2 * backoffMillis);
     }
+  }
 
     @Test
     public void testBackoffMsUpdatesReadTaskExpiry() throws Exception {


### PR DESCRIPTION
Previously on #838, we tried to fix testBackoffMsControlsPollCalls,
but we inadvertently made the test too strict. It would assume a
constant number of 2 + (timeoutMillis / backoffMillis) poll calls,
uniformly distributed across timeoutMillis. It would allow only for a
small deviation of -1%/+10% of the expected time for the poll
calls. It turns out these assumptions are too strict and test
consitently fails during PR test runs, and sometimes on branch test
runs.

The new strategy implemented in this PR instead tests that there's no
window of size backoffMillis with more than 2 poll calls, and no
window of size 2 * backoffMillis with no poll calls. This indirectly
tests that the poll calls are distributed across timeoutMillis,
without expecting too much about the actual timing of each poll call.