### PR TITLE
Fix NPE causing most integration tests to fail

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -55,7 +55,6 @@ import kafka.utils.CoreUtils;
 import kafka.utils.MockTime;
 import kafka.utils.TestUtils;
 import kafka.zk.EmbeddedZookeeper;
-import kafka.zk.KafkaZkClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -171,6 +170,7 @@ public abstract class ClusterTestHarness {
   @Before
   public void setUp() throws Exception {
     zookeeper = new EmbeddedZookeeper();
+    zkConnect = String.format("127.0.0.1:%d", zookeeper.port());
     // start brokers concurrently
     startBrokersConcurrently(numBrokers);
 


### PR DESCRIPTION
Recent AK changes related to the removal of ZooKeeper have necessitated the accompanying changes in kafka-rest's tests.
https://github.com/confluentinc/kafka-rest/pull/893 has done that, but unfortunately it also removed the initialization of the `zkConnect` field which then caused an NPE when it ended up being added to a `ConcurrentHashMap` as a `null`.

This attempts to fix the problem by the simplest of approaches: putting back the initialization of `zkConnect`.

Tested locally on `7.0.x` by running a single, randomly chosen integration test:
- Before this change, `KafkaRestStartUpIntegrationTest` failed with NPEs;
- After this change, `KafkaRestStartUpIntegrationTest` passed successfully;