### PR TITLE
MINOR: fix format for spotless check

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
@@ -248,8 +248,7 @@ public class ConsumerLagsResourceIntegrationTest extends ClusterTestHarness {
               assertEquals(expectedOffsets[finalT][finalP], (long) consumerLagData.getCurrentOffset());
               assertEquals(expectedOffsets[finalT][finalP], (long) consumerLagData.getLogEndOffset());
               assertEquals(0, (long) consumerLagData.getLag());
-            }
-        );
+            });
       }
     }
 


### PR DESCRIPTION
Checked in https://github.com/confluentinc/kafka-rest/commit/74f10d70138777583f4d6f6df82c557558681c04 to 7.0.x to fix `KREST-2408`. When I tried checking in the same changes https://github.com/confluentinc/kafka-rest/pull/906/ to `master` a format issue cropped up, this commit fixes it.

https://jenkins.confluent.io/job/Confluentinc%20Contributors/job/kafka-rest/job/PR-906/2/console
```
12:12:36  [ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.12.3:check (default) on project kafka-rest: The following files had format violations:
12:12:36  [ERROR]     src/test/java/io/confluent/kafkarest/integration/v3/ConsumerLagsResourceIntegrationTest.java
12:12:36  [ERROR]         @@ -258,8 +258,7 @@
12:12:36  [ERROR]          ??????????????assertEquals(
12:12:36  [ERROR]          ??????????????????expectedOffsets[finalT][finalP],?(long)?consumerLagData.getLogEndOffset());
12:12:36  [ERROR]          ??????????????assertEquals(0,?(long)?consumerLagData.getLag());
12:12:36  [ERROR]         -????????????}
12:12:36  [ERROR]         -????????);
12:12:36  [ERROR]         +????????????});
12:12:36  [ERROR]          ??????}
12:12:36  [ERROR]          ????}
```