### PR TITLE
Bind NoSchemaRecordSerializer as Singleton.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.controllers;
 
+import javax.inject.Singleton;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 /** A module to install the various controllers required by the application. */
@@ -31,7 +32,7 @@ public final class ControllersModule extends AbstractBinder {
     bind(ConsumerGroupManagerImpl.class).to(ConsumerGroupManager.class);
     bind(ConsumerLagManagerImpl.class).to(ConsumerLagManager.class);
     bind(ConsumerManagerImpl.class).to(ConsumerManager.class);
-    bindAsContract(NoSchemaRecordSerializer.class);
+    bindAsContract(NoSchemaRecordSerializer.class).in(Singleton.class);
     bind(PartitionManagerImpl.class).to(PartitionManager.class);
     bind(ProduceControllerImpl.class).to(ProduceController.class);
     bind(ReassignmentManagerImpl.class).to(ReassignmentManager.class);


### PR DESCRIPTION
This is to avoid creating a new NoSchemaRecordserializer for each record in a stream. Normally, this instances should be very light and short-lived, so instantiating them should not be a problem. Unfortunately, a new `KafkaJsonSerializerConfig` is created for each `NoSchemaRecordSerializer`, and that thing is everything but light. In special, `AbstractConfig` (super-type) has the bad habit of logging all configs at creation, and when you that doing thousands of times per second, that usually takes a lot of cpu.