### PR TITLE
Re-enable nano-version builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 common {
   slackChannel = '#kafka-rest-warn'
-  upstreamProjects = 'confluentinc/schema-registry'
+  downStreamRepos = ["confluent-security-plugins", "ce-kafka-rest",
+    "confluent-cloud-plugins"]
   nanoVersion = true
 }


### PR DESCRIPTION
They were disabled in the following mis-merge:
https://github.com/confluentinc/kafka-rest/commit/8c63fa99df6e92cdf1da5b277d280fc6aa22fb08

Thanks to Adam Brown for figuring out where we regressed.