### PR TITLE
KREST-1574 Mark consumer lag as preview in openapi docs

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -344,7 +344,7 @@ paths:
           $ref: '#/components/responses/ListConsumersResponse'
 
   /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag-summary:
-    x-audience: component-internal
+    x-lifecycle-stage: Preview
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -359,7 +359,7 @@ paths:
           $ref: '#/components/responses/GetConsumerGroupLagSummaryResponse'
 
   /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
-    x-audience: component-internal
+    x-lifecycle-stage: Preview
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -374,7 +374,7 @@ paths:
           $ref: '#/components/responses/ListConsumerLagsResponse'
 
   /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags/{topic_name}/partitions/{partition_id}:
-    x-audience: component-internal
+    x-lifecycle-stage: Preview
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'


### PR DESCRIPTION
Mark the three consumer lag endpoints as preview, ready for kafka-rest cloud documentation update.

There will be a follow on PR for the CP changes, as these will need to be different as there is no x-lifecycle tag available at present,  and they will also need to go into the 700 branch.