### PR TITLE
KREST-3136 process the produce responses in their own thread

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -195,6 +195,15 @@ public class KafkaRestConfig extends RestConfig {
           + "is 1 hour.";
   public static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DEFAULT = "3600000";
 
+  public static final String PRODUCE_RESPONSE_THREAD_POOL_SIZE =
+      "api.v3.produce.response.thread.pool.size";
+  private static final String PRODUCE_RESPONSE_THREAD_POOL_SIZE_DOC =
+      "Number of threads in the executor thread pool used to process produce responses.";
+  public static final String PRODUCE_RESPONSE_THREAD_POOL_SIZE_DEFAULT =
+      Integer.toString(Runtime.getRuntime().availableProcessors());
+  public static final ConfigDef.Range PRODUCE_RESPONSE_THREAD_POOL_SIZE_VALIDATOR =
+      ConfigDef.Range.between(1, Integer.MAX_VALUE);
+
   public static final String CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG = "consumer.iterator.timeout.ms";
   private static final String CONSUMER_ITERATOR_TIMEOUT_MS_DOC =
       "Timeout for blocking consumer iterator operations. This should be set to a small enough "
@@ -520,6 +529,13 @@ public class KafkaRestConfig extends RestConfig {
             PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DEFAULT,
             Importance.LOW,
             PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DOC)
+        .define(
+            PRODUCE_RESPONSE_THREAD_POOL_SIZE,
+            Type.INT,
+            PRODUCE_RESPONSE_THREAD_POOL_SIZE_DEFAULT,
+            PRODUCE_RESPONSE_THREAD_POOL_SIZE_VALIDATOR,
+            Importance.LOW,
+            PRODUCE_RESPONSE_THREAD_POOL_SIZE_DOC)
         .define(
             CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -123,6 +123,10 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
         .to(Boolean.class);
 
+    bind(config.getInt(KafkaRestConfig.PRODUCE_RESPONSE_THREAD_POOL_SIZE))
+        .qualifiedBy(new ProduceResponseThreadPoolSizeImpl())
+        .to(Integer.class);
+
     bind(config.getProducerConfigs())
         .qualifiedBy(new ProducerConfigsImpl())
         .to(new TypeLiteral<Map<String, Object>>() {});
@@ -303,6 +307,15 @@ public final class ConfigModule extends AbstractBinder {
   private static final class ProduceRateLimitEnabledConfigImpl
       extends AnnotationLiteral<ProduceRateLimitEnabledConfig>
       implements ProduceRateLimitEnabledConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceResponseThreadPoolSizeConfig {}
+
+  private static final class ProduceResponseThreadPoolSizeImpl
+      extends AnnotationLiteral<ProduceResponseThreadPoolSizeConfig>
+      implements ProduceResponseThreadPoolSizeConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
@@ -15,10 +15,24 @@
 
 package io.confluent.kafkarest.resources.v3;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.confluent.kafkarest.config.ConfigModule.ProduceResponseThreadPoolSizeConfig;
 import io.confluent.kafkarest.response.ChunkedOutputFactory;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.time.Clock;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
 import javax.inject.Singleton;
+import org.glassfish.hk2.api.AnnotationLiteral;
+import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 public final class V3ResourcesModule extends AbstractBinder {
@@ -29,5 +43,48 @@ public final class V3ResourcesModule extends AbstractBinder {
     bindAsContract(ChunkedOutputFactory.class);
     bindAsContract(StreamingResponseFactory.class);
     bind(Clock.systemUTC()).to(Clock.class);
+    bindFactory(ProduceResponseExecutorServiceFactory.class)
+        .qualifiedBy(new ProduceResponseThreadPoolImpl())
+        .to(ExecutorService.class)
+        .in(Singleton.class);
+  }
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceResponseThreadPool {}
+
+  private static final class ProduceResponseThreadPoolImpl
+      extends AnnotationLiteral<ProduceResponseThreadPool> implements ProduceResponseThreadPool {}
+
+  private static final class ProduceResponseExecutorServiceFactory
+      implements Factory<ExecutorService> {
+
+    private final int produceResponseThreadPoolSize;
+
+    @Inject
+    ProduceResponseExecutorServiceFactory(
+        @ProduceResponseThreadPoolSizeConfig Integer produceExecutorThreadPoolSize) {
+      this.produceResponseThreadPoolSize = produceExecutorThreadPoolSize;
+    }
+
+    @Override
+    public ExecutorService provide() {
+      ThreadFactory namedThreadFactory =
+          new ThreadFactoryBuilder().setNameFormat("Produce-response-thread-%d").build();
+      return Executors.newFixedThreadPool(produceResponseThreadPoolSize, namedThreadFactory);
+    }
+
+    @Override
+    public void dispose(ExecutorService executorService) {
+      executorService.shutdown();
+      try {
+        if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+          executorService.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        executorService.shutdownNow();
+      }
+    }
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -12,6 +12,7 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 
 import com.fasterxml.jackson.databind.MappingIterator;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.confluent.kafkarest.ProducerMetrics;
 import io.confluent.kafkarest.controllers.ProduceController;
 import io.confluent.kafkarest.controllers.RecordSerializer;
@@ -31,6 +32,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import javax.inject.Provider;
 import org.easymock.EasyMock;
 import org.glassfish.jersey.server.ChunkedOutput;
@@ -668,6 +670,9 @@ public class ProduceActionTest {
     StreamingResponseFactory streamingResponseFactory =
         new StreamingResponseFactory(chunkedOutputFactory);
 
+    // get the current thread so that the call counts can be seen by easy mock
+    ExecutorService executorService = MoreExecutors.newDirectExecutorService();
+
     ProduceAction produceAction =
         new ProduceAction(
             schemaManagerProvider,
@@ -675,9 +680,9 @@ public class ProduceActionTest {
             produceControllerProvider,
             producerMetricsProvider,
             streamingResponseFactory,
-            produceRateLimiters);
+            produceRateLimiters,
+            executorService);
     produceRateLimiters.clear();
-
     return produceAction;
   }
 


### PR DESCRIPTION
We suspect there is conention with the Kafka network thread when using the rest producer.  This commit ensures that produce responses are processed on their own thread.