### PR TITLE
KREST-1577 Replace a manually set Avro version with the Avro version variable.

### DIFF
--- a/kafka-rest-common/pom.xml
+++ b/kafka-rest-common/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.8.2</version>
+            <version>${avro.version}</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This was found while investigating a vulnerability of `commons-compress` which is a transitive dependency of Avro. Surprisingly this somehow doesn't cause a problem with `commons-compress` on `5.4.x`, but we should definitely get rid of it.

As it is in `kafka-rest-common`, it will probably be merged up to some 5.x version, after which `kafka-rest-common` is no longer available.