### PR TITLE
KREST-1936 Remove mask filtering of producer configs.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -44,7 +44,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.MediaType;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Range;
@@ -54,7 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Settings for the REST proxy server.
+ * Settings for the Kafka REST server.
  */
 public class KafkaRestConfig extends RestConfig {
 
@@ -357,13 +356,6 @@ public class KafkaRestConfig extends RestConfig {
   private static final String API_V3_ENABLE_DOC =
       "Whether to enable REST Proxy V3 API. Default is true.";
   private static final boolean API_V3_ENABLE_DEFAULT = true;
-
-  // These property names should not be filtered out when determining the allowed properties for
-  // producer and consumer configs. See KREST-481 for more details.
-  private static final String MONITORING_INTERCEPTOR_TOPIC_CONFIG =
-      "confluent.monitoring.interceptor.topic";
-  private static final String MONITORING_INTERCEPTOR_PUBLISH_MS_PERIOD_CONFIG =
-      "confluent.monitoring.interceptor.publishMs";
 
   private static final ConfigDef config;
 
@@ -848,17 +840,12 @@ public class KafkaRestConfig extends RestConfig {
   }
 
   public Properties getProducerProperties() {
-    Set<String> mask =
-        ImmutableSet.<String>builder()
-            .addAll(ProducerConfig.configNames())
-            .add(MONITORING_INTERCEPTOR_TOPIC_CONFIG)
-            .add(MONITORING_INTERCEPTOR_PUBLISH_MS_PERIOD_CONFIG)
-            .build();
     Map<String, Object> producerConfigs =
-        new ConfigsBuilder(mask)
+        new ConfigsBuilder()
             .addConfig(BOOTSTRAP_SERVERS_CONFIG)
             .addConfigs("client.")
             .addConfigs("producer.")
+            .addConfigs("schema.registry.", false)
             .build();
 
     Properties producerProperties = new Properties();
@@ -925,8 +912,12 @@ public class KafkaRestConfig extends RestConfig {
   }
 
   private final class ConfigsBuilder {
-    private final Set<String> mask ;
+    private final Set<String> mask;
     private final Map<String, ConfigValue> configs = new HashMap<>();
+
+    private ConfigsBuilder() {
+      this.mask = null;
+    }
 
     private ConfigsBuilder(Set<String> mask) {
       this.mask = requireNonNull(mask);
@@ -946,14 +937,17 @@ public class KafkaRestConfig extends RestConfig {
     }
 
     private ConfigsBuilder addConfigs(String prefix, boolean strip) {
-      Map<String, ConfigValue> toAdd =
-          Maps.filterKeys(originalsWithPrefix(prefix, strip), mask::contains)
-              .entrySet()
-              .stream()
-              .collect(
-                  Collectors.toMap(
-                      Entry::getKey,
-                      entry -> ConfigValue.create(prefix + entry.getKey(), entry.getValue())));
+      Map<String, Object> filtered = originalsWithPrefix(prefix, strip);
+      if (mask != null) {
+        filtered = Maps.filterKeys(filtered, mask::contains);
+      }
+      Map<String, ConfigValue> toAdd = filtered
+          .entrySet()
+          .stream()
+          .collect(
+              Collectors.toMap(
+                  Entry::getKey,
+                  entry -> ConfigValue.create(prefix + entry.getKey(), entry.getValue())));
       addConfigs(toAdd);
       return this;
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -37,6 +37,7 @@ import io.confluent.rest.RestConfigException;
 import io.confluent.rest.metrics.RestMetricsContext;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -916,7 +917,7 @@ public class KafkaRestConfig extends RestConfig {
     private final Map<String, ConfigValue> configs = new HashMap<>();
 
     private ConfigsBuilder() {
-      this.mask = null;
+      this(Collections.emptySet());
     }
 
     private ConfigsBuilder(Set<String> mask) {
@@ -938,7 +939,7 @@ public class KafkaRestConfig extends RestConfig {
 
     private ConfigsBuilder addConfigs(String prefix, boolean strip) {
       Map<String, Object> filtered = originalsWithPrefix(prefix, strip);
-      if (mask != null) {
+      if (!mask.isEmpty()) {
         filtered = Maps.filterKeys(filtered, mask::contains);
       }
       Map<String, ConfigValue> toAdd = filtered

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -187,39 +187,39 @@ public class KafkaRestConfigTest {
   }
 
   @Test
-  public void getProducerProperties_doesNotPropagateSchemaRegistryConfigs() {
+  public void getProducerProperties_propagatesSchemaRegistryConfigs() {
     Properties properties = new Properties();
     properties.put("schema.registry.url", "foobar");
     properties.put("schema.registry.basic.auth.user.info", "fozbaz");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
-    assertNull(producerProperties.get("schema.registry.url"));
-    assertNull(producerProperties.get("schema.registry.basic.auth.user.info"));
+    assertEquals("foobar", producerProperties.get("schema.registry.url"));
+    assertEquals("fozbaz", producerProperties.get("schema.registry.basic.auth.user.info"));
   }
 
   @Test
-  public void getProducerProperties_doesNotPropagateClientSchemaRegistryConfigs() {
+  public void getProducerProperties_propagatesClientSchemaRegistryConfigs() {
     Properties properties = new Properties();
     properties.put("client.schema.registry.url", "foobar");
     properties.put("client.schema.registry.basic.auth.user.info", "fozbaz");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
-    assertNull(producerProperties.get("schema.registry.url"));
-    assertNull(producerProperties.get("schema.registry.basic.auth.user.info"));
+    assertEquals("foobar", producerProperties.get("schema.registry.url"));
+    assertEquals("fozbaz", producerProperties.get("schema.registry.basic.auth.user.info"));
   }
 
   @Test
-  public void getProducerProperties_doesNotPropagateProducerSchemaRegistryConfigs() {
+  public void getProducerProperties_propagatesProducerSchemaRegistryConfigs() {
     Properties properties = new Properties();
     properties.put("producer.schema.registry.url", "foobar");
     properties.put("producer.schema.registry.basic.auth.user.info", "fozbaz");
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     Properties producerProperties = config.getProducerProperties();
-    assertNull(producerProperties.get("schema.registry.url"));
-    assertNull(producerProperties.get("schema.registry.basic.auth.user.info"));
+    assertEquals("foobar", producerProperties.get("schema.registry.url"));
+    assertEquals("fozbaz", producerProperties.get("schema.registry.basic.auth.user.info"));
   }
 
   @Test


### PR DESCRIPTION
This change removes the filtering of all properties not explicitly known to be valid for producer configs. This has demonstrated to be a problem for producer configs before (see [KREST-481](https://confluentinc.atlassian.net/browse/KREST-481)), and now causes a problem for other interceptor configs.

Note that such filtering doesn't work in the general case in the face of extensibility mechanisms that Kafka has (like interceptors) that don't provide a way to register their expected and allowed config in advance.

That same filtering has been left unchanged for the different SR-related configs, despite a history of causing problems there too (see [KREST-1187](https://confluentinc.atlassian.net/browse/KREST-1187)). Removing that same filtering for SR-related configs requires more refactoring so it won't be addressed in this change.

P.S. This is pending testing of the exact use-case described by @conan-goldsmith in [KREST-1936](https://confluentinc.atlassian.net/browse/KREST-1936).