### PR TITLE
Implement request rate-limiting for Kafka REST.

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -93,7 +93,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils-test</artifactId>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -31,6 +31,7 @@ import io.confluent.kafkarest.extension.EnumConverterProvider;
 import io.confluent.kafkarest.extension.InstantConverterProvider;
 import io.confluent.kafkarest.extension.ResourceAccesslistFeature;
 import io.confluent.kafkarest.extension.RestResourceExtension;
+import io.confluent.kafkarest.ratelimit.RateLimitFeature;
 import io.confluent.kafkarest.resources.ResourcesFeature;
 import io.confluent.kafkarest.response.ResponseModule;
 import io.confluent.rest.Application;
@@ -98,6 +99,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     config.register(new ConfigModule(appConfig));
     config.register(new ControllersModule());
     config.register(new ExceptionsModule());
+    config.register(RateLimitFeature.class);
     config.register(new ResourcesFeature(appConfig));
     config.register(new ResponseModule());
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -15,6 +15,8 @@
 
 package io.confluent.kafkarest;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS;
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION;
 import static java.util.Collections.emptyMap;
@@ -24,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.CommonClientConfigs.METRICS_CONTEXT_PREFIX;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
@@ -32,11 +35,14 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaJsonSerializerConfig;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
+import io.confluent.kafkarest.ratelimit.RateLimitBackend;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.RestConfigException;
 import io.confluent.rest.metrics.RestMetricsContext;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -365,6 +371,43 @@ public class KafkaRestConfig extends RestConfig {
       "Whether to enable REST Proxy V3 API. Default is true.";
   private static final boolean API_V3_ENABLE_DEFAULT = true;
 
+  public static final String RATE_LIMIT_ENABLE_CONFIG = "rate.limit.enable";
+  private static final String RATE_LIMIT_ENABLE_DOC =
+      "Whether to enable request rate-limiting. Default is false.";
+  private static final boolean RATE_LIMIT_ENABLE_DEFAULT = false;
+
+  public static final String RATE_LIMIT_BACKEND_CONFIG = "rate.limit.backend";
+  private static final String RATE_LIMIT_BACKEND_DOC =
+      "The rate-limiting backend to use. The options are 'guava' and 'resilience4j'. Default is "
+          + "'guava'.";
+  private static final String RATE_LIMIT_BACKEND_DEFAULT = "guava";
+
+  public static final String RATE_LIMIT_PERMITS_PER_SEC_CONFIG = "rate.limit.permits.per.sec";
+  private static final String RATE_LIMIT_PERMITS_PER_SEC_DOC =
+      "The maximum number of permits to emit per second. A permit is an unit of cost for a "
+          + "request. More expensive requests will consume more permits. The cost for each "
+          + "resource/method can configured via rate.limit.default.cost and rate.limit.costs. "
+          + "Default is 50.";
+  private static final Integer RATE_LIMIT_PERMITS_PER_SEC_DEFAULT = 50;
+
+  public static final String RATE_LIMIT_TIMEOUT_MS_CONFIG = "rate.limit.timeout.ms";
+  private static final String RATE_LIMIT_TIMEOUT_MS_DOC =
+      "How much to wait for the necessary permits to proceed, in milliseconds. A request that "
+          + "fails to acquire the necessary permits within the timeout will fail with HTTP 429. "
+          + "Default is 0ms.";
+  private static final long RATE_LIMIT_TIMEOUT_MS_DEFAULT = 0;
+
+  public static final String RATE_LIMIT_DEFAULT_COST_CONFIG = "rate.limit.default.cost";
+  private static final String RATE_LIMIT_DEFAULT_COST_DOC =
+      "The default cost for resources/methods without an explicit cost configured via"
+          + "rate.limit.costs. Default is 1.";
+  private static final int RATE_LIMIT_DEFAULT_COST_DEFAULT = 1;
+
+  public static final String RATE_LIMIT_COSTS_CONFIG = "rate.limit.costs";
+  private static final String RATE_LIMIT_COSTS_DOC =
+      "Map of rate-limit cost per endpoint. The map should be in the form 'api1=10,api2=20'.";
+  private static final String RATE_LIMIT_COSTS_DEFAULT = "";
+
   private static final ConfigDef config;
 
   static {
@@ -667,7 +710,43 @@ public class KafkaRestConfig extends RestConfig {
             Type.BOOLEAN,
             API_V3_ENABLE_DEFAULT,
             Importance.LOW,
-            API_V3_ENABLE_DOC);
+            API_V3_ENABLE_DOC)
+        .define(
+            RATE_LIMIT_ENABLE_CONFIG,
+            Type.BOOLEAN,
+            RATE_LIMIT_ENABLE_DEFAULT,
+            Importance.LOW,
+            RATE_LIMIT_ENABLE_DOC)
+        .define(
+            RATE_LIMIT_BACKEND_CONFIG,
+            Type.STRING,
+            RATE_LIMIT_BACKEND_DEFAULT,
+            Importance.LOW,
+            RATE_LIMIT_BACKEND_DOC)
+        .define(
+            RATE_LIMIT_PERMITS_PER_SEC_CONFIG,
+            Type.INT,
+            RATE_LIMIT_PERMITS_PER_SEC_DEFAULT,
+            Importance.LOW,
+            RATE_LIMIT_PERMITS_PER_SEC_DOC)
+        .define(
+            RATE_LIMIT_TIMEOUT_MS_CONFIG,
+            Type.LONG,
+            RATE_LIMIT_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            RATE_LIMIT_TIMEOUT_MS_DOC)
+        .define(
+            RATE_LIMIT_DEFAULT_COST_CONFIG,
+            Type.INT,
+            RATE_LIMIT_DEFAULT_COST_DEFAULT,
+            Importance.LOW,
+            RATE_LIMIT_DEFAULT_COST_DOC)
+        .define(
+            RATE_LIMIT_COSTS_CONFIG,
+            Type.STRING,
+            RATE_LIMIT_COSTS_DEFAULT,
+            Importance.LOW,
+            RATE_LIMIT_COSTS_DOC);
   }
 
   private static Properties getPropsFromFile(String propsFile) throws RestConfigException {
@@ -860,6 +939,42 @@ public class KafkaRestConfig extends RestConfig {
 
   public boolean isV3ApiEnabled() {
     return getBoolean(API_V3_ENABLE_CONFIG);
+  }
+
+  public final boolean isRateLimitEnabled() {
+    return getBoolean(RATE_LIMIT_ENABLE_CONFIG);
+  }
+
+  public final RateLimitBackend getRateLimitBackend() {
+    return RateLimitBackend.valueOf(getString(RATE_LIMIT_BACKEND_CONFIG).toUpperCase());
+  }
+
+  public final Integer getRateLimitPermitsPerSec() {
+    return getInt(RATE_LIMIT_PERMITS_PER_SEC_CONFIG);
+  }
+
+  public final Duration getRateLimitTimeout() {
+    return Duration.ofMillis(getLong(RATE_LIMIT_TIMEOUT_MS_CONFIG));
+  }
+
+  public final int getRateLimitDefaultCost() {
+    return getInt(RATE_LIMIT_DEFAULT_COST_CONFIG);
+  }
+
+  public final ImmutableMap<String, Integer> getRateLimitCosts() {
+    String value = getString(RATE_LIMIT_COSTS_CONFIG);
+    return Arrays.stream(value.split(","))
+        .filter(entry -> !entry.isEmpty())
+        .peek(
+            entry ->
+                checkArgument(
+                    entry.contains("="),
+                    String.format(
+                        "Invalid value for config %s: %s", RATE_LIMIT_COSTS_CONFIG, value)))
+        .collect(
+            toImmutableMap(
+                entry -> entry.substring(0, entry.indexOf('=')),
+                entry -> Integer.valueOf(entry.substring(entry.indexOf('=') + 1))));
   }
 
   public void addTelemetryReporterProperties(Properties props) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -405,7 +405,8 @@ public class KafkaRestConfig extends RestConfig {
 
   public static final String RATE_LIMIT_COSTS_CONFIG = "rate.limit.costs";
   private static final String RATE_LIMIT_COSTS_DOC =
-      "Map of rate-limit cost per endpoint. The map should be in the form 'api1=10,api2=20'.";
+      "Map of rate-limit cost per endpoint. Example value: "
+          + "\"api.v3.clusters.*=1,api.v3.brokers.list=2\". A cost of zero means no rate-limit.";
   private static final String RATE_LIMIT_COSTS_DEFAULT = "";
 
   private static final ConfigDef config;
@@ -964,17 +965,21 @@ public class KafkaRestConfig extends RestConfig {
   public final ImmutableMap<String, Integer> getRateLimitCosts() {
     String value = getString(RATE_LIMIT_COSTS_CONFIG);
     return Arrays.stream(value.split(","))
+        .map(String::trim)
         .filter(entry -> !entry.isEmpty())
         .peek(
             entry ->
                 checkArgument(
                     entry.contains("="),
                     String.format(
-                        "Invalid value for config %s: %s", RATE_LIMIT_COSTS_CONFIG, value)))
+                        "Invalid value for config %s: %s. Example valid value: "
+                            + "\"api.v3.clusters.*=1,api.v3.brokers.list=2\". A cost of zero means "
+                            + "no rate-limit.",
+                        RATE_LIMIT_COSTS_CONFIG, value)))
         .collect(
             toImmutableMap(
-                entry -> entry.substring(0, entry.indexOf('=')),
-                entry -> Integer.valueOf(entry.substring(entry.indexOf('=') + 1))));
+                entry -> entry.substring(0, entry.indexOf('=')).trim(),
+                entry -> Integer.valueOf(entry.substring(entry.indexOf('=') + 1).trim())));
   }
 
   public void addTelemetryReporterProperties(Properties props) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/StatusCodeException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/StatusCodeException.java
@@ -34,7 +34,7 @@ public class StatusCodeException extends RuntimeException {
     return new StatusCodeException(status, title, detail);
   }
 
-  StatusCodeException(Status status, String title, String detail) {
+  public StatusCodeException(Status status, String title, String detail) {
     this(status, status.getStatusCode(), title, detail);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/DoNotRateLimit.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/DoNotRateLimit.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation used to mark resources/methods that should not be automatically rate-limited.
+ *
+ * <p>A resource/method that is annotated with this annotation has an effective cost of zero for
+ * automatic rate-limiting purposes.
+ *
+ * @see RateLimitFeature
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface DoNotRateLimit {}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimitRequestFilter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimitRequestFilter.java
@@ -17,8 +17,6 @@ package io.confluent.kafkarest.ratelimit;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 
@@ -29,15 +27,14 @@ import javax.ws.rs.container.ContainerRequestFilter;
  * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_DEFAULT_COST_CONFIG} configs.
  */
 final class FixedCostRateLimitRequestFilter implements ContainerRequestFilter {
-  private final Provider<FixedCostRateLimiter> rateLimiter;
+  private final FixedCostRateLimiter rateLimiter;
 
-  @Inject
-  FixedCostRateLimitRequestFilter(Provider<FixedCostRateLimiter> rateLimiter) {
+  FixedCostRateLimitRequestFilter(FixedCostRateLimiter rateLimiter) {
     this.rateLimiter = requireNonNull(rateLimiter);
   }
 
   @Override
   public void filter(ContainerRequestContext requestContext) {
-    rateLimiter.get().rateLimit();
+    rateLimiter.rateLimit();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimitRequestFilter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimitRequestFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+/**
+ * A {@link ContainerRequestFilter} that automatically applies a request rate-limit at a fixed cost
+ * based on the resource/method being requested, according to the {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_COSTS_CONFIG} and {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_DEFAULT_COST_CONFIG} configs.
+ */
+final class FixedCostRateLimitRequestFilter implements ContainerRequestFilter {
+  private final Provider<FixedCostRateLimiter> rateLimiter;
+
+  @Inject
+  FixedCostRateLimitRequestFilter(Provider<FixedCostRateLimiter> rateLimiter) {
+    this.rateLimiter = requireNonNull(rateLimiter);
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    rateLimiter.get().rateLimit();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimiter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+/**
+ * A per-resource fixed-cost rate-limiter.
+ *
+ * <p>In a request scope, the cost used for each {@code rateLimit()} call is determined from the
+ * resource/method being requested, based on the {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_COSTS_CONFIG}. If no cost has been configured
+ * for the particular resource/method being requested, {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_DEFAULT_COST_CONFIG} is used instead. A
+ * configured cost of zero means the request is not rate-limited.
+ *
+ * @see RequestRateLimiter
+ */
+interface FixedCostRateLimiter {
+
+  /**
+   * Ensures a rate of at most {@link
+   * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_PERMITS_PER_SEC_CONFIG} requests passes
+   * through.
+   *
+   * <p>Each {@code rateLimit()} call will wait up to {@link
+   * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_TIMEOUT_MS_CONFIG} for permission to go
+   * through.
+   *
+   * @throws RateLimitExceededException if permission to go through has been denied
+   * @see RequestRateLimiter#rateLimit(int)
+   */
+  void rateLimit();
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimiterFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimiterFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.config.ConfigModule.RateLimitCostsConfig;
+import io.confluent.kafkarest.config.ConfigModule.RateLimitDefaultCostConfig;
+import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import org.glassfish.hk2.api.Factory;
+
+/** A {@link Factory} for {@link FixedCostRateLimiter}. */
+final class FixedCostRateLimiterFactory implements Factory<FixedCostRateLimiter> {
+  private final Map<String, Integer> costs;
+  private final int defaultCost;
+  private final ResourceInfo resourceInfo;
+  private final RequestRateLimiter requestRateLimiter;
+
+  @Inject
+  FixedCostRateLimiterFactory(
+      @RateLimitCostsConfig Map<String, Integer> costs,
+      @RateLimitDefaultCostConfig Integer defaultCost,
+      @Context ResourceInfo resourceInfo,
+      RequestRateLimiter requestRateLimiter) {
+    this.costs = requireNonNull(costs);
+    this.defaultCost = defaultCost;
+    this.resourceInfo = requireNonNull(resourceInfo);
+    this.requestRateLimiter = requireNonNull(requestRateLimiter);
+  }
+
+  @Override
+  public FixedCostRateLimiter provide() {
+    int cost = getCost();
+    if (cost == 0) {
+      return new NullFixedCostRateLimiter();
+    } else {
+      return new FixedCostRateLimiterImpl(requestRateLimiter, cost);
+    }
+  }
+
+  @Override
+  public void dispose(FixedCostRateLimiter rateLimiter) {}
+
+  /** Returns the cost of this request for rate-limiting purposes. */
+  private int getCost() {
+    DoNotRateLimit methodIgnore =
+        resourceInfo.getResourceMethod().getAnnotation(DoNotRateLimit.class);
+    if (methodIgnore != null) {
+      return 0;
+    }
+    DoNotRateLimit classIgnore =
+        resourceInfo.getResourceClass().getAnnotation(DoNotRateLimit.class);
+    if (classIgnore != null) {
+      return 0;
+    }
+    ResourceName methodName = resourceInfo.getResourceMethod().getAnnotation(ResourceName.class);
+    if (methodName != null && costs.containsKey(methodName.value())) {
+      return costs.get(methodName.value());
+    }
+    ResourceName className = resourceInfo.getResourceClass().getAnnotation(ResourceName.class);
+    if (className != null && costs.containsKey(className.value())) {
+      return costs.get(className.value());
+    }
+    return defaultCost;
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimiterImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/FixedCostRateLimiterImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Objects.requireNonNull;
+
+/** A {@link FixedCostRateLimiter} implementation that delegates to {@link RequestRateLimiter}. */
+final class FixedCostRateLimiterImpl implements FixedCostRateLimiter {
+  private final RequestRateLimiter delegate;
+  private final int cost;
+
+  FixedCostRateLimiterImpl(RequestRateLimiter delegate, int cost) {
+    this.delegate = requireNonNull(delegate);
+    this.cost = cost;
+  }
+
+  @Override
+  public void rateLimit() {
+    delegate.rateLimit(cost);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/GuavaRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/GuavaRateLimiter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.util.concurrent.RateLimiter;
+import java.time.Duration;
+
+/** A {@link RequestRateLimiter} implementation based on Guava {@link RateLimiter}. */
+final class GuavaRateLimiter extends RequestRateLimiter {
+  private final RateLimiter delegate;
+  private final Duration timeout;
+
+  private GuavaRateLimiter(RateLimiter delegate, Duration timeout) {
+    this.delegate = requireNonNull(delegate);
+    this.timeout = requireNonNull(timeout);
+  }
+
+  static GuavaRateLimiter create(int permitsPerSecond, Duration timeout) {
+    return new GuavaRateLimiter(RateLimiter.create(permitsPerSecond), timeout);
+  }
+
+  @Override
+  public void rateLimit(int cost) {
+    if (!delegate.tryAcquire(cost, timeout)) {
+      throw new RateLimitExceededException();
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/NullFixedCostRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/NullFixedCostRateLimiter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+/** A {@link FixedCostRateLimiter} that doesn't rate-limit anything. */
+final class NullFixedCostRateLimiter implements FixedCostRateLimiter {
+
+  @Override
+  public void rateLimit() {}
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/NullRequestRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/NullRequestRateLimiter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+/** A {@link RequestRateLimiter} that doesn't rate-limit anything. */
+final class NullRequestRateLimiter extends RequestRateLimiter {
+
+  @Override
+  public void rateLimit(int cost) {}
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitBackend.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitBackend.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+/** A {@link RequestRateLimiter} implementation. */
+public enum RateLimitBackend {
+
+  /** @see <a href="https://bit.ly/3CtV3pk">Detailed Explanation of Guava RateLimiter</a> */
+  GUAVA,
+
+  /** @see <a href="https://resilience4j.readme.io/docs/ratelimiter">Resilience4j RateLimiter</a> */
+  RESILIENCE4J
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitExceededException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import io.confluent.kafkarest.exceptions.StatusCodeException;
+import javax.ws.rs.core.Response;
+
+/**
+ * An exception thrown when the request rate-limit has been exceeded.
+ *
+ * @see RequestRateLimiter#rateLimit(int)
+ */
+public final class RateLimitExceededException extends StatusCodeException {
+
+  public RateLimitExceededException() {
+    super(
+        Response.Status.TOO_MANY_REQUESTS,
+        "Request rate limit exceeded",
+        "The rate limit of requests per second has been exceeded.");
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitFeature.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import io.confluent.kafkarest.config.ConfigModule.RateLimitEnabledConfig;
+import javax.inject.Inject;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ * A feature that configures request rate-limiting in the server.
+ *
+ * <p>This feature will configure a server-wide {@link RequestRateLimiter} based on the {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_BACKEND_CONFIG}, {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_PERMITS_PER_SEC_CONFIG} and {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_TIMEOUT_MS_CONFIG} configs. This rate-limiter
+ * can be used for manually rate-limiting requests.
+ *
+ * <p>In addition to that, this feature also configures a per-endpoint filter that automatically
+ * rate-limits requests based on the {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_COSTS_CONFIG} and {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_DEFAULT_COST_CONFIG} configs.
+ *
+ * <p>This feature can be enabled/disabled via the {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_ENABLE_CONFIG} config.
+ */
+public final class RateLimitFeature implements Feature {
+  private final boolean rateLimitEnabled;
+
+  @Inject
+  RateLimitFeature(@RateLimitEnabledConfig Boolean rateLimitEnabled) {
+    this.rateLimitEnabled = rateLimitEnabled;
+  }
+
+  @Override
+  public boolean configure(FeatureContext context) {
+    if (rateLimitEnabled) {
+      context.register(RateLimitModule.class);
+      context.register(FixedCostRateLimitRequestFilter.class);
+      return true;
+    } else {
+      context.register(NullRateLimitModule.class);
+      return false;
+    }
+  }
+
+  /**
+   * A module to make sure {@link RequestRateLimiter} is injectable, even if rate-limiting is
+   * disabled.
+   */
+  private static final class NullRateLimitModule extends AbstractBinder {
+
+    @Override
+    protected void configure() {
+      bind(NullRequestRateLimiter.class).to(RequestRateLimiter.class);
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitFeature.java
@@ -50,7 +50,7 @@ public final class RateLimitFeature implements Feature {
   public boolean configure(FeatureContext context) {
     if (rateLimitEnabled) {
       context.register(RateLimitModule.class);
-      context.register(FixedCostRateLimitRequestFilter.class);
+      context.register(FixedCostRateLimitFeature.class);
       return true;
     } else {
       context.register(NullRateLimitModule.class);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,21 +13,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafkarest.resources.v3;
+package io.confluent.kafkarest.ratelimit;
 
-import io.confluent.kafkarest.response.ChunkedOutputFactory;
-import io.confluent.kafkarest.response.StreamingResponseFactory;
-import java.time.Clock;
 import javax.inject.Singleton;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
 
-public final class V3ResourcesModule extends AbstractBinder {
+/**
+ * A module to configure bindings for {@link FixedCostRateLimiter} and {@link RequestRateLimiter}.
+ */
+final class RateLimitModule extends AbstractBinder {
 
   @Override
   protected void configure() {
-    bindAsContract(ProduceRateLimiter.class).in(Singleton.class);
-    bindAsContract(ChunkedOutputFactory.class);
-    bindAsContract(StreamingResponseFactory.class);
-    bind(Clock.systemUTC()).to(Clock.class);
+    bindFactory(RequestRateLimiterFactory.class).to(RequestRateLimiter.class).in(Singleton.class);
+
+    bindFactory(FixedCostRateLimiterFactory.class)
+        .to(FixedCostRateLimiter.class)
+        .in(RequestScoped.class);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitModule.java
@@ -17,7 +17,6 @@ package io.confluent.kafkarest.ratelimit;
 
 import javax.inject.Singleton;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.process.internal.RequestScoped;
 
 /**
  * A module to configure bindings for {@link FixedCostRateLimiter} and {@link RequestRateLimiter}.
@@ -27,9 +26,5 @@ final class RateLimitModule extends AbstractBinder {
   @Override
   protected void configure() {
     bindFactory(RequestRateLimiterFactory.class).to(RequestRateLimiter.class).in(Singleton.class);
-
-    bindFactory(FixedCostRateLimiterFactory.class)
-        .to(FixedCostRateLimiter.class)
-        .in(RequestScoped.class);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+/**
+ * A server-wide request rate-limiter.
+ *
+ * <p>Requests are rate-limited based on the {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_PERMITS_PER_SEC_CONFIG} and {@link
+ * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_TIMEOUT_MS_CONFIG} configs.
+ *
+ * <p>This rate-limiter can be injected for manual rate-limiting. Be aware that, unless the
+ * resource/method you're manually rate-limiting is marked with {@link DoNotRateLimit}, the request
+ * will already have been automatically rate-limited.
+ */
+public abstract class RequestRateLimiter {
+
+  RequestRateLimiter() {}
+
+  /**
+   * Ensures a rate of at most {@link
+   * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_PERMITS_PER_SEC_CONFIG} requests passes
+   * through.
+   *
+   * <p>Each {@code rateLimit()} call will wait up to {@link
+   * io.confluent.kafkarest.KafkaRestConfig#RATE_LIMIT_TIMEOUT_MS_CONFIG} for permission to go
+   * through.
+   *
+   * @param cost the cost of the request
+   * @throws RateLimitExceededException if permission to go through has been denied
+   */
+  public abstract void rateLimit(int cost);
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiterFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.config.ConfigModule;
+import java.time.Duration;
+import javax.inject.Inject;
+import org.glassfish.hk2.api.Factory;
+
+/** A {@link Factory} for {@link RequestRateLimiter}. */
+final class RequestRateLimiterFactory implements Factory<RequestRateLimiter> {
+  private final RateLimitBackend backend;
+  private final int permitsPerSecond;
+  private final Duration timeout;
+
+  @Inject
+  RequestRateLimiterFactory(
+      RateLimitBackend backend,
+      @ConfigModule.RateLimitPermitsPerSecConfig Integer permitsPerSecond,
+      @ConfigModule.RateLimitTimeoutConfig Duration timeout) {
+    this.backend = requireNonNull(backend);
+    this.permitsPerSecond = permitsPerSecond;
+    this.timeout = requireNonNull(timeout);
+  }
+
+  @Override
+  public RequestRateLimiter provide() {
+    switch (backend) {
+      case GUAVA:
+        return GuavaRateLimiter.create(permitsPerSecond, timeout);
+      case RESILIENCE4J:
+        return Resilience4JRateLimiter.create(permitsPerSecond, timeout);
+      default:
+        throw new AssertionError("Unknown enum constant: " + backend);
+    }
+  }
+
+  @Override
+  public void dispose(RequestRateLimiter rateLimiter) {}
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/Resilience4JRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/Resilience4JRateLimiter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Objects.requireNonNull;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import java.time.Duration;
+
+/** A {@link RequestRateLimiter} implementation based on Resilience4j {@link RateLimiter}. */
+final class Resilience4JRateLimiter extends RequestRateLimiter {
+  private final RateLimiter delegate;
+
+  private Resilience4JRateLimiter(RateLimiter delegate) {
+    this.delegate = requireNonNull(delegate);
+  }
+
+  static Resilience4JRateLimiter create(int permitsPerSecond, Duration timeout) {
+    RateLimiterConfig config =
+        RateLimiterConfig.custom()
+            .timeoutDuration(timeout)
+            .limitRefreshPeriod(Duration.ofSeconds(1))
+            .limitForPeriod(permitsPerSecond)
+            .build();
+    return new Resilience4JRateLimiter(RateLimiter.of("Resilience4JRateLimiter", config));
+  }
+
+  @Override
+  public void rateLimit(int cost) {
+    if (!delegate.acquirePermission(cost)) {
+      throw new RateLimitExceededException();
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -36,8 +36,7 @@ import io.confluent.kafkarest.entities.v3.ProduceResponse;
 import io.confluent.kafkarest.entities.v3.ProduceResponse.ProduceResponseData;
 import io.confluent.kafkarest.exceptions.BadRequestException;
 import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
-import io.confluent.kafkarest.resources.RateLimiter;
-import io.confluent.kafkarest.response.ChunkedOutputFactory;
+import io.confluent.kafkarest.ratelimit.DoNotRateLimit;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
 import java.time.Duration;
@@ -61,6 +60,7 @@ import javax.ws.rs.core.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@DoNotRateLimit
 @Path("/v3/clusters/{clusterId}/topics/{topicName}/records")
 @ResourceName("api.v3.produce.*")
 public final class ProduceAction {
@@ -82,9 +82,8 @@ public final class ProduceAction {
   private final Provider<RecordSerializer> recordSerializerProvider;
   private final Provider<ProduceController> produceControllerProvider;
   private final Provider<ProducerMetrics> producerMetrics;
-  private final ChunkedOutputFactory chunkedOutputFactory;
   private final StreamingResponseFactory streamingResponseFactory;
-  private final RateLimiter rateLimiter;
+  private final ProduceRateLimiter rateLimiter;
 
   @Inject
   public ProduceAction(
@@ -92,14 +91,12 @@ public final class ProduceAction {
       Provider<RecordSerializer> recordSerializer,
       Provider<ProduceController> produceControllerProvider,
       Provider<ProducerMetrics> producerMetrics,
-      ChunkedOutputFactory chunkedOutputFactory,
       StreamingResponseFactory streamingResponseFactory,
-      RateLimiter rateLimiter) {
+      ProduceRateLimiter rateLimiter) {
     this.schemaManagerProvider = requireNonNull(schemaManagerProvider);
     this.recordSerializerProvider = requireNonNull(recordSerializer);
     this.produceControllerProvider = requireNonNull(produceControllerProvider);
     this.producerMetrics = requireNonNull(producerMetrics);
-    this.chunkedOutputFactory = requireNonNull(chunkedOutputFactory);
     this.streamingResponseFactory = requireNonNull(streamingResponseFactory);
     this.rateLimiter = requireNonNull(rateLimiter);
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiter.java
@@ -13,10 +13,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafkarest.resources;
+package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafkarest.config.ConfigModule.ProduceGracePeriodConfig;
 import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitConfig;
 import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitEnabledConfig;
@@ -29,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 
-public final class RateLimiter {
+final class ProduceRateLimiter {
 
   private static final int ONE_SECOND_MS = 1000;
 
@@ -43,7 +44,7 @@ public final class RateLimiter {
   private final AtomicLong gracePeriodStart = new AtomicLong(-1);
 
   @Inject
-  public RateLimiter(
+  ProduceRateLimiter(
       @ProduceGracePeriodConfig Duration produceGracePeriodConfig,
       @ProduceRateLimitConfig Integer produceRateLimitConfig,
       @ProduceRateLimitEnabledConfig Boolean produceRateLimitEnabledConfig,
@@ -54,8 +55,7 @@ public final class RateLimiter {
     this.clock = requireNonNull(clock);
   }
 
-  public Optional<Duration> calculateGracePeriodExceeded()
-      throws RateLimitGracePeriodExceededException {
+  Optional<Duration> calculateGracePeriodExceeded() throws RateLimitGracePeriodExceededException {
     if (!rateLimitingEnabled) {
       return Optional.empty();
     }
@@ -76,12 +76,14 @@ public final class RateLimiter {
     return waitFor;
   }
 
-  public void clear() {
+  @VisibleForTesting
+  void clear() {
     rateCounter.clear();
     rateCounterSize.set(0);
   }
 
-  public void resetGracePeriodStart() {
+  @VisibleForTesting
+  void resetGracePeriodStart() {
     gracePeriodStart.set(-1);
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/AbstractRateLimitEnabledTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/AbstractRateLimitEnabledTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import org.junit.Test;
+
+abstract class AbstractRateLimitEnabledTest extends AbstractRateLimitTest {
+
+  abstract RateLimitBackend getBackend();
+
+  abstract Duration getRate();
+
+  abstract int getWarmupRequests();
+
+  abstract int getTotalRequests();
+
+  abstract int getSlack();
+
+  @Override
+  final List<Class<?>> getResources() {
+    return ImmutableList.of(FoobarResource.class, FozbazResource.class);
+  }
+
+  @Override
+  final Properties getProperties() {
+    Properties properties = new Properties();
+    properties.put("rate.limit.enable", "true");
+    properties.put("rate.limit.backend", getBackend().toString());
+    properties.put("rate.limit.permits.per.sec", "500");
+    properties.put("rate.limit.default.cost", "1");
+    properties.put("rate.limit.costs", "foobar.*=2,foobar.foo=4,fozbaz.baz=0");
+    return properties;
+  }
+
+  @Test
+  public void rateLimitWithDefaultCost() {
+    int oks = hammerAtConstantRate("fozbaz/foz");
+    assertInRange(500 - getSlack(), 500 + getSlack(), oks);
+  }
+
+  @Test
+  public void rateLimitWithZeroCost() {
+    int oks = hammerAtConstantRate("fozbaz/baz");
+    assertEquals(getTotalRequests() - getWarmupRequests(), oks);
+  }
+
+  @Test
+  public void rateLimitWithClassCost() {
+    int oks = hammerAtConstantRate("foobar/bar");
+    assertInRange(250 - getSlack(), 250 + getSlack(), oks);
+  }
+
+  @Test
+  public void rateLimitWithMethodCost() {
+    int oks = hammerAtConstantRate("foobar/foo");
+    assertInRange(125 - getSlack(), 125 + getSlack(), oks);
+  }
+
+  private int hammerAtConstantRate(String path) {
+    return hammerAtConstantRate(path, getRate(), getWarmupRequests(), getTotalRequests());
+  }
+
+  private static void assertInRange(int lower, int upper, int actual) {
+    assertTrue(
+        String.format("%d not in [%d, %d]", actual, lower, upper),
+        actual >= lower && actual <= upper);
+  }
+
+  @Path("foobar")
+  @ResourceName("foobar.*")
+  public static final class FoobarResource {
+
+    @GET
+    @Path("foo")
+    @ResourceName("foobar.foo")
+    public String foo() {
+      return "foo";
+    }
+
+    @GET
+    @Path("bar")
+    @ResourceName("foobar.bar")
+    public String bar() {
+      return "bar";
+    }
+  }
+
+  @Path("fozbaz")
+  @ResourceName("fozbaz.*")
+  public static final class FozbazResource {
+
+    @GET
+    @Path("foz")
+    @ResourceName("fozbaz.foz")
+    public String foo() {
+      return "foz";
+    }
+
+    @GET
+    @Path("baz")
+    @ResourceName("fozbaz.baz")
+    public String baz() {
+      return "baz";
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/AbstractRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/AbstractRateLimitTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.junit.Assert.fail;
+
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.config.ConfigModule;
+import io.confluent.kafkarest.exceptions.ExceptionsModule;
+import io.confluent.rest.validation.JacksonMessageBodyProvider;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.After;
+import org.junit.Before;
+
+abstract class AbstractRateLimitTest extends JerseyTest {
+  private ScheduledExecutorService executor;
+
+  abstract List<Class<?>> getResources();
+
+  abstract Properties getProperties();
+
+  @Override
+  protected final Application configure() {
+    ResourceConfig resourceConfig = new ResourceConfig(getResources().toArray(new Class<?>[0]));
+    resourceConfig.register(new ConfigModule(new KafkaRestConfig(getProperties())));
+    resourceConfig.register(RateLimitFeature.class);
+    resourceConfig.register(ExceptionsModule.class);
+    resourceConfig.register(JacksonMessageBodyProvider.class);
+    return resourceConfig;
+  }
+
+  @Before
+  @Override
+  public final void setUp() throws Exception {
+    super.setUp();
+    executor = Executors.newScheduledThreadPool(4);
+  }
+
+  @After
+  @Override
+  public final void tearDown() throws Exception {
+    super.tearDown();
+    executor.shutdownNow();
+  }
+
+  final int hammerAtConstantRate(
+      String path, Duration rate, int warmupRequests, int totalRequests) {
+    checkArgument(!rate.isNegative(), "rate must be non-negative");
+    checkArgument(warmupRequests <= totalRequests, "warmupRequests must be at most totalRequests");
+
+    List<Response> responses =
+        IntStream.range(0, totalRequests)
+            .mapToObj(
+                i ->
+                    executor.schedule(
+                        () -> target(path).request(MediaType.APPLICATION_JSON_TYPE).get(),
+                        /* delay= */ i * rate.toMillis(),
+                        TimeUnit.MILLISECONDS))
+            .collect(Collectors.toList()).stream()
+            .map(
+                future -> {
+                  try {
+                    return future.get();
+                  } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toList());
+
+    for (int i = warmupRequests; i < responses.size(); i++) {
+      Response response = responses.get(i);
+      int status = response.getStatus();
+      if (status != 200 && status != 429) {
+        fail(
+            String.format(
+                "Expected HTTP 200 or HTTP 429, but got HTTP %d instead: %s",
+                status, response.readEntity(String.class)));
+      }
+    }
+
+    return (int)
+        responses.subList(warmupRequests, responses.size()).stream()
+            .filter(response -> response.getStatus() == Status.OK.getStatusCode())
+            .count();
+  }
+
+  @Override
+  protected final DeploymentContext configureDeployment() {
+    return super.configureDeployment();
+  }
+
+  @Override
+  protected final TestContainerFactory getTestContainerFactory() throws TestContainerException {
+    return super.getTestContainerFactory();
+  }
+
+  @Override
+  protected final Optional<SSLContext> getSslContext() {
+    return super.getSslContext();
+  }
+
+  @Override
+  protected final Optional<SSLParameters> getSslParameters() {
+    return super.getSslParameters();
+  }
+
+  @Override
+  protected final Client getClient() {
+    return super.getClient();
+  }
+
+  @Override
+  protected final Client setClient(Client client) {
+    return super.setClient(client);
+  }
+
+  @Override
+  protected final void configureClient(ClientConfig config) {
+    super.configureClient(config);
+  }
+
+  @Override
+  protected final URI getBaseUri() {
+    return super.getBaseUri();
+  }
+
+  @Override
+  protected final int getAsyncTimeoutMultiplier() {
+    return super.getAsyncTimeoutMultiplier();
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/DoNotRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/DoNotRateLimitTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class DoNotRateLimitTest extends AbstractRateLimitTest {
+
+  @Override
+  final List<Class<?>> getResources() {
+    return ImmutableList.of(FoobarResource.class, FozbazResource.class);
+  }
+
+  @Override
+  final Properties getProperties() {
+    Properties properties = new Properties();
+    properties.put("rate.limit.enable", "true");
+    properties.put("rate.limit.backend", "guava");
+    properties.put("rate.limit.permits.per.sec", "500");
+    properties.put("rate.limit.default.cost", "1");
+    properties.put("rate.limit.costs", "");
+    return properties;
+  }
+
+  @Test
+  public void doNotRateLimitOnClass() {
+    int oks = hammerAtConstantRate("foobar/foo", Duration.ofMillis(1), 0, 1000);
+    assertEquals(1000, oks);
+  }
+
+  @Test
+  public void doNotRateLimitOnMethod() {
+    int oks = hammerAtConstantRate("fozbaz/foz", Duration.ofMillis(1), 0, 1000);
+    assertEquals(1000, oks);
+  }
+
+  @DoNotRateLimit
+  @Path("foobar")
+  @ResourceName("foobar.*")
+  public static final class FoobarResource {
+
+    @GET
+    @Path("foo")
+    @ResourceName("foobar.foo")
+    public String foo() {
+      return "foo";
+    }
+  }
+
+  @Path("fozbaz")
+  @ResourceName("fozbaz.*")
+  public static final class FozbazResource {
+
+    @DoNotRateLimit
+    @GET
+    @Path("foz")
+    @ResourceName("fozbaz.foz")
+    public String foo() {
+      return "foz";
+    }
+
+    @GET
+    @Path("baz")
+    @ResourceName("fozbaz.baz")
+    public String baz() {
+      return "baz";
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
@@ -15,10 +15,9 @@
 
 package io.confluent.kafkarest.ratelimit;
 
+import java.time.Duration;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.time.Duration;
 
 @RunWith(JUnit4.class)
 public final class GuavaRateLimitTest extends AbstractRateLimitEnabledTest {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Duration;
+
+@RunWith(JUnit4.class)
+public final class GuavaRateLimitTest extends AbstractRateLimitEnabledTest {
+
+  @Override
+  RateLimitBackend getBackend() {
+    return RateLimitBackend.GUAVA;
+  }
+
+  @Override
+  Duration getRate() {
+    return Duration.ofMillis(1);
+  }
+
+  @Override
+  int getWarmupRequests() {
+    return 500;
+  }
+
+  @Override
+  int getTotalRequests() {
+    return 1500;
+  }
+
+  @Override
+  int getSlack() {
+    return 5;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/RateLimitDisabledTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/RateLimitDisabledTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class RateLimitDisabledTest extends AbstractRateLimitTest {
+
+  @Override
+  List<Class<?>> getResources() {
+    return singletonList(FooResource.class);
+  }
+
+  @Override
+  Properties getProperties() {
+    Properties properties = new Properties();
+    properties.put("rate.limit.enable", "false");
+    return properties;
+  }
+
+  @Test
+  public void rateLimitDisabled_doesNotRateLimit() {
+    long oks = hammerAtConstantRate("foobar", Duration.ofMillis(1), 0, 1000);
+    assertEquals(1000, oks);
+  }
+
+  @Path("foobar")
+  public static final class FooResource {
+
+    @GET
+    public String bar() {
+      return "foobar";
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/Resilience4jRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/Resilience4jRateLimitTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import java.time.Duration;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class Resilience4jRateLimitTest extends AbstractRateLimitEnabledTest {
+
+  @Override
+  RateLimitBackend getBackend() {
+    return RateLimitBackend.RESILIENCE4J;
+  }
+
+  @Override
+  Duration getRate() {
+    return Duration.ofMillis(1);
+  }
+
+  @Override
+  int getWarmupRequests() {
+    return 750;
+  }
+
+  @Override
+  int getTotalRequests() {
+    return 1750;
+  }
+
+  @Override
+  int getSlack() {
+    return 0;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -18,7 +18,6 @@ import io.confluent.kafkarest.entities.ProduceResult;
 import io.confluent.kafkarest.entities.v3.ProduceRequest;
 import io.confluent.kafkarest.entities.v3.ProduceResponse;
 import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
-import io.confluent.kafkarest.resources.RateLimiter;
 import io.confluent.kafkarest.response.ChunkedOutputFactory;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.StreamingResponse.ResultOrError;
@@ -111,8 +110,8 @@ public class ProduceActionTest {
         getChunkedOutput(chunkedOutputFactory1, TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD1);
     Clock clock = mock(Clock.class);
 
-    RateLimiter rateLimiter =
-        new RateLimiter(
+    ProduceRateLimiter rateLimiter =
+        new ProduceRateLimiter(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
@@ -584,7 +583,7 @@ public class ProduceActionTest {
   private static ProduceAction getProduceAction(
       Properties properties, ChunkedOutputFactory chunkedOutputFactory, Clock clock, int times) {
     return getProduceAction(
-        new RateLimiter(
+        new ProduceRateLimiter(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
@@ -595,7 +594,7 @@ public class ProduceActionTest {
   }
 
   private static ProduceAction getProduceAction(
-      RateLimiter rateLimiter,
+      ProduceRateLimiter rateLimiter,
       ChunkedOutputFactory chunkedOutputFactory,
       int times,
       int producerId) {
@@ -618,7 +617,6 @@ public class ProduceActionTest {
             recordSerializerProvider,
             produceControllerProvider,
             producerMetricsProvider,
-            chunkedOutputFactory,
             streamingResponseFactory,
             rateLimiter);
     rateLimiter.resetGracePeriodStart();

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-ratelimiter</artifactId>
+                <version>1.7.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.jupiter.version}</version>


### PR DESCRIPTION
This PR adds 6 configs:

 * rate.limit.enable
 * rate.limit.backend ('guava' or 'resilience4j')
 * rate.limit.permits.per.sec
 * rate.limit.timeout.ms
 * rate.limit.default.cost
 * rate.limit.costs (map of endpoint=cost,...)

If rate-limiting is enabled, requests to all endpoints are rate-limited to at most `rate.limit.permits.per.sec` per second, using the permit cost configured via `rate.limit.costs`, or `rate.limit.default.cost` if no cost has been configured for the endpoint.

Each request will wait up to `rate.limit.timeout.ms` milliseconds for the necessary permits to proceed, or fail with HTTP 429 if can't obtain the permits within the timeout. Endpoints annotated with `@DoNotRateLimit` (currently only `ProduceAction`) ignore rate-limiting.

There are two implementations of the rate-limiting algorithm: Guava and Resilence4j. The implementation can be chosen via `rate.limit.backend`. See https://www.alibabacloud.com/blog/detailed-explanation-of-guava-ratelimiters-throttling-mechanism_594820 and https://resilience4j.readme.io/docs/ratelimiter for more details about each implementation.

On a code level, this PR introduces two public types: `RateLimitFeature` and `RequestRatelimiter`. `RateLimitFeature` configures rate-limiting according the rules above. `RequestRatelimiter` is the singleton rate-limiter responsible for keeping track of all request rates. This rate-limiter can be injected for manual injection, but make sure the endpoint is annotated with `@DoNotRateLimit`, otherwise you might rate-limit twice.

The automatic rate-limiting of requests (using `rate.limit.costs` and `rate.limit.default.cost`) is accomplished by `FixedCostRateLimiRequestFilter`.

This PR also renames the existing `RateLimiter` to `v3.ProduceRateLimiter` since its logic is very specific to `v3.ProduceAction`. Ideally we should unify both rate-limiters, but I ran out of time trying to do that.

The rate-limiter introduced in this PR is supposed to be used in conjuction with rest-utils `DosFilter`. While `DosFilter` protects the server against all requests (including unauthenticated ones), the requests rate-limited by `RequestRateLimiter` are already authenticated.