### PR TITLE
KREST-2303: Try harder to find ConsumerLag in integration test.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -247,7 +247,7 @@ public class TestUtils {
     testWithRetry(assertions, DEFAULT_EXP_BACKOFF_RETRIES, null, DEFAULT_RETRY_INTERVAL, true);
   }
 
-  private static void testWithRetry(
+  public static void testWithRetry(
       Runnable assertions,
       int numRetries,
       Duration timeout,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
@@ -247,8 +247,11 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
               assertEquals(expectedOffsets[finalT][finalP], (long) consumerLagData.getCurrentOffset());
               assertEquals(expectedOffsets[finalT][finalP], (long) consumerLagData.getLogEndOffset());
               assertEquals(0, (long) consumerLagData.getLag());
-            }
-        );
+            },
+            /* numRetries= */ 6,
+            /* timeout= */ null,
+            /* initialRetryInterval= */ Duration.ofMillis(200),
+            /* isExponentialBackoff= */ true);
       }
     }
 


### PR DESCRIPTION
getConsumerLag_returnsConsumerLag produces some records to a couple of
topics, creates a few consumers, then tries to find what is the
consumer lag for each consumer. It turns out it takes some time for
consumer information to propagate everywhere. That means, sometimes,
the test can't find the consumer lags.

By default it tries 3 times. This change makes it try harder: 6 times
instead. There's no data involved in the choice of the new value other
than it is twice the current value.

Assuming 200ms exponential backoff, currently the tries are around
times 0ms, 200ms and 600ms. With the new value of 6 tries, it should
look like 0ms, 200ms, 600ms, 1s400ms, 3s and 6s200ms. That should give
it plenty of time for consumer data to flow everywhere. It will make
tests slower though.