### PR TITLE
KREST-2654 Rate limit per clusterId

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -162,7 +162,9 @@ public class KafkaRestConfig extends RestConfig {
       "Maximum number of requests per second before the grace period for producer rate limiting "
           + "comes into force. Within the grace period, the wait_for_ms field of the response "
           + "suggests to the client how long to wait before attempting to produce again. "
-          + "Once the grace period has expired the client is disconnected.";
+          + "Once the grace period has expired the client is disconnected. "
+          + "The limit is enforced per clusterId, so the total rate limit will be "
+          + "number of clusters * api.v3.produce.rate.limit.max.requests.per.sec ";
   public static final String PRODUCE_MAX_REQUESTS_PER_SECOND_DEFAULT = "10000";
   public static final ConfigDef.Range PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR =
       ConfigDef.Range.between(1, Integer.MAX_VALUE);
@@ -174,6 +176,12 @@ public class KafkaRestConfig extends RestConfig {
   public static final String PRODUCE_GRACE_PERIOD_MS_DEFAULT = "30000";
   public static final ConfigDef.Range PRODUCE_GRACE_PERIOD_MS_VALIDATOR =
       ConfigDef.Range.between(0, Integer.MAX_VALUE);
+
+  public static final String PRODUCE_CACHE_EXPIRY_MS = "api.v3.produce.cache.expiry.ms";
+  private static final String PRODUCE_CACHE_EXPIRY_MS_DOC =
+      "How long after the last produce a cluster remains in the cache storing rateLimits. Default "
+          + "is 1 hour.";
+  public static final String PRODUCE_CACHE_EXPIRY_MS_DEFAULT = "3600000";
 
   public static final String CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG = "consumer.iterator.timeout.ms";
   private static final String CONSUMER_ITERATOR_TIMEOUT_MS_DOC =
@@ -487,6 +495,12 @@ public class KafkaRestConfig extends RestConfig {
             PRODUCE_GRACE_PERIOD_MS_VALIDATOR,
             Importance.LOW,
             PRODUCE_GRACE_PERIOD_MS_DOC)
+        .define(
+            PRODUCE_CACHE_EXPIRY_MS,
+            Type.INT,
+            PRODUCE_CACHE_EXPIRY_MS_DEFAULT,
+            Importance.LOW,
+            PRODUCE_CACHE_EXPIRY_MS_DOC)
         .define(
             CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -177,11 +177,12 @@ public class KafkaRestConfig extends RestConfig {
   public static final ConfigDef.Range PRODUCE_GRACE_PERIOD_MS_VALIDATOR =
       ConfigDef.Range.between(0, Integer.MAX_VALUE);
 
-  public static final String PRODUCE_CACHE_EXPIRY_MS = "api.v3.produce.cache.expiry.ms";
-  private static final String PRODUCE_CACHE_EXPIRY_MS_DOC =
+  public static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS =
+      "api.v3.produce.rate.limit.cache.expiry.ms";
+  private static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DOC =
       "How long after the last produce a cluster remains in the cache storing rateLimits. Default "
           + "is 1 hour.";
-  public static final String PRODUCE_CACHE_EXPIRY_MS_DEFAULT = "3600000";
+  public static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DEFAULT = "3600000";
 
   public static final String CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG = "consumer.iterator.timeout.ms";
   private static final String CONSUMER_ITERATOR_TIMEOUT_MS_DOC =
@@ -496,11 +497,11 @@ public class KafkaRestConfig extends RestConfig {
             Importance.LOW,
             PRODUCE_GRACE_PERIOD_MS_DOC)
         .define(
-            PRODUCE_CACHE_EXPIRY_MS,
+            PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS,
             Type.INT,
-            PRODUCE_CACHE_EXPIRY_MS_DEFAULT,
+            PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DEFAULT,
             Importance.LOW,
-            PRODUCE_CACHE_EXPIRY_MS_DOC)
+            PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DOC)
         .define(
             CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -91,7 +91,7 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
         .to(Boolean.class);
 
-    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_CACHE_EXPIRY_MS)))
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
         .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
         .to(Duration.class);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -79,6 +79,22 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new CrnAuthorityConfigImpl())
         .to(String.class);
 
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitConfigImpl())
+        .to(Integer.class);
+
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS)))
+        .qualifiedBy(new ProduceGracePeriodConfigImpl())
+        .to(Duration.class);
+
+    bind(config.getBoolean(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED))
+        .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
+        .to(Boolean.class);
+
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_CACHE_EXPIRY_MS)))
+        .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
+        .to(Duration.class);
+
     bind(config.getString(KafkaRestConfig.HOST_NAME_CONFIG))
         .qualifiedBy(new HostNameConfigImpl())
         .to(String.class);
@@ -262,6 +278,15 @@ public final class ConfigModule extends AbstractBinder {
 
   private static final class ProduceGracePeriodConfigImpl
       extends AnnotationLiteral<ProduceGracePeriodConfig> implements ProduceGracePeriodConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceRateLimitCacheExpiryConfig {}
+
+  private static final class ProduceRateLimitCacheExpiryConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitCacheExpiryConfig>
+      implements ProduceRateLimitCacheExpiryConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
@@ -28,6 +28,6 @@ public final class RateLimitGracePeriodExceededException extends StatusCodeExcep
             + " messages per second exceeded within the grace period of "
             + gracePeriod.toMillis()
             + " ms ",
-        "connection will be closed.");
+        "Connection will be closed.");
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.confluent.kafkarest.config.ConfigModule.ProduceGracePeriodConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitCacheExpiryConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitEnabledConfig;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+
+public class ProduceRateLimiters {
+
+  private final int maxRequestsPerSecond;
+  private final Duration gracePeriod;
+  private final boolean rateLimitingEnabled;
+  private LoadingCache<String, ProduceRateLimiter> cache;
+
+  @Inject
+  public ProduceRateLimiters(
+      @ProduceGracePeriodConfig Duration produceGracePeriodConfig,
+      @ProduceRateLimitConfig Integer produceRateLimitConfig,
+      @ProduceRateLimitEnabledConfig Boolean produceRateLimitEnabledConfig,
+      @ProduceRateLimitCacheExpiryConfig Duration produceRateLimitCacheExpiryConfig,
+      Clock time) {
+    this.maxRequestsPerSecond = requireNonNull(produceRateLimitConfig);
+    this.gracePeriod = requireNonNull(produceGracePeriodConfig);
+    this.rateLimitingEnabled = requireNonNull(produceRateLimitEnabledConfig);
+    requireNonNull(time);
+
+    CacheLoader<String, ProduceRateLimiter> loader =
+        new CacheLoader<String, ProduceRateLimiter>() {
+          @Override
+          public ProduceRateLimiter load(String key) {
+            return new ProduceRateLimiter(
+                gracePeriod, maxRequestsPerSecond, produceRateLimitEnabledConfig, time);
+          }
+        };
+
+    cache =
+        CacheBuilder.newBuilder()
+            .expireAfterAccess(produceRateLimitCacheExpiryConfig.toMillis(), TimeUnit.MILLISECONDS)
+            .build(loader);
+  }
+
+  public Optional<Duration> calculateGracePeriodExceeded(String clusterId) {
+    if (!rateLimitingEnabled) {
+      return Optional.empty();
+    }
+    ProduceRateLimiter rateLimiter = cache.getUnchecked(clusterId);
+    Optional<Duration> waitTime = rateLimiter.calculateGracePeriodExceeded();
+    return waitTime;
+  }
+
+  public void clear() {
+    cache.invalidateAll();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
@@ -25,7 +25,7 @@ public final class V3ResourcesModule extends AbstractBinder {
 
   @Override
   protected void configure() {
-    bindAsContract(ProduceRateLimiter.class).in(Singleton.class);
+    bindAsContract(ProduceRateLimiters.class).in(Singleton.class);
     bindAsContract(ChunkedOutputFactory.class);
     bindAsContract(StreamingResponseFactory.class);
     bind(Clock.systemUTC()).to(Clock.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -1,0 +1,167 @@
+package io.confluent.kafkarest.resources;
+
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_CACHE_EXPIRY_MS;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.confluent.kafkarest.exceptions.RateLimitGracePeriodExceededException;
+import io.confluent.kafkarest.resources.v3.ProduceRateLimiters;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProduceRateLimitersTest {
+
+  @Test
+  public void rateLimitingDisabledNoWaitTimeGiven() {
+    Clock clock = mock(Clock.class);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "false");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            clock);
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+
+    assertFalse(waitTime.isPresent());
+  }
+
+  @Test
+  public void newRateLimiterReturnsNoWait() {
+    Clock clock = mock(Clock.class);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            clock);
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+
+    assertFalse(waitTime.isPresent());
+  }
+
+  @Test
+  public void waitTimesReturnedForMultipleClusters() {
+    Clock clock = mock(Clock.class);
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+    expect(clock.millis()).andReturn(2L);
+    replay(clock);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            clock);
+
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+    waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertTrue(waitTime.isPresent());
+    assertEquals(waitTime.get().toMillis(), 1000);
+    Optional<Duration> waitTime2 = produceRateLimiters.calculateGracePeriodExceeded("clusterId2");
+    assertFalse(waitTime2.isPresent());
+    assertTrue(waitTime.isPresent());
+    assertEquals(waitTime.get().toMillis(), 1000);
+  }
+
+  @Test
+  public void gracePeriodExceptionThrown() {
+    Clock clock = mock(Clock.class);
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+    replay(clock);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(0));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            clock);
+
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+    try {
+      produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+      fail("RateLimitGracePeriodExceededException should be thrown");
+    } catch (RateLimitGracePeriodExceededException e) {
+      assertEquals("Connection will be closed.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void cacheExpiresforeRateLimit() throws InterruptedException {
+    Clock clock = mock(Clock.class);
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+    expect(clock.millis()).andReturn(8L);
+    replay(clock);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(100));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(5));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            clock);
+
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+    waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertTrue(waitTime.isPresent());
+    assertEquals(waitTime.get().toMillis(), 1000);
+    Thread.sleep(6);
+    waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -1,8 +1,8 @@
 package io.confluent.kafkarest.resources;
 
-import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
@@ -33,14 +33,15 @@ public class ProduceRateLimitersTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "false");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock);
     Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
 
@@ -55,14 +56,15 @@ public class ProduceRateLimitersTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock);
     Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
 
@@ -81,14 +83,15 @@ public class ProduceRateLimitersTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock);
 
     Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
@@ -113,14 +116,15 @@ public class ProduceRateLimitersTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(0));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock);
 
     Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
@@ -145,14 +149,15 @@ public class ProduceRateLimitersTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(100));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(5));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(5));
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock);
 
     Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -1,8 +1,8 @@
 package io.confluent.kafkarest.resources.v3;
 
-import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyObject;
@@ -48,7 +48,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_GRACE_PERIOD_MS, "0");
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, "1");
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, "3600000");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, "3600000");
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -102,7 +102,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory0 = mock(ChunkedOutputFactory.class);
@@ -118,7 +118,8 @@ public class ProduceActionTest {
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock);
 
     ProduceAction produceAction0 =
@@ -209,7 +210,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -311,7 +312,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(10000));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(30000));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -370,7 +371,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -594,7 +595,8 @@ public class ProduceActionTest {
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
-            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
             clock),
         chunkedOutputFactory,
         times,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -1,5 +1,6 @@
 package io.confluent.kafkarest.resources.v3;
 
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
@@ -47,6 +48,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_GRACE_PERIOD_MS, "0");
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, "1");
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, "3600000");
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -68,7 +70,7 @@ public class ProduceActionTest {
         ErrorResponse.create(
             429,
             "Rate limit of 1 messages per second exceeded within the grace period of 0 ms "
-                + ": connection will be closed.");
+                + ": Connection will be closed.");
     ResultOrError resultOrErrorFail = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorFail); // failing second produce
@@ -100,6 +102,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory0 = mock(ChunkedOutputFactory.class);
@@ -110,19 +113,20 @@ public class ProduceActionTest {
         getChunkedOutput(chunkedOutputFactory1, TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD1);
     Clock clock = mock(Clock.class);
 
-    ProduceRateLimiter rateLimiter =
-        new ProduceRateLimiter(
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
             clock);
 
     ProduceAction produceAction0 =
         getProduceAction(
-            rateLimiter, chunkedOutputFactory0, TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD0, 0);
+            produceRateLimiters, chunkedOutputFactory0, TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD0, 0);
     ProduceAction produceAction1 =
         getProduceAction(
-            rateLimiter, chunkedOutputFactory1, TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD1, 1);
+            produceRateLimiters, chunkedOutputFactory1, TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD1, 1);
     MappingIterator<ProduceRequest> requests0 =
         getProduceRequestsMappingIterator(TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD0);
     MappingIterator<ProduceRequest> requests1 =
@@ -159,7 +163,7 @@ public class ProduceActionTest {
         ErrorResponse.create(
             429,
             "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : connection will be closed.");
+                + "ms : Connection will be closed.");
     ResultOrError resultOrErrorOKProd5 = ResultOrError.error(err);
     expect(mockedChunkedOutput1.isClosed()).andReturn(false);
     mockedChunkedOutput1.write(resultOrErrorOKProd5);
@@ -205,6 +209,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -252,7 +257,7 @@ public class ProduceActionTest {
         ErrorResponse.create(
             429,
             "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : connection will be closed.");
+                + "ms : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -306,6 +311,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(10000));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(30000));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -364,6 +370,7 @@ public class ProduceActionTest {
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_CACHE_EXPIRY_MS, Integer.toString(3600000));
 
     // setup
     ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
@@ -407,7 +414,7 @@ public class ProduceActionTest {
         ErrorResponse.create(
             429,
             "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : connection will be closed.");
+                + "ms : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -583,10 +590,11 @@ public class ProduceActionTest {
   private static ProduceAction getProduceAction(
       Properties properties, ChunkedOutputFactory chunkedOutputFactory, Clock clock, int times) {
     return getProduceAction(
-        new ProduceRateLimiter(
+        new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_CACHE_EXPIRY_MS))),
             clock),
         chunkedOutputFactory,
         times,
@@ -594,7 +602,7 @@ public class ProduceActionTest {
   }
 
   private static ProduceAction getProduceAction(
-      ProduceRateLimiter rateLimiter,
+      ProduceRateLimiters produceRateLimiters,
       ChunkedOutputFactory chunkedOutputFactory,
       int times,
       int producerId) {
@@ -618,9 +626,8 @@ public class ProduceActionTest {
             produceControllerProvider,
             producerMetricsProvider,
             streamingResponseFactory,
-            rateLimiter);
-    rateLimiter.resetGracePeriodStart();
-    rateLimiter.clear();
+            produceRateLimiters);
+    produceRateLimiters.clear();
 
     return produceAction;
   }


### PR DESCRIPTION
Before this change, in a multi-tennant cluster, the overall rate limit for produce would be contributed to by all all the sepaate logical clusters.

This meant that one customer could use up the whole quote for the PKC for their single LKC, effectively blocking other customers from using their clusters.

This commit updates the rate limit to be per cluster id, so that each LKC has its own rate limit.

We'll have to carefully consider what to set the limit to, as if there are many LKCs we need to be careful not to swamp the cluster.