### PR TITLE
Pin google-java-format version to 1.11.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,13 @@
 			    <googleJavaFormat />
 		        </java>
 		    </configuration>
+		    <dependencies>
+		      <dependency>
+			<groupId>com.google.googlejavaformat</groupId>
+			<artifactId>google-java-format</artifactId>
+			<version>1.11.0</version>
+		      </dependency>
+		    </dependencies>
                     <executions>
 	                <execution>
 			    <phase>compile</phase>


### PR DESCRIPTION
Different versions of `google-java-format` will format the code in slightly different ways. This pin is go guarantee we always use the same version everywhere. 