### PR TITLE
KREST-1965 Ignore some known very flaky tests

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -64,11 +64,15 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+// TODO ddimitrov This continues being way too flaky.
+//  Until we fix it (KREST-1542), we should ignore it, as it might be hiding even worse errors.
+@Ignore
 @RunWith(JUnit4.class)
 public class ProduceActionIntegrationTest {
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -401,6 +401,9 @@ public class KafkaConsumerManagerTest {
         consumerManager.deleteConsumer(groupName, consumer.cid());
     }
 
+  // TODO ddimitrov This continues being way too flaky, even after some fix attempts.
+  //  Until we fix it (KREST-2300), we should ignore it, as it might be hiding even worse errors.
+  @Ignore
   @Test
   public void testBackoffMsControlsPollCalls() throws Exception {
     long timeoutMillis = 5000L;


### PR DESCRIPTION
The two tests ignored here are way too flaky and we have seen at least one occasion were one of them was hiding an even worse problem: https://github.com/confluentinc/kafka-rest/pull/893.

We have added tasks for actually fixing them, but in the meantime they should not be causing as much trouble as they currently are.