### PR TITLE
KREST-2260: Use super user when creating topic in AuthorizationErrorTest.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -13,7 +13,6 @@
  * specific language governing permissions and limitations under the License.
  */
 
-
 package io.confluent.kafkarest.integration;
 
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
@@ -28,9 +27,9 @@ import io.confluent.kafkarest.Versions;
 import io.confluent.kafkarest.entities.v2.BinaryPartitionProduceRequest;
 import io.confluent.kafkarest.entities.v2.BinaryTopicProduceRequest;
 import io.confluent.kafkarest.entities.v2.BinaryTopicProduceRequest.BinaryTopicProduceRecord;
+import io.confluent.kafkarest.entities.v2.CreateConsumerInstanceRequest;
 import io.confluent.kafkarest.entities.v2.CreateConsumerInstanceResponse;
 import io.confluent.kafkarest.entities.v2.PartitionOffset;
-import io.confluent.kafkarest.entities.v2.CreateConsumerInstanceRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -38,6 +37,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import kafka.security.authorizer.AclAuthorizer;
 import kafka.server.KafkaConfig;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -45,7 +45,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import scala.Option;
-import scala.collection.JavaConverters;
 
 public class AuthorizationErrorTest
     extends AbstractProducerTest<BinaryTopicProduceRequest, BinaryPartitionProduceRequest> {
@@ -72,7 +71,14 @@ public class AuthorizationErrorTest
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    createTopic(TOPIC_NAME, 1, (short) 1);
+    Properties properties = restConfig.getAdminProperties();
+    properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+    properties.put(
+        "sasl.jaas.config",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+            + " username=\"admin\""
+            + " password=\"admin-secret\";");
+    createTopic(TOPIC_NAME, 1, (short) 1, properties);
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -73,11 +73,7 @@ public class AuthorizationErrorTest
     super.setUp();
     Properties properties = restConfig.getAdminProperties();
     properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    properties.put(
-        "sasl.jaas.config",
-        "org.apache.kafka.common.security.plain.PlainLoginModule required "
-            + " username=\"admin\""
-            + " password=\"admin-secret\";");
+    properties.put("sasl.jaas.config", createPlainLoginModule("admin", "admin-secret"));
     createTopic(TOPIC_NAME, 1, (short) 1, properties);
   }
 
@@ -112,11 +108,13 @@ public class AuthorizationErrorTest
     restProperties.put(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
     restProperties.put("client.security.protocol","SASL_PLAINTEXT");
     restProperties.put("client.sasl.mechanism", "PLAIN");
-    restProperties.put("client.sasl.jaas.config",
-        "org.apache.kafka.common.security.plain.PlainLoginModule required "
-            + " username=\"" + USERNAME + "\""
-            + " password=\"alice-secret\";"
-    );
+    restProperties.put("client.sasl.jaas.config", createPlainLoginModule(USERNAME, "alice-secret"));
+  }
+
+  private static String createPlainLoginModule(String username, String password) {
+    return "org.apache.kafka.common.security.plain.PlainLoginModule required "
+        + " username=\"" + username + "\""
+        + " password=\"" + password + "\";";
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -400,6 +400,10 @@ public abstract class ClusterTestHarness {
   protected final void createTopic(String topicName, int numPartitions, short replicationFactor) {
     Properties properties = restConfig.getAdminProperties();
     properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+    createTopic(topicName, numPartitions, replicationFactor, properties);
+  }
+
+  protected final void createTopic(String topicName, int numPartitions, short replicationFactor, Properties properties) {
     AdminClient adminClient = AdminClient.create(properties);
 
     CreateTopicsResult result =


### PR DESCRIPTION
Prior to https://github.com/confluentinc/kafka-rest/pull/893, this topic was being created directly in Zookeeper, bypassing Kafka authorization entirely.

Now that we are using Kafka to create the topic, we need to pass through authorization. This changes uses the super-user to create the topic, so that we don't fail authorization.