### PR TITLE
Remove ZooKeeperClient/KafkaZkClient usage from tests

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -72,9 +72,7 @@ public class AuthorizationErrorTest
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    kafka.utils.TestUtils.createTopic(zkClient, TOPIC_NAME, 1, 1,
-        JavaConverters.asScalaBuffer(this.servers),
-        new Properties());
+    createTopic(TOPIC_NAME, 1, (short) 1);
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
@@ -111,10 +111,8 @@ public class AvroProducerTest extends ClusterTestHarness {
   public void setUp() throws Exception {
     super.setUp();
     final int numPartitions = 3;
-    final int replicationFactor = 1;
-    kafka.utils.TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
-        JavaConverters.asScalaBuffer(this.servers),
-        new Properties());
+    final short replicationFactor = 1;
+    createTopic(topicName, numPartitions, replicationFactor);
 
     deserializerProps = new Properties();
     deserializerProps.setProperty("schema.registry.url", schemaRegConnect);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -56,7 +56,6 @@ import kafka.utils.MockTime;
 import kafka.utils.TestUtils;
 import kafka.zk.EmbeddedZookeeper;
 import kafka.zk.KafkaZkClient;
-import kafka.zookeeper.ZooKeeperClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -73,10 +72,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.utils.Time;
 import org.eclipse.jetty.server.Server;
 import org.junit.After;
 import org.junit.Assert;
@@ -128,7 +125,6 @@ public abstract class ClusterTestHarness {
   // ZK Config
   protected String zkConnect;
   protected EmbeddedZookeeper zookeeper;
-  protected KafkaZkClient zkClient;
   protected int zkConnectionTimeout = 10000;
   protected int zkSessionTimeout = 6000;
 
@@ -175,15 +171,6 @@ public abstract class ClusterTestHarness {
   @Before
   public void setUp() throws Exception {
     zookeeper = new EmbeddedZookeeper();
-    zkConnect = String.format("127.0.0.1:%d", zookeeper.port());
-    Time time = Time.SYSTEM;
-    zkClient = new KafkaZkClient(
-        new ZooKeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, Integer.MAX_VALUE,
-            time,
-            "testMetricGroup", "testMetricGroupType"),
-        JaasUtils.isZkSaslEnabled(),
-        time);
-
     // start brokers concurrently
     startBrokersConcurrently(numBrokers);
 
@@ -309,7 +296,6 @@ public abstract class ClusterTestHarness {
       CoreUtils.delete(server.config().logDirs());
     }
 
-    zkClient.close();
     zookeeper.shutdown();
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/JsonProducerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/JsonProducerTest.java
@@ -41,10 +41,8 @@ public class JsonProducerTest
   public void setUp() throws Exception {
     super.setUp();
     final int numPartitions = 3;
-    final int replicationFactor = 1;
-    kafka.utils.TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
-        JavaConverters.asScalaBuffer(this.servers),
-        new Properties());
+    final short replicationFactor = 1;
+    createTopic(topicName, numPartitions, replicationFactor);
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -80,7 +80,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     topic2Configs.setProperty("cleanup.policy", "delete");
   }
 
-  private static final int numReplicas = 2;
+  private static final short numReplicas = 2;
 
   public MetadataAPITest() {
     super(2, false);
@@ -90,10 +90,8 @@ public class MetadataAPITest extends ClusterTestHarness {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    kafka.utils.TestUtils.createTopic(zkClient, topic1Name, topic1Partitions.size(), numReplicas,
-        JavaConverters.asScalaBuffer(this.servers), new Properties());
-    kafka.utils.TestUtils.createTopic(zkClient, topic2Name, topic2Partitions.size(), numReplicas,
-        JavaConverters.asScalaBuffer(this.servers), topic2Configs);
+    createTopic(topic1Name, topic1Partitions.size(), numReplicas);
+    createTopic(topic2Name, topic2Partitions.size(), numReplicas);
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ProducerTest.java
@@ -108,10 +108,8 @@ public class ProducerTest
   public void setUp() throws Exception {
     super.setUp();
     final int numPartitions = 3;
-    final int replicationFactor = 1;
-    kafka.utils.TestUtils.createTopic(zkClient, topicName, numPartitions, replicationFactor,
-        JavaConverters.asScalaBuffer(this.servers),
-        new Properties());
+    final short replicationFactor = 1;
+    createTopic(topicName, numPartitions, replicationFactor);
   }
 
   @Test


### PR DESCRIPTION
These are internal classes and hence can change in incompatible ways.
One such incompatible change committed to Apache Kafka 3.0 is the reason
why we need this in 7.0.x too.