### PR TITLE
Fix(#341): Remove deadlock when rebalancing by multiple consumer instances

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -66,7 +66,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
   private final Queue<ConsumerRecord<KafkaKeyT, KafkaValueT>> consumerRecords = new ArrayDeque<>();
 
   volatile long expiration;
-  private final Long expirationLock;
+  private final Object expirationLock = new Object();
 
   KafkaConsumerState(
       KafkaRestConfig config,
@@ -78,7 +78,6 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
     this.consumer = consumer;
     this.expiration = config.getTime().milliseconds()
                       + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
-    this.expirationLock = this.expiration;
   }
 
   public ConsumerInstanceId getId() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -65,7 +65,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
 
   private final Queue<ConsumerRecord<KafkaKeyT, KafkaValueT>> consumerRecords = new ArrayDeque<>();
 
-  volatile long expiration;
+  volatile Long expiration;
 
   KafkaConsumerState(
       KafkaRestConfig config,
@@ -335,13 +335,17 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
         .map(OffsetAndTimestamp::offset);
   }
 
-  public synchronized boolean expired(long nowMs) {
-    return expiration <= nowMs;
+  public boolean expired(long nowMs) {
+    synchronized (expiration) {
+      return expiration <= nowMs;
+    }
   }
 
-  public synchronized void updateExpiration() {
-    this.expiration = config.getTime().milliseconds()
-                      + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
+  public void updateExpiration() {
+    synchronized (expiration) {
+      this.expiration = config.getTime().milliseconds()
+                        + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
+    }
   }
 
   public synchronized KafkaRestConfig getConfig() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -509,7 +509,7 @@ public class KafkaConsumerManagerTest {
     public void testConsumerExpirationIsUpdated() throws Exception {
         bootstrapConsumer(consumer);
         KafkaConsumerState state = consumerManager.getConsumerInstance(groupName, consumer.cid());
-        long initialExpiration = state.expiration;
+        long initialExpiration = state.expiration.value;
         consumerManager.readRecords(groupName, consumer.cid(), BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
                 new ConsumerReadCallback<ByteString, ByteString>() {
                     @Override
@@ -521,12 +521,12 @@ public class KafkaConsumerManagerTest {
                     }
                 });
         Thread.sleep(100);
-        assertTrue(state.expiration > initialExpiration);
-        initialExpiration = state.expiration;
+        assertTrue(state.expiration.value > initialExpiration);
+        initialExpiration = state.expiration.value;
         awaitRead();
         assertTrue("Callback failed to fire", sawCallback);
-        assertTrue(state.expiration > initialExpiration);
-        initialExpiration = state.expiration;
+        assertTrue(state.expiration.value > initialExpiration);
+        initialExpiration = state.expiration.value;
 
         consumerManager.commitOffsets(groupName, consumer.cid(), null, null, new KafkaConsumerManager.CommitCallback() {
             @Override
@@ -537,7 +537,7 @@ public class KafkaConsumerManagerTest {
                 actualOffsets = offsets;
             }
         }).get();
-        assertTrue(state.expiration > initialExpiration);
+        assertTrue(state.expiration.value > initialExpiration);
     }
 
     private void awaitRead() throws InterruptedException {


### PR DESCRIPTION
this is to fix the issue: #341
when rebalancing starts by multiple instances in a consumer group, a pseudo deadlock condition occurs:

thread a. (Consumer Expiration Thread)
 1) acquired the KafkaConsumerManager instance (lock A) within KafkaConsumerManager$ExpirationThread::Run
 2) waiting to acquire the KafkaConsumerState instance (lock B) within KafkaConsumerState::expired
![thread-a-monitor](https://user-images.githubusercontent.com/11866595/143591099-fad01452-7ea8-4706-a98e-380f30e5057d.png)

thread b.
 1) acquired the KafkaConsumerState instance (lock B) within KafkaConsumerState::hasNext in KafkaConsumerReadTask::addRecords
 2) waiting to acquire the ?? (lock C) within KafkaConsumer::poll(0) by rebalancing
![thread-b-running](https://user-images.githubusercontent.com/11866595/143591118-c559cbad-c027-4e10-b5e0-f21c2fc6706c.png)

thread c.
 1) acquired the ?? (lock C) within jettyHandler
 2) waiting to acquire the KafkaConsumerManager instance (lock A) within KafkaConsumerManager::getConsumerInstance in readRecords
![thread-c-monitor](https://user-images.githubusercontent.com/11866595/143591133-a67e323e-b96c-4773-92af-d97209365bbd.png)


a cyclic lock order is generated by 3 locks and 3 threads, resulting in deadlock.
to resolve this, split the KafkaConsumerState instance lock (lock B) into two locks - a KafkaConsumerState instance lock(existing) and KafkaConsumerState.expiration member lock(new).
as a result, lock B of thread a and lock B of thread b become different locks, breaking the cycle.

since thread b is actually in the running state, the lock C is not exactly the the Java synchronization object.
perhaps it needs permission(lock) to use jetty's handler when certain events are triggered by rebalancing inside KafkaConsumer::poll, which I've referred to as the lock C.