### PR TITLE
KREST-2837 move produce resource cleanup to end of streaming response.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
@@ -129,8 +129,5 @@ public class DefaultKafkaRestContext implements KafkaRestContext {
     if (adminClient != null) {
       adminClient.close();
     }
-    if (producer != null) {
-      producer.close();
-    }
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ProduceController.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ProduceController.java
@@ -37,4 +37,7 @@ public interface ProduceController {
       Optional<ByteString> key,
       Optional<ByteString> value,
       Instant timestamp);
+
+  /** dispose of any resources. */
+  void dispose();
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ProduceControllerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ProduceControllerImpl.java
@@ -78,4 +78,10 @@ final class ProduceControllerImpl implements ProduceController {
         });
     return result;
   }
+
+  @Override
+  public void dispose() {
+    log.debug("Closing Producer");
+    producer.close();
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -102,7 +102,9 @@ public final class ProduceAction {
       throws Exception {
     ProduceController controller = produceController.get();
     StreamingResponse.from(requests)
-        .compose(request -> produce(clusterId, topicName, request, controller))
+        .compose(
+            request -> produce(clusterId, topicName, request, controller),
+            () -> controller.dispose())
         .resume(asyncResponse);
   }
 


### PR DESCRIPTION
As noticed in previous testing we are seeing producers closed before all messages are written to them. This is because the context shutdown() call that closes the producer is made in a filter called when a response is created rather than completed. For streaming concerns the response is created (and resumed) a long time before it has completed writing. 

To keep things generic a new 'dispose' Runnable has been added to ComposingStreamingResponse, this is called in an overriden resume() method directly after the superclass resume (that closes the response channel) is called.

I this case the runnable calls a new method on the ProducerController for disposing of resources. 

This behaviour is covered in the existing integration tests. 