### PR TITLE
#341 - fix deadlock condition when rebalancing by multiple instances

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -65,7 +65,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
 
   private final Queue<ConsumerRecord<KafkaKeyT, KafkaValueT>> consumerRecords = new ArrayDeque<>();
 
-  volatile long expiration;
+  volatile Long expiration;
 
   KafkaConsumerState(
       KafkaRestConfig config,
@@ -335,13 +335,17 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
         .map(OffsetAndTimestamp::offset);
   }
 
-  public synchronized boolean expired(long nowMs) {
-    return expiration <= nowMs;
+  public boolean expired(long nowMs) {
+    synchronized (expiration) {
+      return expiration <= nowMs;
+    }
   }
 
-  public synchronized void updateExpiration() {
-    this.expiration = config.getTime().milliseconds()
-                      + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
+  public void updateExpiration() {
+    synchronized (expiration) {
+      this.expiration = config.getTime().milliseconds()
+              + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
+    }
   }
 
   public synchronized KafkaRestConfig getConfig() {


### PR DESCRIPTION
this is to fix the issue: #341
when rebalancing starts by multiple instances in a consumer group, a pseudo deadlock condition occurs:

thread a. (Consumer Expiration Thread)
 1) acquired the KafkaConsumerManager instance (lock A) within KafkaConsumerManager$ExpirationThread::Run
 2) waiting to acquire the KafkaConsumerState instance (lock B) within KafkaConsumerState::expired
 
thread b.
 1) acquired the KafkaConsumerState instance (lock B) within KafkaConsumerState::hasNext in KafkaConsumerReadTask::addRecords
 2) waiting to acquire the ?? (lock C) within KafkaConsumer::poll(0) by rebalancing

thread c.
 1) acquired the ?? (lock C) within jettyHandler
 2) waiting to acquire the KafkaConsumerManager instance (lock A) within KafkaConsumerManager::getConsumerInstance in readRecords


a cyclic lock order is generated by 3 locks and 3 threads, resulting in deadlock.
to resolve this, split the KafkaConsumerState instance lock (lock B) into two locks - a KafkaConsumerState instance lock(existing) and KafkaConsumerState.expiration member lock(new).
as a result, lock B of thread a and lock B of thread b become different locks, breaking the cycle.

since thread b is actually in the running state, the lock C is not exactly the the Java synchronization object.
perhaps it needs permission(lock) to use jetty's handler when certain events are triggered by rebalancing inside KafkaConsumer::poll, which I've referred to as the lock C.