### PR TITLE
Log setup/teardown of integration tests

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -75,6 +75,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.collection.JavaConverters;
 
@@ -85,6 +87,8 @@ import scala.collection.JavaConverters;
  */
 @Category(IntegrationTest.class)
 public abstract class ClusterTestHarness {
+
+  private static final Logger log = LoggerFactory.getLogger(ClusterTestHarness.class);
 
   public static final int DEFAULT_NUM_BROKERS = 1;
 
@@ -167,6 +171,7 @@ public abstract class ClusterTestHarness {
 
   @Before
   public void setUp() throws Exception {
+    log.info("Starting setup of {}", getClass().getSimpleName());
     zookeeper = new EmbeddedZookeeper();
     zkConnect = String.format("127.0.0.1:%d", zookeeper.port());
     Time time = Time.SYSTEM;
@@ -230,9 +235,11 @@ public abstract class ClusterTestHarness {
     restApp = new KafkaRestApplication(restConfig);
     restServer = restApp.createServer();
     restServer.start();
+    log.info("Completed setup of {}", getClass().getSimpleName());
   }
 
   private void startBrokersConcurrently(int numBrokers) {
+    log.info("Starting concurrently {} brokers for {}", numBrokers, getClass().getSimpleName());
     configs =
         IntStream.range(0, numBrokers)
             .mapToObj(brokerId -> KafkaConfig.fromProps(
@@ -250,6 +257,7 @@ public abstract class ClusterTestHarness {
                                     System.nanoTime()))))
                 .collect(toList()))
             .join();
+    log.info("Started all {} brokers for {}", numBrokers, getClass().getSimpleName());
   }
 
   protected void setupAcls() {
@@ -285,6 +293,7 @@ public abstract class ClusterTestHarness {
 
   @After
   public void tearDown() throws Exception {
+    log.info("Starting teardown of {}", getClass().getSimpleName());
     if (restServer != null) {
       restServer.stop();
       restServer.join();
@@ -304,6 +313,7 @@ public abstract class ClusterTestHarness {
 
     zkClient.close();
     zookeeper.shutdown();
+    log.info("Completed teardown of {}", getClass().getSimpleName());
   }
 
   protected Invocation.Builder request(String path) {


### PR DESCRIPTION
Some of kafka-rest's integration tests seem to take more than 80% of their running time just for setup + teardown. In addition to that, during the teardown, some errors that would usually indicate a serious failure can be seen.

This change adds some simple logging that will help identifying the rough ratios of setup to actual test to teardown. It will also help us identify if some usually unexpected error is happening during teardown (which might actually make the error expected).