### PR TITLE
Pass KafkaRestContext to HK2 via ContainerRequestContext.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -28,10 +28,8 @@ import io.confluent.kafkarest.controllers.ControllersModule;
 import io.confluent.kafkarest.exceptions.ExceptionsModule;
 import io.confluent.kafkarest.exceptions.KafkaRestExceptionMapper;
 import io.confluent.kafkarest.extension.EnumConverterProvider;
-import io.confluent.kafkarest.extension.ContextInvocationHandler;
 import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.extension.KafkaRestCleanupFilter;
-import io.confluent.kafkarest.extension.KafkaRestContextProvider;
 import io.confluent.kafkarest.extension.ResourceAccesslistFeature;
 import io.confluent.kafkarest.extension.RestResourceExtension;
 import io.confluent.kafkarest.resources.ResourcesFeature;
@@ -39,7 +37,6 @@ import io.confluent.kafkarest.response.ResponseModule;
 import io.confluent.rest.Application;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
-import java.lang.reflect.Proxy;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Properties;
@@ -97,21 +94,13 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
                                     + KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG
                                     + " needs to be configured");
     }
-    KafkaRestContextProvider.initialize(appConfig);
-    ContextInvocationHandler contextInvocationHandler = new ContextInvocationHandler();
-    KafkaRestContext context =
-        (KafkaRestContext) Proxy.newProxyInstance(
-            KafkaRestContext.class.getClassLoader(),
-            new Class[]{KafkaRestContext.class},
-            contextInvocationHandler
-        );
 
     config.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
     config.register(new BackendsModule());
     config.register(new ConfigModule(appConfig));
     config.register(new ControllersModule());
     config.register(new ExceptionsModule());
-    config.register(new ResourcesFeature(context, appConfig));
+    config.register(new ResourcesFeature(appConfig));
     config.register(new ResponseModule());
 
     config.register(ResourceAccesslistFeature.class);
@@ -147,11 +136,8 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
 
   @Override
   public void onShutdown() {
-
     for (RestResourceExtension restResourceExtension : restResourceExtensions) {
       restResourceExtension.clean();
     }
-
-    KafkaRestContextProvider.clean();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/ResourcesFeature.java
@@ -18,25 +18,22 @@ package io.confluent.kafkarest.resources;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.kafkarest.KafkaRestConfig;
-import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.kafkarest.resources.v2.V2ResourcesFeature;
 import io.confluent.kafkarest.resources.v3.V3ResourcesFeature;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
 public final class ResourcesFeature implements Feature {
-  private final KafkaRestContext context;
   private final KafkaRestConfig config;
 
-  public ResourcesFeature(KafkaRestContext context, KafkaRestConfig config) {
-    this.context = requireNonNull(context);
+  public ResourcesFeature(KafkaRestConfig config) {
     this.config = requireNonNull(config);
   }
 
   @Override
   public boolean configure(FeatureContext configurable) {
     if (config.isV2ApiEnabled()) {
-      configurable.register(new V2ResourcesFeature(context));
+      configurable.register(V2ResourcesFeature.class);
     }
     if (config.isV3ApiEnabled()) {
       configurable.register(V3ResourcesFeature.class);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/ConsumersResource.java
@@ -48,6 +48,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -87,6 +88,7 @@ public final class ConsumersResource {
 
   private final KafkaRestContext ctx;
 
+  @Inject
   public ConsumersResource(KafkaRestContext ctx) {
     this.ctx = ctx;
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/V2ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/V2ResourcesFeature.java
@@ -15,22 +15,15 @@
 
 package io.confluent.kafkarest.resources.v2;
 
-import io.confluent.kafkarest.KafkaRestContext;
-import java.util.Objects;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
 public final class V2ResourcesFeature implements Feature {
-  private final KafkaRestContext context;
-
-  public V2ResourcesFeature(KafkaRestContext context) {
-    this.context = Objects.requireNonNull(context);
-  }
 
   @Override
   public boolean configure(FeatureContext configurable) {
     configurable.register(BrokersResource.class);
-    configurable.register(new ConsumersResource(context));
+    configurable.register(ConsumersResource.class);
     configurable.register(PartitionsResource.class);
     configurable.register(ProduceToPartitionAction.class);
     configurable.register(ProduceToTopicAction.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestContextIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestContextIntegrationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration;
+
+import static java.util.Collections.singletonList;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.KafkaRestContext;
+import io.confluent.kafkarest.ProducerPool;
+import io.confluent.kafkarest.backends.kafka.KafkaModule;
+import io.confluent.kafkarest.common.KafkaFutures;
+import io.confluent.kafkarest.extension.RestResourceExtension;
+import io.confluent.kafkarest.v2.KafkaConsumerManager;
+import io.confluent.rest.exceptions.RestException;
+import java.util.Properties;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.producer.Producer;
+import org.junit.Test;
+
+public class KafkaRestContextIntegrationTest extends ClusterTestHarness {
+
+  /** HTTP 418 I'm a teapot */
+  private static final int I_M_A_TEAPOT_STATUS_CODE = 418;
+
+  private DescribeClusterResult describeClusterResult;
+
+  public KafkaRestContextIntegrationTest() {
+    super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
+  }
+
+  @Override
+  protected void overrideKafkaRestConfigs(Properties restProperties) {
+    restProperties.put(
+        KafkaRestConfig.KAFKA_REST_RESOURCE_EXTENSION_CONFIG,
+        singletonList(KafkaRestContextExtension.class));
+  }
+
+  @Test
+  public void withoutRequestContextProperty_defaultContextIsUsed() {
+    Response response = request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void withRequestContextProperty_contextFromRequestIsUsed() {
+    Response response =
+        request("/v3/clusters")
+            .header("X-Teapot-Context", "")
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(I_M_A_TEAPOT_STATUS_CODE, response.getStatus());
+  }
+
+  public static final class KafkaRestContextExtension implements RestResourceExtension {
+
+    @Override
+    public void register(Configurable<?> configurable, KafkaRestConfig config) {
+      configurable.register(KafkaRestContextRequestFilter.class);
+    }
+
+    @Override
+    public void clean() {}
+  }
+
+  private static final class KafkaRestContextRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+      if (requestContext.getHeaderString("X-Teapot-Context") != null) {
+        requestContext.setProperty(
+            KafkaModule.KAFKA_REST_CONTEXT_PROPERTY_NAME, new TeapotKafkaRestContext());
+      }
+    }
+  }
+
+  private static final class TeapotKafkaRestContext implements KafkaRestContext {
+
+    @Override
+    public KafkaRestConfig getConfig() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ProducerPool getProducerPool() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KafkaConsumerManager getKafkaConsumerManager() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Admin getAdmin() {
+      Admin adminClient = mock(Admin.class);
+      DescribeClusterResult describeClusterResult = mock(DescribeClusterResult.class);
+      expect(adminClient.describeCluster(anyObject())).andReturn(describeClusterResult);
+      expect(describeClusterResult.clusterId())
+          .andReturn(
+              KafkaFutures.failedFuture(
+                  new RestException(
+                      "I'm a teapot", I_M_A_TEAPOT_STATUS_CODE, I_M_A_TEAPOT_STATUS_CODE)));
+      expect(describeClusterResult.controller())
+          .andReturn(
+              KafkaFutures.failedFuture(
+                  new RestException(
+                      "I'm a teapot", I_M_A_TEAPOT_STATUS_CODE, I_M_A_TEAPOT_STATUS_CODE)));
+      expect(describeClusterResult.nodes())
+          .andReturn(
+              KafkaFutures.failedFuture(
+                  new RestException(
+                      "I'm a teapot", I_M_A_TEAPOT_STATUS_CODE, I_M_A_TEAPOT_STATUS_CODE)));
+      replay(adminClient, describeClusterResult);
+      return adminClient;
+    }
+
+    @Override
+    public Producer<byte[], byte[]> getProducer() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void shutdown() {}
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestContextIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaRestContextIntegrationTest.java
@@ -48,8 +48,6 @@ public class KafkaRestContextIntegrationTest extends ClusterTestHarness {
   /** HTTP 418 I'm a teapot */
   private static final int I_M_A_TEAPOT_STATUS_CODE = 418;
 
-  private DescribeClusterResult describeClusterResult;
-
   public KafkaRestContextIntegrationTest() {
     super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
   }


### PR DESCRIPTION
Currently the mechanism used by the various request
processing stages (request/response filters/interceptors and request
handlers) to communicate with each other is
KafkaRestContextProvider. This class owns a thread-local, which is
supposed to keep state per-request-handling-thread (although that's
not 100% true in the presence of async requests). If this thread-local
is not set, than Kafka REST fallsback to a default KafkaRestContext,
which is kept in the KafkaRestContextProvider in a static variable, to
preserve singleton property. This has worked fine so far because up to
this point there has always been a single KafkaRestApplication running
per JVM, but that assumption is not valid anymore. Since the static
cannot isolation the singleton instances accross multiple
KafkaRestApplication instances in the same JVM, another approach is
taken here.

What this PR does is to use instead the ContainerRequestContext to
keep the state per-request state. This approach has the nice benefit
of working, regardless of the request being suspended or not. The
default singleton KafkaRestContext is owned by HK2 now, and will be
isolated per injector (which will be one per application).

A follow-up PR will be made to delete KafkaRestContextProvider, once
all usages have been removed.