### PR TITLE
Actually pin google-java-format to 1.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,16 +150,11 @@
 		    <version>2.12.3</version>
 		    <configuration>
 	  	        <java>
-			    <googleJavaFormat />
+			    <googleJavaFormat>
+			        <version>1.7</version>
+			    </googleJavaFormat>
 		        </java>
 		    </configuration>
-		    <dependencies>
-		      <dependency>
-			<groupId>com.google.googlejavaformat</groupId>
-			<artifactId>google-java-format</artifactId>
-			<version>1.11.0</version>
-		      </dependency>
-		    </dependencies>
                     <executions>
 	                <execution>
 			    <phase>compile</phase>


### PR DESCRIPTION
Our jenkins jobs run Java 8. The latest version of google-java-format that supports Java 8 is 1.7. google-java-format 1.11.0 requires Java 11.