### PR TITLE
KREST-2303: Try longer consumer poll in getConsumerLag integration test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -268,7 +268,7 @@ public class TestUtils {
     testWithRetry(assertions, DEFAULT_EXP_BACKOFF_RETRIES, null, DEFAULT_RETRY_INTERVAL, true);
   }
 
-  public static void testWithRetry(
+  private static void testWithRetry(
       Runnable assertions,
       int numRetries,
       Duration timeout,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
@@ -227,7 +227,8 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
     KafkaConsumer<?, ?> consumer = createConsumer(group1, "client-1");
     consumer.subscribe(Arrays.asList(topic1, topic2));
     // consume from subscribed topics (zero lag)
-    consumer.poll(Duration.ofSeconds(1));
+    consumer.poll(Duration.ofSeconds(5));
+    consumer.poll(Duration.ofSeconds(5));
     consumer.commitSync();
 
     for (int t = 0; t < numTopics; t++) {
@@ -257,11 +258,8 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
               assertEquals(
                   expectedOffsets[finalT][finalP], (long) consumerLagData.getLogEndOffset());
               assertEquals(0, (long) consumerLagData.getLag());
-            },
-            /* numRetries= */ 6,
-            /* timeout= */ null,
-            /* initialRetryInterval= */ Duration.ofMillis(200),
-            /* isExponentialBackoff= */ true);
+            }
+        );
       }
     }
 


### PR DESCRIPTION
Most recent test failure: 
https://jenkins.confluent.io/job/confluentinc/job/kafka-rest/job/master/5718/testReport/io.confluent.kafkarest.integration.v3/ConsumerLagsResourceIntegrationTest/getConsumerLag_returnsConsumerLag/
```
[2021-09-13 12:18:29,812] INFO 127.0.0.1 - - [13/Sep/2021:12:18:29 +0000] "GET /v3/clusters/lz7kmpQcRlmmyZFgDkR4JA/consumer-groups/consumer-group-1/lags/topic-1/partitions/0 HTTP/1.1" 404 73 "-" "Jersey/2.34 (HttpUrlConnection 1.8.0_292)" 94 (io.confluent.rest-utils.requests:62)
[2021-09-13 12:18:36,418] ERROR Request Failed with exception  (io.confluent.rest.exceptions.DebuggableExceptionMapper:103)
javax.ws.rs.NotFoundException: Consumer group offsets could not be found.
```
Most recent testbreak ticket: https://confluentinc.atlassian.net/browse/KREST-2408

Not sure if original test failure was also due to `Consumer group offsets could not be found`, but I have a feeling that was the case since `listConsumerLags_returnsConsumerLags` did not fail. Increasing the consumer poll time will hopefully fix this. 