### PR TITLE
KREST-3255: Rate limit REST Produce on size of data

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -169,6 +169,17 @@ public class KafkaRestConfig extends RestConfig {
   public static final ConfigDef.Range PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR =
       ConfigDef.Range.between(1, Integer.MAX_VALUE);
 
+  public static final String PRODUCE_MAX_BYTES_PER_SECOND =
+      "api.v3.produce.rate.limit.max.bytes.per.sec";
+  private static final String PRODUCE_MAX_BYTES_PER_SECOND_DOC =
+      "Maximum number of bytes per second before the grace period for producer rate limiting "
+          + "comes into force. Within the grace period, the wait_for_ms field of the response "
+          + "suggests to the client how long to wait before attempting to produce again. "
+          + "Once the grace period has expired the client is disconnected.";
+  public static final String PRODUCE_MAX_BYTES_PER_SECOND_DEFAULT = "10000";
+  public static final ConfigDef.Range PRODUCE_MAX_BYTES_PER_SECOND_VALIDATOR =
+      ConfigDef.Range.between(1, Integer.MAX_VALUE);
+
   public static final String PRODUCE_GRACE_PERIOD_MS = "api.v3.produce.rate.limit.grace.period.ms";
   private static final String PRODUCE_GRACE_PERIOD_MS_DOC =
       "The grace period over which clients are allowed to exceed the produce request rate limit "
@@ -489,6 +500,13 @@ public class KafkaRestConfig extends RestConfig {
             PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR,
             Importance.LOW,
             PRODUCE_MAX_REQUESTS_PER_SECOND_DOC)
+        .define(
+            PRODUCE_MAX_BYTES_PER_SECOND,
+            Type.INT,
+            PRODUCE_MAX_BYTES_PER_SECOND_DEFAULT,
+            PRODUCE_MAX_BYTES_PER_SECOND_VALIDATOR,
+            Importance.LOW,
+            PRODUCE_MAX_BYTES_PER_SECOND_DOC)
         .define(
             PRODUCE_GRACE_PERIOD_MS,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -79,22 +79,6 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new CrnAuthorityConfigImpl())
         .to(String.class);
 
-    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
-        .qualifiedBy(new ProduceRateLimitConfigImpl())
-        .to(Integer.class);
-
-    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS)))
-        .qualifiedBy(new ProduceGracePeriodConfigImpl())
-        .to(Duration.class);
-
-    bind(config.getBoolean(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED))
-        .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
-        .to(Boolean.class);
-
-    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
-        .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
-        .to(Duration.class);
-
     bind(config.getString(KafkaRestConfig.HOST_NAME_CONFIG))
         .qualifiedBy(new HostNameConfigImpl())
         .to(String.class);
@@ -123,9 +107,17 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new ProduceGracePeriodConfigImpl())
         .to(Duration.class);
 
-    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
-        .qualifiedBy(new ProduceRateLimitConfigImpl())
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_BYTES_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitBytesConfigImpl())
         .to(Integer.class);
+
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitCountConfigImpl())
+        .to(Integer.class);
+
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
+        .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
+        .to(Duration.class);
 
     bind(config.getBoolean(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED))
         .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
@@ -288,13 +280,20 @@ public final class ConfigModule extends AbstractBinder {
       extends AnnotationLiteral<ProduceRateLimitCacheExpiryConfig>
       implements ProduceRateLimitCacheExpiryConfig {}
 
+  public @interface ProduceRateLimitCountConfig {}
+
+  private static final class ProduceRateLimitCountConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitCountConfig>
+      implements ProduceRateLimitCountConfig {}
+
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
-  public @interface ProduceRateLimitConfig {}
+  public @interface ProduceRateLimitBytesConfig {}
 
-  private static final class ProduceRateLimitConfigImpl
-      extends AnnotationLiteral<ProduceRateLimitConfig> implements ProduceRateLimitConfig {}
+  private static final class ProduceRateLimitBytesConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitBytesConfig>
+      implements ProduceRateLimitBytesConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ProduceRequest.java
@@ -66,8 +66,7 @@ public abstract class ProduceRequest {
   @JsonInclude(Include.NON_ABSENT)
   public abstract Optional<Instant> getTimestamp();
 
-  @JsonProperty("originalSize")
-  @JsonInclude(Include.NON_ABSENT)
+  @JsonIgnore
   public abstract Optional<Long> getOriginalSize();
 
   @JsonCreator()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
@@ -22,16 +22,6 @@ public final class RateLimitGracePeriodExceededException extends StatusCodeExcep
 
   public RateLimitGracePeriodExceededException(
       int maxRequestsPerSec, int maxBytesPerSec, Duration gracePeriod) {
-    super(
-        Status.TOO_MANY_REQUESTS,
-        "Rate limit of "
-            + maxRequestsPerSec
-            + " messages per second or "
-            + maxBytesPerSec
-            + " bytes per second "
-            + "exceeded within the grace period of "
-            + gracePeriod.toMillis()
-            + " ms ",
-        "Connection will be closed.");
+    super(Status.TOO_MANY_REQUESTS, "Rate limit exceeded ", "Connection will be closed.");
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
@@ -20,12 +20,16 @@ import javax.ws.rs.core.Response.Status;
 
 public final class RateLimitGracePeriodExceededException extends StatusCodeException {
 
-  public RateLimitGracePeriodExceededException(int maxRequestsPerSec, Duration gracePeriod) {
+  public RateLimitGracePeriodExceededException(
+      int maxRequestsPerSec, int maxBytesPerSec, Duration gracePeriod) {
     super(
         Status.TOO_MANY_REQUESTS,
         "Rate limit of "
             + maxRequestsPerSec
-            + " messages per second exceeded within the grace period of "
+            + " messages per second or "
+            + maxBytesPerSec
+            + " bytes per second "
+            + "exceeded within the grace period of "
             + gracePeriod.toMillis()
             + " ms ",
         "Connection will be closed.");

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -118,9 +118,17 @@ public final class ProduceAction {
         .from(requests)
         .compose(
             request -> {
-              Optional<Duration> waitFor =
-                  produceRateLimiters.calculateGracePeriodExceeded(clusterId);
-              return produce(clusterId, topicName, request, controller, waitFor);
+              Optional<Long> messageSize = request.getOriginalSize();
+              if (messageSize.isPresent()) {
+                return produce(
+                    clusterId,
+                    topicName,
+                    request,
+                    controller,
+                    produceRateLimiters.calculateGracePeriodExceeded(clusterId, messageSize.get()));
+              } else {
+                return produce(clusterId, topicName, request, controller, Optional.empty());
+              }
             })
         .resume(asyncResponse);
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiter.java
@@ -140,7 +140,7 @@ final class ProduceRateLimiter {
     return Optional.of((Duration.ofMillis((long) waitForMs)));
   }
 
-  private final class TimeAndSize {
+  private static final class TimeAndSize {
     private long time;
     private long size;
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -69,10 +69,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
-                + "within the grace period of 0 ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorFail = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorFail); // failing second produce
@@ -165,10 +162,7 @@ public class ProduceActionTest {
     mockedChunkedOutput0.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
-                + "within the grace period of 10 ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorOKProd5 = ResultOrError.error(err);
     expect(mockedChunkedOutput1.isClosed()).andReturn(false);
     mockedChunkedOutput1.write(resultOrErrorOKProd5);
@@ -260,10 +254,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
-                + "within the grace period of 10 ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -419,10 +410,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.write(resultOrErrorOKProd5);
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
-                + "within the grace period of 10 ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -469,10 +457,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 100 messages per second or 30 bytes per second exceeded within "
-                + "the grace period of 0 ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorFail = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorFail); // failing second produce

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -1,6 +1,7 @@
 package io.confluent.kafkarest.resources.v3;
 
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_BYTES_PER_SECOND;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
@@ -47,6 +48,7 @@ public class ProduceActionTest {
     Properties properties = new Properties();
     properties.put(PRODUCE_GRACE_PERIOD_MS, "0");
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, "1");
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, "3600000");
 
@@ -69,8 +71,8 @@ public class ProduceActionTest {
     ErrorResponse err =
         ErrorResponse.create(
             429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 0 ms "
-                + ": Connection will be closed.");
+            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
+                + "within the grace period of 0 ms : Connection will be closed.");
     ResultOrError resultOrErrorFail = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorFail); // failing second produce
@@ -100,6 +102,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD1 = 3;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -117,6 +120,7 @@ public class ProduceActionTest {
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_BYTES_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
@@ -163,8 +167,8 @@ public class ProduceActionTest {
     ErrorResponse err =
         ErrorResponse.create(
             429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : Connection will be closed.");
+            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
+                + "within the grace period of 10 ms : Connection will be closed.");
     ResultOrError resultOrErrorOKProd5 = ResultOrError.error(err);
     expect(mockedChunkedOutput1.isClosed()).andReturn(false);
     mockedChunkedOutput1.write(resultOrErrorOKProd5);
@@ -208,6 +212,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD = 7;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -257,8 +262,8 @@ public class ProduceActionTest {
     ErrorResponse err =
         ErrorResponse.create(
             429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : Connection will be closed.");
+            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
+                + "within the grace period of 10 ms : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -310,6 +315,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_STREAMING_CALLS = 4;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(10000));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(30000));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -369,6 +375,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD = 5;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -414,8 +421,8 @@ public class ProduceActionTest {
     ErrorResponse err =
         ErrorResponse.create(
             429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : Connection will be closed.");
+            "Rate limit of 1 messages per second or 999999999 bytes per second exceeded "
+                + "within the grace period of 10 ms : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -427,6 +434,61 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse1 = new FakeAsyncResponse();
     produceAction.produce(fakeAsyncResponse1, "clusterId", "topicName", requests);
+
+    // check results
+    EasyMock.verify(requests);
+    EasyMock.verify(mockedChunkedOutput);
+  }
+
+  @Test
+  public void produceWithByteLimit() throws Exception {
+    // config
+    final int TOTAL_NUMBER_OF_PRODUCE_CALLS = 2;
+    Properties properties = new Properties();
+    properties.put(PRODUCE_GRACE_PERIOD_MS, "0");
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, "100");
+    properties.put(
+        PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(30)); // first record is 25 bytes long
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, "3600000");
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+
+    // setup
+    ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
+    ChunkedOutput<ResultOrError> mockedChunkedOutput =
+        getChunkedOutput(chunkedOutputFactory, TOTAL_NUMBER_OF_PRODUCE_CALLS);
+    Clock clock = mock(Clock.class);
+    ProduceAction produceAction = getProduceAction(properties, chunkedOutputFactory, clock, 1);
+    MappingIterator<ProduceRequest> requests =
+        getProduceRequestsMappingIterator(TOTAL_NUMBER_OF_PRODUCE_CALLS);
+
+    // expected results
+    ProduceResponse produceResponse = getProduceResponse(0);
+    ResultOrError resultOrErrorOK = ResultOrError.result(produceResponse);
+    expect(mockedChunkedOutput.isClosed()).andReturn(false);
+    mockedChunkedOutput.write(resultOrErrorOK); // successful first produce
+    mockedChunkedOutput.close();
+
+    ErrorResponse err =
+        ErrorResponse.create(
+            429,
+            "Rate limit of 100 messages per second or 30 bytes per second exceeded within "
+                + "the grace period of 0 ms : Connection will be closed.");
+    ResultOrError resultOrErrorFail = ResultOrError.error(err);
+    expect(mockedChunkedOutput.isClosed()).andReturn(false);
+    mockedChunkedOutput.write(resultOrErrorFail); // failing second produce
+    mockedChunkedOutput.close(); // error close
+    mockedChunkedOutput.close(); // second close always happens on tidy up
+
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+
+    replay(mockedChunkedOutput, chunkedOutputFactory, clock);
+
+    // run test
+    FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
+    produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests);
+    FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
+    produceAction.produce(fakeAsyncResponse2, "clusterId", "topicName", requests);
 
     // check results
     EasyMock.verify(requests);
@@ -455,14 +517,13 @@ public class ProduceActionTest {
   private static MappingIterator<ProduceRequest> getProduceRequestsMappingIterator(int times)
       throws IOException {
     MappingIterator<ProduceRequest> requests = mock(MappingIterator.class);
-    ProduceRequest request = ProduceRequest.builder().build();
+    ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
     for (int i = 0; i < times; i++) {
       expect(requests.hasNext()).andReturn(true).times(1);
       expect(requests.nextValue()).andReturn(request).times(1);
       expect(requests.hasNext()).andReturn(false).times(1);
       requests.close();
     }
-    // requests.close();
     replay(requests);
     return requests;
   }
@@ -472,7 +533,7 @@ public class ProduceActionTest {
     MappingIterator<ProduceRequest> requests = mock(MappingIterator.class);
 
     for (int i = 0; i < times; i++) {
-      ProduceRequest request = ProduceRequest.builder().build();
+      ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
       expect(requests.hasNext()).andReturn(true).times(1);
       expect(requests.nextValue()).andReturn(request).times(1);
     }
@@ -494,7 +555,7 @@ public class ProduceActionTest {
     expect(clock.millis()).andReturn(1015L);
     replay(clock);
 
-    ProduceRequest request = ProduceRequest.builder().build();
+    ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
     expect(requests.hasNext()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
@@ -594,6 +655,7 @@ public class ProduceActionTest {
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_BYTES_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),


### PR DESCRIPTION
Extend the existing rest produce rate limiter to also limit on bytes, as well as the original rate count

Tested with a locally running REST producer, as well as the new unit test.

Default bytes per second is 10000