### PR TITLE
KREST-574 Make openapi.yaml match what is needed for cloud docs

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1,11 +1,20 @@
 openapi: 3.0.0
 
 info:
-  title: Kafka HTTP API
+  title: REST Admin API
   version: 3.0.0
+  contact:
+    name: Kafka REST Team
+    url: https://confluent.slack.com/app_redirect?channel=kafka-rest-eng
+    email: kafka-clients-proxy-team@confluent.io
+  x-api-id: 499e3476-71e0-4d6f-b4f9-6776cec6df27
+  x-api-group: v3
+  x-audience: external-public
+  x-tag-group: Cluster Admin for Kafka (%s)
 
 servers:
   - url: "{protocol}://{address}:{port}/v3"
+    x-audience: component-internal
     description: Kafka REST Proxy. See https://docs.confluent.io/current/kafka-rest/index.html.
     variables:
       address:
@@ -20,7 +29,9 @@ servers:
         enum:
           - http
           - https
+
   - url: "{protocol}://{address}:{port}/kafka/v3"
+    x-audience: component-internal
     description: Kafka REST Proxy as part of Confluent Server.
     variables:
       protocol:
@@ -36,12 +47,19 @@ servers:
         default: "8090"
         description: Port of the server
 
+  - url: https://example.us-central1.gcp.confluent.cloud
+    x-audience: business-unit-internal
+    description: Confluent Cloud REST Endpoint. For example https://example.us-central1.gcp.confluent.cloud 
+
 paths:
-  /clusters:
+  /kafka/v3/kafka/v3/clusters:
     x-audience: component-internal
     get:
       summary: 'List Clusters'
-      description: 'Returns a list of known Kafka clusters. Currently both Kafka and Kafka REST
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        'Returns a list of known Kafka clusters. Currently both Kafka and Kafka REST
         Proxy are only aware of the Kafka cluster pointed at by the
         ``bootstrap.servers`` configuration. Therefore only one Kafka cluster will be returned in the
         response.'
@@ -51,28 +69,36 @@ paths:
         '200':
           $ref: '#/components/responses/ListClustersResponse'
 
-  /clusters/{cluster_id}:
+  /kafka/v3/clusters/{cluster_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'Get Cluster'
-      description: 'Returns the Kafka cluster with the specified ``cluster_id``.'
+      operationId: getKafkaV3Cluster
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the Kafka cluster with the specified ``cluster_id``.
       tags:
-        - Cluster
+        - Cluster (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetClusterResponse'
 
-  /clusters/{cluster_id}/acls:
+  /kafka/v3/clusters/{cluster_id}/acls:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'Search ACLs'
-      description: 'Returns a list of ACLs that match the search criteria.'
+      operationId: getKafkaV3Acls
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns a list of ACLs that match the search criteria.
       tags:
-        - ACL
+        - ACL (v3)
       parameters:
         - $ref: '#/components/parameters/AclResourceType'
         - $ref: '#/components/parameters/AclResourceName'
@@ -87,9 +113,13 @@ paths:
 
     post:
       summary: 'Create ACLs'
-      description: 'Creates an ACL.'
+      operationId: createKafkaV3Acls
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Creates an ACL.
       tags:
-        - ACL
+        - ACL (v3)
       requestBody:
         $ref: '#/components/requestBodies/CreateAclRequest'
       responses:
@@ -98,9 +128,13 @@ paths:
 
     delete:
       summary: 'Delete ACLs'
-      description: 'Deletes the list of ACLs that matches the search criteria.'
+      operationId: deleteKafkaV3Acls
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Deletes the list of ACLs that matches the search criteria.
       tags:
-        - ACL
+        - ACL (v3)
       parameters:
         - $ref: '#/components/parameters/AclResourceType'
         - $ref: '#/components/parameters/AclResourceName'
@@ -113,53 +147,70 @@ paths:
         '200':
           $ref: '#/components/responses/DeleteAclsResponse'
 
-  /clusters/{cluster_id}/broker-configs:
+  /kafka/v3/clusters/{cluster_id}/broker-configs:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'List Cluster Configs'
-      description: 'Returns a list of configuration parameters for the specified Kafka cluster.'
+      operationId: listKafkaV3ClusterConfigs
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns a list of configuration parameters for the specified Kafka
+        cluster.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListClusterConfigsResponse'
 
-  /clusters/{cluster_id}/broker-configs:alter:
+  /kafka/v3/clusters/{cluster_id}/broker-configs:alter:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     post:
       summary: 'Batch Alter Cluster Configs'
-      description: 'Updates or deletes a set of Kafka cluster configuration parameters.'
+      operationId: updateKafkaV3ClusterConfigs
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Updates or deletes a set of Kafka cluster configuration parameters.
       tags:
-        - Configs
+        - Configs (v3)
       requestBody:
         $ref: '#/components/requestBodies/AlterClusterConfigBatchRequest'
       responses:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/broker-configs/{name}:
+  /kafka/v3/clusters/{cluster_id}/broker-configs/{name}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConfigName'
 
     get:
       summary: 'Get Cluster Config'
-      description: 'Returns the configuration parameter specified by ``name``.'
+      operationId: getKafkaV3ClusterConfig
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the configuration parameter specified by ``name``.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetClusterConfigResponse'
 
     put:
       summary: 'Update Cluster Config'
-      description: 'Updates the configuration parameter specified by ``name``.'
+      operationId: updateKafkaV3ClusterConfig
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Updates the configuration parameter specified by ``name``.
       tags:
-        - Configs
+        - Configs (v3)
       requestBody:
         $ref: '#/components/requestBodies/UpdateClusterConfigRequest'
       responses:
@@ -168,28 +219,37 @@ paths:
 
     delete:
       summary: 'Reset Cluster Config'
-      description: 'Resets the configuration parameter specified by ``name`` to its default value.'
+      operationId: deleteKafkaV3ClusterConfig
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Resets the configuration parameter specified by ``name`` to its
+        default value.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/brokers:
+  /kafka/v3/clusters/{cluster_id}/brokers:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'List Brokers'
-      description: 'Return a list of brokers that belong to the specified Kafka cluster.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Return a list of brokers that belong to the specified 
+        Kafka cluster.
       tags:
         - Broker
       responses:
         '200':
           $ref: '#/components/responses/ListBrokersResponse'
 
-  /clusters/{cluster_id}/brokers/{broker_id}:
+  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -197,28 +257,34 @@ paths:
 
     get:
       summary: 'Get Broker'
-      description: 'Returns the broker specified by ``broker_id``.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the broker specified by ``broker_id``.
       tags:
         - Broker
       responses:
         '200':
           $ref: '#/components/responses/GetBrokerResponse'
 
-  /clusters/{cluster_id}/brokers/-/configs:
+  /kafka/v3/clusters/{cluster_id}/brokers/-/configs:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'List All Broker Configs'
-      description: 'Return the list of configuration parameters for all the brokers in the given Kafka cluster.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Return the list of configuration parameters for all the brokers in the given Kafka cluster.
       tags:
         - Configs
       responses:
         '200':
           $ref: '#/components/responses/ListBrokerConfigsResponse'
 
-  /clusters/{cluster_id}/brokers/{broker_id}/configs:
+  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/configs:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -226,14 +292,17 @@ paths:
 
     get:
       summary: 'List Broker Configs'
-      description: 'Return the list of configuration parameters that belong to the specified Kafka broker.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Return the list of configuration parameters that belong to the specified Kafka broker.
       tags:
         - Configs
       responses:
         '200':
           $ref: '#/components/responses/ListBrokerConfigsResponse'
 
-  /clusters/{cluster_id}/brokers/{broker_id}/configs:alter:
+  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/configs:alter:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -241,7 +310,10 @@ paths:
 
     post:
       summary: 'Batch Alter Broker Configs'
-      description: 'Updates or deletes a set of broker configuration parameters.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Updates or deletes a set of broker configuration parameters.
       tags:
         - Configs
       requestBody:
@@ -250,7 +322,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/brokers/{broker_id}/configs/{name}:
+  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/configs/{name}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -259,7 +331,10 @@ paths:
 
     get:
       summary: 'Get Broker Config'
-      description: 'Return the configuration parameter specified by ``name``.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Return the configuration parameter specified by ``name``.
       tags:
         - Configs
       responses:
@@ -268,7 +343,10 @@ paths:
 
     put:
       summary: 'Update Broker Config'
-      description: 'Updates the configuration parameter specified by ``name``.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Updates the configuration parameter specified by ``name``.
       tags:
         - Configs
       requestBody:
@@ -279,14 +357,17 @@ paths:
 
     delete:
       summary: 'Reset Broker Config'
-      description: 'Resets the configuration parameter specified by ``name`` to its default value.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Resets the configuration parameter specified by ``name`` to its default value.
       tags:
         - Configs
       responses:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/brokers/{broker_id}/partition-replicas:
+  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/partition-replicas:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -294,7 +375,10 @@ paths:
 
     get:
       summary: 'Search Replicas by Broker'
-      description: 'Returns the list of replicas assigned to the specified broker.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of replicas assigned to the specified broker.
       tags:
         - Broker
         - Replica
@@ -302,78 +386,104 @@ paths:
         '200':
           $ref: '#/components/responses/SearchReplicasByBrokerResponse'
 
-  /clusters/{cluster_id}/consumer-groups:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'List Consumer Groups'
-      description: 'Returns the list of consumer groups that belong to the specified Kafka cluster.'
+      operationId: listKafkaV3ConsumerGroups
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of consumer groups that belong to the specified
+        Kafka cluster.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListConsumerGroupsResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
       summary: 'Get Consumer Group'
-      description: 'Returns the consumer group specified by the ``consumer_group_id``.'
+      operationId: getKafkaV3ConsumerGroup
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the consumer group specified by the ``consumer_group_id``.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetConsumerGroupResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
       summary: 'List Consumers'
-      description: 'Returns a list of consumers that belong to the specified consumer group.'
+      operationId: listKafkaV3Consumers
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns a list of consumers that belong to the specified consumer
+        group.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListConsumersResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag-summary:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag-summary:
     x-lifecycle-stage: Preview
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
+      x-lifecycle-stage: Preview
       summary: 'Get Consumer Group Lag Summary.'
-      description: 'Returns the max and total lag of the consumers belonging to the specified consumer group.'
+      operationId: getKafkaV3ConsumerGroupLagSummary
+      description: |-
+        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+        Returns the max and total lag of the consumers belonging to the
+        specified consumer group.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetConsumerGroupLagSummaryResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
     x-lifecycle-stage: Preview
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
+      x-lifecycle-stage: Preview
+      operationId: listKafkaV3ConsumerLags
       summary: 'List Consumer Lags'
-      description: 'Returns a list of consumer lags of the consumers belonging to the specified consumer group.'
+      description: |-
+        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+        Returns a list of consumer lags of the consumers belonging to the
+        specified consumer group.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListConsumerLagsResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags/{topic_name}/partitions/{partition_id}:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags/{topic_name}/partitions/{partition_id}:
     x-lifecycle-stage: Preview
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -382,15 +492,20 @@ paths:
       - $ref: '#/components/parameters/PartitionId'
 
     get:
-      summary: 'Get Consumer Lag'
-      description: 'Returns the consumer lag on a partition with the given `partition_id`.'
+      x-lifecycle-stage: Preview
+      operationId: getKafkaV3ConsumerLag
+      summary: 'Get Consumer Lag'      
+      description: |-
+        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+        Returns the consumer lag on a partition with the given `partition_id`.
       tags:
-        - Partition
+        - Partition (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetConsumerLagResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -398,14 +513,19 @@ paths:
 
     get:
       summary: 'Get Consumer'
-      description: 'Returns the consumer specified by the ``consumer_id``.'
+      operationId: getKafkaV3Consumer
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the consumer specified by the ``consumer_id``.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetConsumerResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments:
+    x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -413,14 +533,19 @@ paths:
 
     get:
       summary: 'List Consumer Assignments'
-      description: 'Returns a list of partition assignments for the specified consumer.'
+      operationId: listKafkaV3ConsumerAssignment
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns a list of partition assignments for the specified consumer.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListConsumerAssignmentsResponse'
 
-  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments/{topic_name}/partitions/{partition_id}:
+  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments/{topic_name}/partitions/{partition_id}:
+    x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -430,91 +555,120 @@ paths:
 
     get:
       summary: 'Get Consumer Assignment'
-      description: 'Returns information about the assignment for the specified consumer to the specified partition.'
+      operationId: getKafkaV3ConsumerAssignment
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns information about the assignment for the specified consumer
+        to the specified partition.
       tags:
-        - Consumer Group
+        - Consumer Group (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetConsumerAssignmentResponse'
 
-  /clusters/{cluster_id}/topics:
+  /kafka/v3/clusters/{cluster_id}/topics:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'List Topics'
-      description: 'Returns the list of topics that belong to the specified Kafka cluster.'
+      operationId: listKafkaV3Topics
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of topics that belong to the specified Kafka cluster.
       tags:
-        - Topic
+        - Topic (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListTopicsResponse'
 
     post:
       summary: 'Create Topic'
-      description: 'Creates a topic.'
+      operationId: createKafkaV3Topic
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Creates a topic.
       tags:
-        - Topic
+        - Topic (v3)
       requestBody:
         $ref: '#/components/requestBodies/CreateTopicRequest'
       responses:
         '201':
           $ref: '#/components/responses/CreateTopicResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
 
     get:
       summary: 'Get Topic'
-      description: 'Returns the topic with the given `topic_name`.'
+      operationId: getKafkaV3Topic
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the topic with the given `topic_name`.
       tags:
-        - Topic
+        - Topic (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetTopicResponse'
 
     delete:
       summary: 'Delete Topic'
-      description: 'Deletes the topic with the given `topic_name`.'
+      operationId: deleteKafkaV3Topic
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Deletes the topic with the given `topic_name`.
       tags:
-        - Topic
+        - Topic (v3)
       responses:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/topics/{topic_name}/configs:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
 
     get:
       summary: 'List Topic Configs'
-      description: 'Return the list of configs that belong to the specified topic.'
+      operationId: listKafkaV3TopicConfigs
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Return the list of configs that belong to the specified topic.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListTopicConfigsResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/configs:alter:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs:alter:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
 
     post:
       summary: 'Batch Alter Topic Configs'
-      description: 'Updates or deletes a set of topic configs.'
+      operationId: updateKafkaV3TopicConfigBatch
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Updates or deletes a set of topic configs.
       tags:
-        - Configs
+        - Configs (v3)
       requestBody:
         $ref: '#/components/requestBodies/AlterTopicConfigBatchRequest'
       responses:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/topics/{topic_name}/configs/{name}:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs/{name}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -522,18 +676,26 @@ paths:
 
     get:
       summary: 'Get Topic Config'
-      description: 'Return the config with the given `name`.'
+      operationId: getKafkaV3TopicConfig
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Return the config with the given `name`.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetTopicConfigResponse'
 
     put:
       summary: 'Update Topic Config'
-      description: 'Updates the config with given `name`.'
+      operationId: updateKafkaV3TopicConfig
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Updates the config with given `name`.
       tags:
-        - Configs
+        - Configs (v3)
       requestBody:
         $ref: '#/components/requestBodies/UpdateTopicConfigRequest'
       responses:
@@ -542,28 +704,36 @@ paths:
 
     delete:
       summary: 'Reset Topic Config'
-      description: 'Resets the config with given `name` to its default value.'
+      operationId: deleteKafkaV3TopicConfig
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Resets the config with given `name` to its default value.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '204':
           description: 'No Content'
 
-  /clusters/{cluster_id}/topics/{topic_name}/partitions:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
 
     get:
       summary: 'List Partitions'
-      description: 'Returns the list of partitions that belong to the specified topic.'
+      operationId: listKafkaV3Partitions
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of partitions that belong to the specified topic.
       tags:
-        - Partition
+        - Partition (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListPartitionsResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -571,28 +741,35 @@ paths:
 
     get:
       summary: 'Get Partition'
-      description: 'Returns the partition with the given `partition_id`.'
+      operationId: getKafkaV3Partition
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the partition with the given `partition_id`.
       tags:
-        - Partition
+        - Partition (v3)
       responses:
         '200':
           $ref: '#/components/responses/GetPartitionResponse'
 
-  /clusters/{cluster_id}/topics/-/partitions/-/reassignment:
+  /kafka/v3/clusters/{cluster_id}/topics/-/partitions/-/reassignment:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'List All Replica Reassignments'
-      description: 'Returns the list of all ongoing replica reassignments in the given Kafka cluster.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of all ongoing replica reassignments in the given Kafka cluster.
       tags:
         - Partition
       responses:
         '200':
           $ref: '#/components/responses/ListAllReassignmentsResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/partitions/-/reassignment:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/-/reassignment:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -600,14 +777,17 @@ paths:
 
     get:
       summary: 'Search Replica Reassignments By Topic'
-      description: 'Returns the list of ongoing replica reassignments for the given topic.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of ongoing replica reassignments for the given topic.
       tags:
         - Partition
       responses:
         '200':
           $ref: '#/components/responses/SearchReassignmentsByTopicResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/reassignment:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/reassignment:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -616,14 +796,17 @@ paths:
 
     get:
       summary: 'Get Replica Reassignments'
-      description: 'Returns the list of ongoing replica reassignments for the given partition.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of ongoing replica reassignments for the given partition.
       tags:
         - Partition
       responses:
         '200':
           $ref: '#/components/responses/GetReassignmentResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -632,14 +815,17 @@ paths:
 
     get:
       summary: 'List Replicas'
-      description: 'Returns the list of replicas for the specified partition.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the list of replicas for the specified partition.
       tags:
         - Replica
       responses:
         '200':
           $ref: '#/components/responses/ListReplicasResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas/{broker_id}:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas/{broker_id}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -649,27 +835,35 @@ paths:
 
     get:
       summary: 'Get Replica'
-      description: 'Returns the replica for the specified partition assigned to the specified broker.'
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns the replica for the specified partition assigned to the specified broker.
       tags:
         - Replica
       responses:
         '200':
           $ref: '#/components/responses/GetReplicaResponse'
           
-  /clusters/{cluster_id}/topics/-/configs:
+  /kafka/v3/clusters/{cluster_id}/topics/-/configs:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
       summary: 'Get All Topic Configs'
-      description: 'Returns all topic configurations for topics hosted by the specified cluster.'
+      operationId: listKafkaV3AllTopicConfigs
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Returns all topic configurations for topics hosted by the specified
+        cluster.
       tags:
-        - Configs
+        - Configs (v3)
       responses:
         '200':
           $ref: '#/components/responses/ListTopicConfigsResponse'
 
-  /clusters/{cluster_id}/topics/{topic_name}/records:
+  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/records:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -677,13 +871,16 @@ paths:
 
     post:
       summary: 'Produce records to the given topic.'
-      description: 'Produce records to the given topic, returning delivery reports for each
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        
+        Produce records to the given topic, returning delivery reports for each
                     record produced. This API can be used in streaming mode by setting "Transfer-Encoding:
                     chunked" header. For as long as the connection is kept open, the server will
                     keep accepting records. For each record sent to the server, the server will
                     asynchronously send back a delivery report, in the same order. Records are
                     streamed to and from the server as Concatenated JSON. Errors are reported per
-                    record. The HTTP status code will be HTTP 200 OK as long as the connection is successfully established.'
+                    record. The HTTP status code will be HTTP 200 OK as long as the connection is successfully established.
       tags:
         - Records
       requestBody:
@@ -892,7 +1089,7 @@ components:
 
     AclOperation:
       type: string
-      enum:
+      x-extensible-enum:
         - UNKNOWN
         - ANY
         - ALL
@@ -909,7 +1106,7 @@ components:
 
     AclPatternType:
       type: string
-      enum:
+      x-extensible-enum:
         - UNKNOWN
         - ANY
         - MATCH
@@ -918,7 +1115,7 @@ components:
 
     AclPermission:
       type: string
-      enum:
+      x-extensible-enum:
         - UNKNOWN
         - ANY
         - DENY
@@ -954,7 +1151,7 @@ components:
                 nullable: true
               operation:
                 type: string
-                enum:
+                x-extensible-enum:
                   - SET
                   - DELETE
                 nullable: true
@@ -1048,7 +1245,7 @@ components:
 
     ClusterConfigType:
       type: string
-      enum:
+      x-extensible-enum:
         - BROKER
 
     ClusterData:
@@ -1159,7 +1356,7 @@ components:
 
     ConfigSource:
       type: string
-      enum:
+      x-extensible-enum:
         - DYNAMIC_CLUSTER_LINK_CONFIG
         - DYNAMIC_TOPIC_CONFIG
         - DYNAMIC_BROKER_LOGGER_CONFIG
@@ -1305,7 +1502,7 @@ components:
 
     ConsumerGroupState:
       type: string
-      enum:
+      x-extensible-enum:
         - UNKNOWN
         - PREPARING_REBALANCE
         - COMPLETING_REBALANCE
@@ -1473,9 +1670,11 @@ components:
       required:
         - size
       properties:
+        size:
+          type: integer
         type:
           type: string
-          enum:
+          x-extensible-enum:
             - BINARY
             - JSON
             - AVRO
@@ -1517,7 +1716,7 @@ components:
       properties:
         type:
           type: string
-          enum:
+          x-extensible-enum:
             - BINARY
             - JSON
             - AVRO
@@ -1528,7 +1727,7 @@ components:
           nullable: true
         subject_name_strategy:
           type: string
-          enum:
+          x-extensible-enum:
             - TOPIC_NAME
             - RECORD_NAME
             - TOPIC_RECORD_NAME
@@ -1812,11 +2011,11 @@ components:
           example:
             kind: 'KafkaAcl'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=kafka-cluster&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
             resource_type: 'CLUSTER'
-            resource_name: 'cluster-1'
+            resource_name: 'kafka-cluster'
             pattern_type: 'LITERAL'
-            principal: 'alice'
+            principal: 'principalType:principalName'
             host: '*'
             operation: 'DESCRIBE'
             permission: 'DENY'
@@ -1967,7 +2166,7 @@ components:
           example:
             kind: 'KafkaTopic'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-X'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-X'
             cluster_id: 'cluster-1'
             topic_name: 'topic-X'
@@ -1975,11 +2174,11 @@ components:
             replication_factor: 3
             partitions_count: 1
             partitions:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-X/partitions'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions'
             configs:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-X/configs'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/configs'
             partition_reassignments:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-X/partitions/-/reassignments'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions/-/reassignments'
 
     DeleteAclsResponse:
       description: 'The list of deleted ACLs.'
@@ -1998,7 +2197,7 @@ components:
             data:
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
                 cluster_id: 'cluster-1'
                 resource_type: 'TOPIC'
                 resource_name: 'topic-'
@@ -2009,7 +2208,7 @@ components:
                 permission: 'ALLOW'
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
                 cluster_id: 'cluster-1'
                 resource_type: 'CLUSTER'
                 resource_name: 'cluster-2'
@@ -2028,7 +2227,7 @@ components:
           example:
             kind: 'KafkaBrokerConfig'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/configs/compression.type'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/compression.type'
               resource_name: 'crn:///kafka=cluster-1/broker=1/config=compression.type'
             cluster_id: 'cluster-1'
             broker_id: 1
@@ -2055,16 +2254,16 @@ components:
           example:
             kind: 'KafkaBroker'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               resource_name: 'crn:///kafka=cluster-1/broker=1'
             cluster_id: 'cluster-1'
             broker_id: 1
             host: 'localhost'
             port: 9291
             configs:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/configs'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
             partition_replicas:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/partition-replicas'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
 
     GetClusterConfigResponse:
       description: 'The cluster configuration parameter.'
@@ -2075,7 +2274,7 @@ components:
           example:
             kind: 'KafkaClusterConfig'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/broker-configs/compression.type'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type'
               resource_name: 'crn:///kafka=cluster-1/broker-config=compression.type'
             cluster_id: 'cluster-1'
             config_type: 'BROKER'
@@ -2102,23 +2301,23 @@ components:
           example:
             kind: 'KafkaCluster'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1'
               resource_name: 'crn:///kafka=cluster-1'
             cluster_id: 'cluster-1'
             controller:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
             acls:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/acls'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls'
             brokers:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/brokers'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
             broker_configs:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/broker-configs'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
             consumer_groups:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
             topics:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
             partition_reassignments:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
 
     GetConsumerAssignmentResponse:
       description: 'The consumer group assignment.'
@@ -2129,7 +2328,7 @@ components:
           example:
             kind: 'KafkaConsumerAssignment'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=1/partition=1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2137,9 +2336,9 @@ components:
             topic_name: 'topic-1'
             partition_id: 1
             partition:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
             lag:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
 
     GetConsumerGroupResponse:
       description: 'The consumer group.'
@@ -2150,7 +2349,7 @@ components:
           example:
             kind: 'KafkaConsumerGroup'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2158,11 +2357,11 @@ components:
             partition_assignor: 'org.apache.kafka.clients.consumer.RoundRobinAssignor'
             state: 'STABLE'
             coordinator:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
             consumers:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
             lag_summary:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
 
     GetConsumerGroupLagSummaryResponse:
       description: 'The max and total consumer lag in a consumer group.'
@@ -2173,7 +2372,7 @@ components:
           example:
             kind: 'KafkaConsumerGroupLagSummary'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
               resource_name: 'crn:///kafka=cluster-1/consumer-groups=consumer-group-1/lag-summary'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2185,9 +2384,9 @@ components:
             max_lag: 100
             total_lag: 110
             max_lag_consumer:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
             max_lag_partition:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
 
     GetConsumerLagResponse:
       description: 'The consumer lag.'
@@ -2198,7 +2397,7 @@ components:
           example:
             kind: 'KafkaConsumerLag'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2220,7 +2419,7 @@ components:
           example:
             kind: 'KafkaConsumer'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2228,7 +2427,7 @@ components:
             instance_id: 'consumer-instance-1'
             client_id: 'client-1'
             assignments:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
 
     GetPartitionResponse:
       description: 'The partition'
@@ -2239,17 +2438,17 @@ components:
           example:
             kind: 'KafkaPartition'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
             partition_id: 1
             leader:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
             replicas:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
             reassignment:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
 
     GetReassignmentResponse:
       description: 'The ongoing replicas reassignments.'
@@ -2260,7 +2459,7 @@ components:
           example:
             kind: 'KafkaReassignment'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/reassignment'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2271,7 +2470,7 @@ components:
             removing_replicas:
               - 3
             replicas:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
 
     GetReplicaResponse:
       description: 'The replica.'
@@ -2282,7 +2481,7 @@ components:
           example:
             kind: 'KafkaReplica'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2291,7 +2490,7 @@ components:
             is_leader: true
             is_in_sync: true
             broker:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
 
     GetTopicConfigResponse:
       description: 'The topic configuration parameter.'
@@ -2302,7 +2501,7 @@ components:
           example:
             kind: 'KafkaTopicConfig'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/compression.type'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/compression.type'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/config=compression.type'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2329,7 +2528,7 @@ components:
           example:
             kind: 'KafkaTopic'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2337,11 +2536,11 @@ components:
             replication_factor: 3
             partitions_count: 1
             partitions:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
             configs:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/configs'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
             partition_reassignments:
-              related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
+              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
 
     ListAllReassignmentsResponse:
       description: "The ongoing replicas reassignments."
@@ -2352,12 +2551,12 @@ components:
           example:
             kind: 'KafkaReassignmentList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
               next: null
             data:
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2368,10 +2567,10 @@ components:
                 removing_replicas:
                   - 3
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2/reassignment'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-2/partition=2/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
@@ -2382,10 +2581,10 @@ components:
                   - 2
                   - 3
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3/reassignment'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3/partition=3/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
@@ -2396,7 +2595,7 @@ components:
                   - 1
                   - 2
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3/replicas'
 
     ListBrokerConfigsResponse:
       description: 'The list of broker configs.'
@@ -2407,12 +2606,12 @@ components:
           example:
             kind: 'KafkaBrokerConfigList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/configs'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
               next: null
             data:
               - kind: 'KafkaBrokerConfig'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/configs/max.connections'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/max.connections'
                   resource_name: 'crn:///kafka=cluster-1/broker=1/config=max.connections'
                 cluster_id: 'cluster-1'
                 broker_id: 1
@@ -2431,7 +2630,7 @@ components:
                     source: 'DEFAULT_CONFIG'
               - kind: 'KafkaBrokerConfig'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/configs/compression.type'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/compression.type'
                   resource_name: 'crn:///kafka=cluster-1/broker=1/config=compression.type'
                 cluster_id: 'cluster-1'
                 broker_id: 1
@@ -2458,45 +2657,45 @@ components:
           example:
             kind: 'KafkaBrokerList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/brokers'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
               next: null
             data:
               - kind: 'KafkaBroker'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                   resource_name: 'crn:///kafka=cluster-1/broker=1'
                 cluster_id: 'cluster-1'
                 broker_id: 1
                 host: 'localhost'
                 port: 9291
                 configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
                 partition_replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/partition-replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
               - kind: 'KafkaBroker'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
                   resource_name: 'crn:///kafka=cluster-1/broker=2'
                 cluster_id: 'cluster-1'
                 broker_id: 2
                 host: 'localhost'
                 port: 9292
                 configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/2/configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2/configs'
                 partition_replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/2/partition-replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2/partition-replicas'
               - kind: 'KafkaBroker'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
                   resource_name: 'crn:///kafka=cluster-1/broker=3'
                 cluster_id: 'cluster-1'
                 broker_id: 3
                 host: 'localhost'
                 port: 9293
                 configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3/configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3/configs'
                 partition_replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3/partition-replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3/partition-replicas'
 
     ListClusterConfigsResponse:
       description: 'The list of cluster configs.'
@@ -2507,12 +2706,12 @@ components:
           example:
             kind: 'KafkaClusterConfigList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/broker-configs'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
               next: null
             data:
               - kind: 'KafkaClusterConfig'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/broker-configs/max.connections'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/max.connections'
                   resource_name: 'crn:///kafka=cluster-1/broker-config=max.connections'
                 cluster_id: 'cluster-1'
                 config_type: 'BROKER'
@@ -2531,7 +2730,7 @@ components:
                     source: 'DEFAULT_CONFIG'
               - kind: 'KafkaClusterConfig'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/broker-configs/compression.type'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type'
                   resource_name: 'crn:///kafka=cluster-1/broker-config=compression.type'
                 cluster_id: 'cluster-1'
                 config_type: 'BROKER'
@@ -2558,28 +2757,28 @@ components:
           example:
             kind: 'KafkaClusterList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters'
               next: null
             data:
               - kind: 'KafkaCluster'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1'
                   resource_name: 'crn:///kafka=cluster-1'
                 cluster_id: 'cluster-1'
                 controller:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                 acls:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/acls'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls'
                 brokers:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
                 broker_configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/broker-configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
                 consumer_groups:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
                 topics:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
                 partition_reassignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
 
     ListConsumerAssignmentsResponse:
       description: 'The list of consumer group assignments.'
@@ -2590,12 +2789,12 @@ components:
           example:
             kind: 'KafkaConsumerAssignmentList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
               next: null
             data:
               - kind: 'KafkaConsumerAssignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=1/partition=1'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2603,12 +2802,12 @@ components:
                 topic_name: 'topic-1'
                 partition_id: 1
                 partition:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
                 lag:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-2/partitions/2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-2/partitions/2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=2/partition=2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2616,12 +2815,12 @@ components:
                 topic_name: 'topic-2'
                 partition_id: 2
                 partition:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/2'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2'
                 lag:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-2/partitions/2'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-2/partitions/2'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-3/partitions/3'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-3/partitions/3'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=3/partition=3'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2629,9 +2828,9 @@ components:
                 topic_name: 'topic-3'
                 partition_id: 3
                 partition:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/3'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3'
                 lag:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-3/partitions/3'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-3/partitions/3'
 
     ListConsumerGroupsResponse:
       description: 'The list of consumer groups.'
@@ -2642,12 +2841,12 @@ components:
           example:
             kind: 'KafkaConsumerGroupList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
               next: null
             data:
               - kind: 'KafkaConsumerGroup'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2655,14 +2854,14 @@ components:
                 partition_assignor: 'org.apache.kafka.clients.consumer.RoundRobinAssignor'
                 state: 'STABLE'
                 coordinator:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                 consumers:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
                 lag_summary:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
               - kind: 'KafkaConsumerGroup'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-2'
@@ -2670,14 +2869,14 @@ components:
                 partition_assignor: 'org.apache.kafka.clients.consumer.StickyAssignor'
                 state: 'PREPARING_REBALANCE'
                 coordinator:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/2'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
                 consumers:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-2/consumers'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2/consumers'
                 lag_summary:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-2/lag-summary'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2/lag-summary'
               - kind: 'KafkaConsumerGroup'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-3'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-3'
@@ -2685,11 +2884,11 @@ components:
                 partition_assignor: 'org.apache.kafka.clients.consumer.RangeAssignor'
                 state: 'DEAD'
                 coordinator:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
                 consumers:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
                 lag_summary:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-3/lag-summary'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3/lag-summary'
 
     ListConsumerLagsResponse:
      description: 'The list of consumer lags.'
@@ -2700,12 +2899,12 @@ components:
          example:
            kind: 'KafkaConsumerLagList'
            metadata:
-             self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags'
+             self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags'
              next: null
            data:
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+                 self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
@@ -2719,7 +2918,7 @@ components:
                lag: 100
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/2'
+                 self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/2'
                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=2'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
@@ -2733,7 +2932,7 @@ components:
                lag: 10
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/3'
+                 self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/3'
                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=3'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
@@ -2755,12 +2954,12 @@ components:
           example:
             kind: 'KafkaConsumerList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
               next: null
             data:
               - kind: 'KafkaConsumer'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2768,10 +2967,10 @@ components:
                 instance_id: 'consumer-instance-1'
                 client_id: 'client-1'
                 assignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
               - kind: 'KafkaConsumer'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2779,10 +2978,10 @@ components:
                 instance_id: 'consumer-instance-2'
                 client_id: 'client-2'
                 assignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
               - kind: 'KafkaConsumer'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2790,7 +2989,7 @@ components:
                 instance_id: 'consumer-instance-2'
                 client_id: 'client-2'
                 assignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
 
     ListPartitionsResponse:
       description: 'The list of partitions.'
@@ -2801,48 +3000,48 @@ components:
           example:
             kind: 'KafkaPartitionList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
               next: null
             data:
               - kind: 'KafkaPartition'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
                 partition_id: 1
                 leader:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
                 reassignment:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
               - kind: 'KafkaPartition'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
                 partition_id: 2
                 leader:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/2'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/2'
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
                 reassignment:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
               - kind: 'KafkaPartition'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
                 partition_id: 3
                 leader:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas/3'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas/3'
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
                 reassignment:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
 
     ListReplicasResponse:
       description: 'The list of replicas.'
@@ -2853,12 +3052,12 @@ components:
           example:
             kind: 'KafkaReplicaList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
               next: null
             data:
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2867,10 +3066,10 @@ components:
                 is_leader: true
                 is_in_sync: true
                 broker:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/2'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2879,10 +3078,10 @@ components:
                 is_leader: false
                 is_in_sync: true
                 broker:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/2'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/3'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/3'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2891,7 +3090,7 @@ components:
                 is_leader: false
                 is_in_sync: false
                 broker:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/3'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
 
     ListTopicConfigsResponse:
       description: 'The list of cluster configs.'
@@ -2902,12 +3101,12 @@ components:
           example:
             kind: 'KafkaTopicConfigList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/configs'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
               next: null
             data:
               - kind: 'KafkaTopicConfig'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/configs/cleanup.policy'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/cleanup.policy'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/config=cleanup.policy'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2926,7 +3125,7 @@ components:
                     source: 'DEFAULT_CONFIG'
               - kind: 'KafkaTopicConfig'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/configs/compression.type'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/config=compression.type'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2953,12 +3152,12 @@ components:
           example:
             kind: 'KafkaTopicList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
               next: null
             data:
               - kind: 'KafkaTopic'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2966,14 +3165,14 @@ components:
                 replication_factor: 3
                 partitions_count: 1
                 partitions:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
                 configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
                 partition_reassignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
               - kind: 'KafkaTopic'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
@@ -2981,14 +3180,14 @@ components:
                 replication_factor: 4
                 partitions_count: 1
                 partitions:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions'
                 configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/configs'
                 partition_reassignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/-/reassignments'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/-/reassignments'
               - kind: 'KafkaTopic'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
@@ -2996,11 +3195,11 @@ components:
                 replication_factor: 5
                 partitions_count: 1
                 partitions:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions'
                 configs:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/configs'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/configs'
                 partition_reassignments:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/-/reassignments'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/-/reassignments'
 
     ProduceResponse:
       description: ''
@@ -3033,11 +3232,11 @@ components:
           example:
             kind: 'KafkaAclList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/acls?principal=alice'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?principal=alice'
             data:
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
                 cluster_id: 'cluster-1'
                 resource_type: 'TOPIC'
                 resource_name: 'topic-'
@@ -3048,7 +3247,7 @@ components:
                 permission: 'ALLOW'
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
                 cluster_id: 'cluster-1'
                 resource_type: 'CLUSTER'
                 resource_name: 'cluster-2'
@@ -3067,12 +3266,12 @@ components:
           example:
             kind: 'KafkaReassignmentList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
               next: null
             data:
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3083,10 +3282,10 @@ components:
                 removing_replicas:
                   - 3
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3097,10 +3296,10 @@ components:
                   - 2
                   - 3
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3111,7 +3310,7 @@ components:
                   - 1
                   - 2
                 replicas:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
 
     SearchReplicasByBrokerResponse:
       description: 'The list of replicas.'
@@ -3122,12 +3321,12 @@ components:
           example:
             kind: 'KafkaReplicaList'
             metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1/partition-replicas'
+              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
               next: null
             data:
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3136,10 +3335,10 @@ components:
                 is_leader: true
                 is_in_sync: true
                 broker:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-2/partitions/3/replicas/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/3/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3/partition=3/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
@@ -3148,10 +3347,10 @@ components:
                 is_leader: false
                 is_in_sync: true
                 broker:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'http://localhost:9391/v3/clusters/cluster-1/topics/topic-3/partitions/1/replicas/1'
+                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/1/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3/partition=1/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
@@ -3160,4 +3359,23 @@ components:
                 is_leader: false
                 is_in_sync: false
                 broker:
-                  related: 'http://localhost:9391/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+tags:
+  - name: Cluster (v3)
+    description: |-
+      [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+  - name: Configs (v3)
+    description: |-
+      [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+  - name: ACL (v3)
+    description: |-
+      [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+  - name: Consumer Group (v3)
+    description: |-
+      [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+  - name: Partition (v3)
+    description: |-
+      [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+  - name: Topic (v3)
+    description: |-
+      [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -47,12 +47,12 @@ servers:
         default: "8090"
         description: Port of the server
 
-  - url: https://pkc-00000.region.provider.confluent.cloud
+  - url: https://pkc-00000.region.provider.confluent.cloud/kafka/v3
     x-audience: business-unit-internal
     description: Confluent Cloud REST Endpoint. For example https://pkc-00000.region.provider.confluent.cloud 
 
 paths:
-  /kafka/v3/clusters:
+  /clusters:
     x-audience: component-internal
     get:
       summary: 'List Clusters'
@@ -69,7 +69,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListClustersResponse'
 
-  /kafka/v3/clusters/{cluster_id}:
+  /clusters/{cluster_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -86,7 +86,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetClusterResponse'
 
-  /kafka/v3/clusters/{cluster_id}/acls:
+  /clusters/{cluster_id}/acls:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -147,7 +147,7 @@ paths:
         '200':
           $ref: '#/components/responses/DeleteAclsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/broker-configs:
+  /clusters/{cluster_id}/broker-configs:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -165,7 +165,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListClusterConfigsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/broker-configs:alter:
+  /clusters/{cluster_id}/broker-configs:alter:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -184,7 +184,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/broker-configs/{name}:
+  /clusters/{cluster_id}/broker-configs/{name}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConfigName'
@@ -231,7 +231,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/brokers:
+  /clusters/{cluster_id}/brokers:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -249,7 +249,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListBrokersResponse'
 
-  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}:
+  /clusters/{cluster_id}/brokers/{broker_id}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -267,7 +267,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetBrokerResponse'
 
-  /kafka/v3/clusters/{cluster_id}/brokers/-/configs:
+  /clusters/{cluster_id}/brokers/-/configs:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -284,7 +284,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListBrokerConfigsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/configs:
+  /clusters/{cluster_id}/brokers/{broker_id}/configs:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -302,7 +302,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListBrokerConfigsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/configs:alter:
+  /clusters/{cluster_id}/brokers/{broker_id}/configs:alter:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -322,7 +322,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/configs/{name}:
+  /clusters/{cluster_id}/brokers/{broker_id}/configs/{name}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -367,7 +367,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/brokers/{broker_id}/partition-replicas:
+  /clusters/{cluster_id}/brokers/{broker_id}/partition-replicas:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -386,7 +386,7 @@ paths:
         '200':
           $ref: '#/components/responses/SearchReplicasByBrokerResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups:
+  /clusters/{cluster_id}/consumer-groups:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -404,7 +404,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumerGroupsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -422,7 +422,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerGroupResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -441,18 +441,20 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumersResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag-summary:
-    x-lifecycle-stage: Preview
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lag-summary:
+    x-lifecycle-stage: Early Access
+    x-request-access-name: Cluster Admin For Kafka v3
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
-      x-lifecycle-stage: Preview
+      x-lifecycle-stage: Early Access
+      x-request-access-name: Cluster Admin For Kafka v3
       summary: 'Get Consumer Group Lag Summary.'
       operationId: getKafkaV3ConsumerGroupLagSummary
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Cluster Admin for Kafka (v3)](https://img.shields.io/badge/-Request%20Access%20To%20Cluster%20Admin%20For%20Kafka%20v3-%23bc8540)](mailto:ccloud-rest-api+consumer-lag-earlyaccess@confluent.io?subject=Request%20to%20join%20v3%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cluster%20Admin%20For%20Kafka%20v3%20Early%20Access%20to%20provide%20early%20feedback%20on%20consumer%20lag%20apis%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
 
         Returns the max and total lag of the consumers belonging to the
         specified consumer group.
@@ -462,18 +464,20 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerGroupLagSummaryResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
-    x-lifecycle-stage: Preview
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags:
+    x-lifecycle-stage: Early Access
+    x-request-access-name: Cluster Admin For Kafka v3
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
 
     get:
-      x-lifecycle-stage: Preview
+      x-lifecycle-stage: Early Access
+      x-request-access-name: Cluster Admin For Kafka v3
       operationId: listKafkaV3ConsumerLags
       summary: 'List Consumer Lags'
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Cluster Admin for Kafka (v3)](https://img.shields.io/badge/-Request%20Access%20To%20Cluster%20Admin%20For%20Kafka%20v3-%23bc8540)](mailto:ccloud-rest-api+consumer-lag-earlyaccess@confluent.io?subject=Request%20to%20join%20v3%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cluster%20Admin%20For%20Kafka%20v3%20Early%20Access%20to%20provide%20early%20feedback%20on%20consumer%20lag%20apis%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
 
         Returns a list of consumer lags of the consumers belonging to the
         specified consumer group.
@@ -483,8 +487,9 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumerLagsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags/{topic_name}/partitions/{partition_id}:
-    x-lifecycle-stage: Preview
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/lags/{topic_name}/partitions/{partition_id}:
+    x-lifecycle-stage: Early Access
+    x-request-access-name: Cluster Admin For Kafka v3
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -492,11 +497,12 @@ paths:
       - $ref: '#/components/parameters/PartitionId'
 
     get:
-      x-lifecycle-stage: Preview
+      x-lifecycle-stage: Early Access
+      x-request-access-name: Cluster Admin For Kafka v3
       operationId: getKafkaV3ConsumerLag
       summary: 'Get Consumer Lag'      
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Cluster Admin for Kafka (v3)](https://img.shields.io/badge/-Request%20Access%20To%20Cluster%20Admin%20For%20Kafka%20v3-%23bc8540)](mailto:ccloud-rest-api+consumer-lag-earlyaccess@confluent.io?subject=Request%20to%20join%20v3%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cluster%20Admin%20For%20Kafka%20v3%20Early%20Access%20to%20provide%20early%20feedback%20on%20consumer%20lag%20apis%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
 
         Returns the consumer lag on a partition with the given `partition_id`.
       tags:
@@ -505,7 +511,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerLagResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/ConsumerGroupId'
@@ -515,7 +521,7 @@ paths:
       summary: 'Get Consumer'
       operationId: getKafkaV3Consumer
       description: |-
-        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Cluster Admin for Kafka (v3)](https://img.shields.io/badge/-Request%20Access%20To%20Cluster%20Admin%20For%20Kafka%20v3-%23bc8540)](mailto:ccloud-rest-api+consumer-lag-earlyaccess@confluent.io?subject=Request%20to%20join%20v3%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cluster%20Admin%20For%20Kafka%20v3%20Early%20Access%20to%20provide%20early%20feedback%20on%20consumer%20lag%20apis%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
         
         Returns the consumer specified by the ``consumer_id``.
       tags:
@@ -524,7 +530,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -544,7 +550,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListConsumerAssignmentsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments/{topic_name}/partitions/{partition_id}:
+  /clusters/{cluster_id}/consumer-groups/{consumer_group_id}/consumers/{consumer_id}/assignments/{topic_name}/partitions/{partition_id}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -567,7 +573,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetConsumerAssignmentResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics:
+  /clusters/{cluster_id}/topics:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -599,7 +605,7 @@ paths:
         '201':
           $ref: '#/components/responses/CreateTopicResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}:
+  /clusters/{cluster_id}/topics/{topic_name}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -630,7 +636,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs:
+  /clusters/{cluster_id}/topics/{topic_name}/configs:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -648,7 +654,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListTopicConfigsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs:alter:
+  /clusters/{cluster_id}/topics/{topic_name}/configs:alter:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -668,7 +674,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs/{name}:
+  /clusters/{cluster_id}/topics/{topic_name}/configs/{name}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -715,7 +721,7 @@ paths:
         '204':
           description: 'No Content'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -733,7 +739,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListPartitionsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
       - $ref: '#/components/parameters/TopicName'
@@ -752,7 +758,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetPartitionResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/-/partitions/-/reassignment:
+  /clusters/{cluster_id}/topics/-/partitions/-/reassignment:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -769,7 +775,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListAllReassignmentsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/-/reassignment:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions/-/reassignment:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -787,7 +793,7 @@ paths:
         '200':
           $ref: '#/components/responses/SearchReassignmentsByTopicResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/reassignment:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/reassignment:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -806,7 +812,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetReassignmentResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -825,7 +831,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListReplicasResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas/{broker_id}:
+  /clusters/{cluster_id}/topics/{topic_name}/partitions/{partition_id}/replicas/{broker_id}:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -845,7 +851,7 @@ paths:
         '200':
           $ref: '#/components/responses/GetReplicaResponse'
           
-  /kafka/v3/clusters/{cluster_id}/topics/-/configs:
+  /clusters/{cluster_id}/topics/-/configs:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
 
@@ -863,7 +869,7 @@ paths:
         '200':
           $ref: '#/components/responses/ListTopicConfigsResponse'
 
-  /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/records:
+  /clusters/{cluster_id}/topics/{topic_name}/records:
     x-audience: component-internal
     parameters:
       - $ref: '#/components/parameters/ClusterId'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -47,12 +47,12 @@ servers:
         default: "8090"
         description: Port of the server
 
-  - url: https://example.us-central1.gcp.confluent.cloud
+  - url: https://pkc-00000.region.provider.confluent.cloud
     x-audience: business-unit-internal
-    description: Confluent Cloud REST Endpoint. For example https://example.us-central1.gcp.confluent.cloud 
+    description: Confluent Cloud REST Endpoint. For example https://pkc-00000.region.provider.confluent.cloud 
 
 paths:
-  /kafka/v3/kafka/v3/clusters:
+  /kafka/v3/clusters:
     x-audience: component-internal
     get:
       summary: 'List Clusters'
@@ -2011,7 +2011,7 @@ components:
           example:
             kind: 'KafkaAcl'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=kafka-cluster&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=kafka-cluster&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
             resource_type: 'CLUSTER'
             resource_name: 'kafka-cluster'
             pattern_type: 'LITERAL'
@@ -2166,7 +2166,7 @@ components:
           example:
             kind: 'KafkaTopic'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-X'
             cluster_id: 'cluster-1'
             topic_name: 'topic-X'
@@ -2174,11 +2174,11 @@ components:
             replication_factor: 3
             partitions_count: 1
             partitions:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions'
             configs:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/configs'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/configs'
             partition_reassignments:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions/-/reassignments'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions/-/reassignments'
 
     DeleteAclsResponse:
       description: 'The list of deleted ACLs.'
@@ -2197,7 +2197,7 @@ components:
             data:
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
                 cluster_id: 'cluster-1'
                 resource_type: 'TOPIC'
                 resource_name: 'topic-'
@@ -2208,7 +2208,7 @@ components:
                 permission: 'ALLOW'
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
                 cluster_id: 'cluster-1'
                 resource_type: 'CLUSTER'
                 resource_name: 'cluster-2'
@@ -2227,7 +2227,7 @@ components:
           example:
             kind: 'KafkaBrokerConfig'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/compression.type'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/compression.type'
               resource_name: 'crn:///kafka=cluster-1/broker=1/config=compression.type'
             cluster_id: 'cluster-1'
             broker_id: 1
@@ -2254,16 +2254,16 @@ components:
           example:
             kind: 'KafkaBroker'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               resource_name: 'crn:///kafka=cluster-1/broker=1'
             cluster_id: 'cluster-1'
             broker_id: 1
             host: 'localhost'
             port: 9291
             configs:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
             partition_replicas:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
 
     GetClusterConfigResponse:
       description: 'The cluster configuration parameter.'
@@ -2274,7 +2274,7 @@ components:
           example:
             kind: 'KafkaClusterConfig'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type'
               resource_name: 'crn:///kafka=cluster-1/broker-config=compression.type'
             cluster_id: 'cluster-1'
             config_type: 'BROKER'
@@ -2301,23 +2301,23 @@ components:
           example:
             kind: 'KafkaCluster'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1'
               resource_name: 'crn:///kafka=cluster-1'
             cluster_id: 'cluster-1'
             controller:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
             acls:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls'
             brokers:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
             broker_configs:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
             consumer_groups:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
             topics:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
             partition_reassignments:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
 
     GetConsumerAssignmentResponse:
       description: 'The consumer group assignment.'
@@ -2328,7 +2328,7 @@ components:
           example:
             kind: 'KafkaConsumerAssignment'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=1/partition=1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2336,9 +2336,9 @@ components:
             topic_name: 'topic-1'
             partition_id: 1
             partition:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
             lag:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
 
     GetConsumerGroupResponse:
       description: 'The consumer group.'
@@ -2349,7 +2349,7 @@ components:
           example:
             kind: 'KafkaConsumerGroup'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2357,11 +2357,11 @@ components:
             partition_assignor: 'org.apache.kafka.clients.consumer.RoundRobinAssignor'
             state: 'STABLE'
             coordinator:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
             consumers:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
             lag_summary:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
 
     GetConsumerGroupLagSummaryResponse:
       description: 'The max and total consumer lag in a consumer group.'
@@ -2372,7 +2372,7 @@ components:
           example:
             kind: 'KafkaConsumerGroupLagSummary'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
               resource_name: 'crn:///kafka=cluster-1/consumer-groups=consumer-group-1/lag-summary'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2384,9 +2384,9 @@ components:
             max_lag: 100
             total_lag: 110
             max_lag_consumer:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
             max_lag_partition:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
 
     GetConsumerLagResponse:
       description: 'The consumer lag.'
@@ -2397,7 +2397,7 @@ components:
           example:
             kind: 'KafkaConsumerLag'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2419,7 +2419,7 @@ components:
           example:
             kind: 'KafkaConsumer'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
               resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1'
             cluster_id: 'cluster-1'
             consumer_group_id: 'consumer-group-1'
@@ -2427,7 +2427,7 @@ components:
             instance_id: 'consumer-instance-1'
             client_id: 'client-1'
             assignments:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
 
     GetPartitionResponse:
       description: 'The partition'
@@ -2438,17 +2438,17 @@ components:
           example:
             kind: 'KafkaPartition'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
             partition_id: 1
             leader:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
             replicas:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
             reassignment:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
 
     GetReassignmentResponse:
       description: 'The ongoing replicas reassignments.'
@@ -2459,7 +2459,7 @@ components:
           example:
             kind: 'KafkaReassignment'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/reassignment'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2470,7 +2470,7 @@ components:
             removing_replicas:
               - 3
             replicas:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
 
     GetReplicaResponse:
       description: 'The replica.'
@@ -2481,7 +2481,7 @@ components:
           example:
             kind: 'KafkaReplica'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2490,7 +2490,7 @@ components:
             is_leader: true
             is_in_sync: true
             broker:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
 
     GetTopicConfigResponse:
       description: 'The topic configuration parameter.'
@@ -2501,7 +2501,7 @@ components:
           example:
             kind: 'KafkaTopicConfig'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/compression.type'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/compression.type'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1/config=compression.type'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2528,7 +2528,7 @@ components:
           example:
             kind: 'KafkaTopic'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1'
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
@@ -2536,11 +2536,11 @@ components:
             replication_factor: 3
             partitions_count: 1
             partitions:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
             configs:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
             partition_reassignments:
-              related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
+              related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
 
     ListAllReassignmentsResponse:
       description: "The ongoing replicas reassignments."
@@ -2551,12 +2551,12 @@ components:
           example:
             kind: 'KafkaReassignmentList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
               next: null
             data:
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -2567,10 +2567,10 @@ components:
                 removing_replicas:
                   - 3
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2/reassignment'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-2/partition=2/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
@@ -2581,10 +2581,10 @@ components:
                   - 2
                   - 3
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3/reassignment'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3/partition=3/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
@@ -2595,7 +2595,7 @@ components:
                   - 1
                   - 2
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3/replicas'
 
     ListBrokerConfigsResponse:
       description: 'The list of broker configs.'
@@ -2606,12 +2606,12 @@ components:
           example:
             kind: 'KafkaBrokerConfigList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
               next: null
             data:
               - kind: 'KafkaBrokerConfig'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/max.connections'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/max.connections'
                   resource_name: 'crn:///kafka=cluster-1/broker=1/config=max.connections'
                 cluster_id: 'cluster-1'
                 broker_id: 1
@@ -2630,7 +2630,7 @@ components:
                     source: 'DEFAULT_CONFIG'
               - kind: 'KafkaBrokerConfig'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/compression.type'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs/compression.type'
                   resource_name: 'crn:///kafka=cluster-1/broker=1/config=compression.type'
                 cluster_id: 'cluster-1'
                 broker_id: 1
@@ -2657,45 +2657,45 @@ components:
           example:
             kind: 'KafkaBrokerList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
               next: null
             data:
               - kind: 'KafkaBroker'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                   resource_name: 'crn:///kafka=cluster-1/broker=1'
                 cluster_id: 'cluster-1'
                 broker_id: 1
                 host: 'localhost'
                 port: 9291
                 configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/configs'
                 partition_replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
               - kind: 'KafkaBroker'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
                   resource_name: 'crn:///kafka=cluster-1/broker=2'
                 cluster_id: 'cluster-1'
                 broker_id: 2
                 host: 'localhost'
                 port: 9292
                 configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2/configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2/configs'
                 partition_replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2/partition-replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2/partition-replicas'
               - kind: 'KafkaBroker'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
                   resource_name: 'crn:///kafka=cluster-1/broker=3'
                 cluster_id: 'cluster-1'
                 broker_id: 3
                 host: 'localhost'
                 port: 9293
                 configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3/configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3/configs'
                 partition_replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3/partition-replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3/partition-replicas'
 
     ListClusterConfigsResponse:
       description: 'The list of cluster configs.'
@@ -2706,12 +2706,12 @@ components:
           example:
             kind: 'KafkaClusterConfigList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
               next: null
             data:
               - kind: 'KafkaClusterConfig'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/max.connections'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/max.connections'
                   resource_name: 'crn:///kafka=cluster-1/broker-config=max.connections'
                 cluster_id: 'cluster-1'
                 config_type: 'BROKER'
@@ -2730,7 +2730,7 @@ components:
                     source: 'DEFAULT_CONFIG'
               - kind: 'KafkaClusterConfig'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type'
                   resource_name: 'crn:///kafka=cluster-1/broker-config=compression.type'
                 cluster_id: 'cluster-1'
                 config_type: 'BROKER'
@@ -2757,28 +2757,28 @@ components:
           example:
             kind: 'KafkaClusterList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters'
               next: null
             data:
               - kind: 'KafkaCluster'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1'
                   resource_name: 'crn:///kafka=cluster-1'
                 cluster_id: 'cluster-1'
                 controller:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                 acls:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls'
                 brokers:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers'
                 broker_configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs'
                 consumer_groups:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
                 topics:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
                 partition_reassignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
 
     ListConsumerAssignmentsResponse:
       description: 'The list of consumer group assignments.'
@@ -2789,12 +2789,12 @@ components:
           example:
             kind: 'KafkaConsumerAssignmentList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
               next: null
             data:
               - kind: 'KafkaConsumerAssignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-1/partitions/1'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=1/partition=1'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2802,12 +2802,12 @@ components:
                 topic_name: 'topic-1'
                 partition_id: 1
                 partition:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
                 lag:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-2/partitions/2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-2/partitions/2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=2/partition=2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2815,12 +2815,12 @@ components:
                 topic_name: 'topic-2'
                 partition_id: 2
                 partition:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/2'
                 lag:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-2/partitions/2'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-2/partitions/2'
               - kind: 'KafkaConsumerAssignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-3/partitions/3'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments/topic-3/partitions/3'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1/assignment=topic=3/partition=3'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2828,9 +2828,9 @@ components:
                 topic_name: 'topic-3'
                 partition_id: 3
                 partition:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/3'
                 lag:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-3/partitions/3'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-3/partitions/3'
 
     ListConsumerGroupsResponse:
       description: 'The list of consumer groups.'
@@ -2841,12 +2841,12 @@ components:
           example:
             kind: 'KafkaConsumerGroupList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups'
               next: null
             data:
               - kind: 'KafkaConsumerGroup'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2854,14 +2854,14 @@ components:
                 partition_assignor: 'org.apache.kafka.clients.consumer.RoundRobinAssignor'
                 state: 'STABLE'
                 coordinator:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                 consumers:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
                 lag_summary:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lag-summary'
               - kind: 'KafkaConsumerGroup'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-2'
@@ -2869,14 +2869,14 @@ components:
                 partition_assignor: 'org.apache.kafka.clients.consumer.StickyAssignor'
                 state: 'PREPARING_REBALANCE'
                 coordinator:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
                 consumers:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2/consumers'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2/consumers'
                 lag_summary:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2/lag-summary'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-2/lag-summary'
               - kind: 'KafkaConsumerGroup'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-3'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-3'
@@ -2884,11 +2884,11 @@ components:
                 partition_assignor: 'org.apache.kafka.clients.consumer.RangeAssignor'
                 state: 'DEAD'
                 coordinator:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
                 consumers:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3/consumers'
                 lag_summary:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3/lag-summary'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-3/lag-summary'
 
     ListConsumerLagsResponse:
      description: 'The list of consumer lags.'
@@ -2899,12 +2899,12 @@ components:
          example:
            kind: 'KafkaConsumerLagList'
            metadata:
-             self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags'
+             self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags'
              next: null
            data:
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
+                 self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/1'
                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=1'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
@@ -2918,7 +2918,7 @@ components:
                lag: 100
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/2'
+                 self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/2'
                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=2'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
@@ -2932,7 +2932,7 @@ components:
                lag: 10
              - kind: 'KafkaConsumerLag'
                metadata:
-                 self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/3'
+                 self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/lags/topic-1/partitions/3'
                  resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/lag=topic-1/partition=3'
                cluster_id: 'cluster-1'
                consumer_group_id: 'consumer-group-1'
@@ -2954,12 +2954,12 @@ components:
           example:
             kind: 'KafkaConsumerList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers'
               next: null
             data:
               - kind: 'KafkaConsumer'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-1'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2967,10 +2967,10 @@ components:
                 instance_id: 'consumer-instance-1'
                 client_id: 'client-1'
                 assignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-1/assignments'
               - kind: 'KafkaConsumer'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2978,10 +2978,10 @@ components:
                 instance_id: 'consumer-instance-2'
                 client_id: 'client-2'
                 assignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
               - kind: 'KafkaConsumer'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2'
                   resource_name: 'crn:///kafka=cluster-1/consumer-group=consumer-group-1/consumer=consumer-2'
                 cluster_id: 'cluster-1'
                 consumer_group_id: 'consumer-group-1'
@@ -2989,7 +2989,7 @@ components:
                 instance_id: 'consumer-instance-2'
                 client_id: 'client-2'
                 assignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/consumer-groups/consumer-group-1/consumers/consumer-2/assignments'
 
     ListPartitionsResponse:
       description: 'The list of partitions.'
@@ -3000,48 +3000,48 @@ components:
           example:
             kind: 'KafkaPartitionList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
               next: null
             data:
               - kind: 'KafkaPartition'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
                 partition_id: 1
                 leader:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
                 reassignment:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
               - kind: 'KafkaPartition'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
                 partition_id: 2
                 leader:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/2'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/2'
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
                 reassignment:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
               - kind: 'KafkaPartition'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
                 partition_id: 3
                 leader:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas/3'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas/3'
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
                 reassignment:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
 
     ListReplicasResponse:
       description: 'The list of replicas.'
@@ -3052,12 +3052,12 @@ components:
           example:
             kind: 'KafkaReplicaList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
               next: null
             data:
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3066,10 +3066,10 @@ components:
                 is_leader: true
                 is_in_sync: true
                 broker:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/2'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3078,10 +3078,10 @@ components:
                 is_leader: false
                 is_in_sync: true
                 broker:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/3'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas/3'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/replica=3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3090,7 +3090,7 @@ components:
                 is_leader: false
                 is_in_sync: false
                 broker:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
 
     ListTopicConfigsResponse:
       description: 'The list of cluster configs.'
@@ -3101,12 +3101,12 @@ components:
           example:
             kind: 'KafkaTopicConfigList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
               next: null
             data:
               - kind: 'KafkaTopicConfig'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/cleanup.policy'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/cleanup.policy'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/config=cleanup.policy'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3125,7 +3125,7 @@ components:
                     source: 'DEFAULT_CONFIG'
               - kind: 'KafkaTopicConfig'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/config=compression.type'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3152,12 +3152,12 @@ components:
           example:
             kind: 'KafkaTopicList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics'
               next: null
             data:
               - kind: 'KafkaTopic'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3165,14 +3165,14 @@ components:
                 replication_factor: 3
                 partitions_count: 1
                 partitions:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions'
                 configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs'
                 partition_reassignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/-/reassignments'
               - kind: 'KafkaTopic'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
@@ -3180,14 +3180,14 @@ components:
                 replication_factor: 4
                 partitions_count: 1
                 partitions:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions'
                 configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/configs'
                 partition_reassignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/-/reassignments'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/-/reassignments'
               - kind: 'KafkaTopic'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
@@ -3195,11 +3195,11 @@ components:
                 replication_factor: 5
                 partitions_count: 1
                 partitions:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions'
                 configs:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/configs'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/configs'
                 partition_reassignments:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/-/reassignments'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/-/reassignments'
 
     ProduceResponse:
       description: ''
@@ -3232,11 +3232,11 @@ components:
           example:
             kind: 'KafkaAclList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?principal=alice'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?principal=alice'
             data:
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=TOPIC&resource_name=topic-&pattern_type=PREFIXED&principal=alice&host=*&operation=ALL&permission=ALLOW'
                 cluster_id: 'cluster-1'
                 resource_type: 'TOPIC'
                 resource_name: 'topic-'
@@ -3247,7 +3247,7 @@ components:
                 permission: 'ALLOW'
               - kind: 'KafkaAcl'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
                 cluster_id: 'cluster-1'
                 resource_type: 'CLUSTER'
                 resource_name: 'cluster-2'
@@ -3266,12 +3266,12 @@ components:
           example:
             kind: 'KafkaReassignmentList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/-/partitions/-/reassignment'
               next: null
             data:
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=1/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3282,10 +3282,10 @@ components:
                 removing_replicas:
                   - 3
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/1/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3296,10 +3296,10 @@ components:
                   - 2
                   - 3
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas'
               - kind: 'KafkaReassignment'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/reassignment'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=3/reassignment'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3310,7 +3310,7 @@ components:
                   - 1
                   - 2
                 replicas:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/3/replicas'
 
     SearchReplicasByBrokerResponse:
       description: 'The list of replicas.'
@@ -3321,12 +3321,12 @@ components:
           example:
             kind: 'KafkaReplicaList'
             metadata:
-              self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
+              self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1/partition-replicas'
               next: null
             data:
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/partitions/2/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1/partition=2/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
@@ -3335,10 +3335,10 @@ components:
                 is_leader: true
                 is_in_sync: true
                 broker:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/3/replicas/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-2/partitions/3/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3/partition=3/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
@@ -3347,10 +3347,10 @@ components:
                 is_leader: false
                 is_in_sync: true
                 broker:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
               - kind: 'KafkaReplica'
                 metadata:
-                  self: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/1/replicas/1'
+                  self: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-3/partitions/1/replicas/1'
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3/partition=1/replica=1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
@@ -3359,7 +3359,7 @@ components:
                 is_leader: false
                 is_in_sync: false
                 broker:
-                  related: 'https://example.us-central1.gcp.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
+                  related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
 tags:
   - name: Cluster (v3)
     description: |-


### PR DESCRIPTION
Title needs to change

Contact details are required

x-api/x-audience-x-tags are required

Include both cloud and platform servers, tag the platform ones as x-audience: component-internal so that they are excluded from the cloud docs, and the could one as x-audience: business-unit-internal (arbitrary choice from the options) so it can be excluded from the platform one

Add /kafka/v3 at the front of each path to match the cloud requirements

Change the tags (which make the titles) to all include (v3) to match the cloud requirements

Add `operationId ` which is just a unique string per endpoint, as required by cloud

Add extra `x-lifecycle-stage: Preview` tags at the `get` level for the lag endpoints, and link to the icons indicating preview status in the description

Added in linebreaks to stop the linter complaining

Changed `enum` to `x-extensible-enum` where it was possible to do this (the fields need to be SNAKE_CASE) to allow the change, as otherwise the linter broke.  Note that there are a couple of enums that I think could be extensible_enums that weren't changed over, but for now I am just making our docs match what has been published.  We can address any missing ones as part of https://confluentinc.atlassian.net/wiki/spaces/~70581479/pages/2575204659/Kafka+Admin+REST+v3+API+Linting+Errors

Added a missing, required, size parameter to ProduceResponseData as the linter spotted this and failed

Updated example urls to not be localhost.  eg `localhost:PORTNUMBER/v3/` has changed to be `example.us-central1.gcp.confluent.cloud/kafka/v3`

`CreateAclRequest` had a couple of bugs.  The resource name has to be `kafka-cluster`, not the arbitrary `cluster-1`.  And the principal requires a : in the middle, and is expecting to be of the `format principalType:principalName`

Added tags with the section descriptions as required for the cloud docs.

Added in public usage icon
