### PR TITLE
Update the internal Slack channel name used by Jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
 common {
-  slackChannel = '#rest-proxy-warn'
+  slackChannel = '#kafka-rest-warn'
   upstreamProjects = 'confluentinc/schema-registry'
 }


### PR DESCRIPTION
This should help us with the internal notifications about Kafka REST build status.