### PR TITLE
Cherry pick for rate limit based on cluster id and rate limit on bytes into release branch

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -162,7 +162,9 @@ public class KafkaRestConfig extends RestConfig {
       "Maximum number of requests per second before the grace period for producer rate limiting "
           + "comes into force. Within the grace period, the wait_for_ms field of the response "
           + "suggests to the client how long to wait before attempting to produce again. "
-          + "Once the grace period has expired the client is disconnected.";
+          + "Once the grace period has expired the client is disconnected. "
+          + "The limit is enforced per clusterId, so the total rate limit will be "
+          + "number of clusters * api.v3.produce.rate.limit.max.requests.per.sec ";
   public static final String PRODUCE_MAX_REQUESTS_PER_SECOND_DEFAULT = "10000";
   public static final ConfigDef.Range PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR =
       ConfigDef.Range.between(1, Integer.MAX_VALUE);
@@ -174,6 +176,13 @@ public class KafkaRestConfig extends RestConfig {
   public static final String PRODUCE_GRACE_PERIOD_MS_DEFAULT = "30000";
   public static final ConfigDef.Range PRODUCE_GRACE_PERIOD_MS_VALIDATOR =
       ConfigDef.Range.between(0, Integer.MAX_VALUE);
+
+  public static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS =
+      "api.v3.produce.rate.limit.cache.expiry.ms";
+  private static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DOC =
+      "How long after the last produce a cluster remains in the cache storing rateLimits. Default "
+          + "is 1 hour.";
+  public static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DEFAULT = "3600000";
 
   public static final String CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG = "consumer.iterator.timeout.ms";
   private static final String CONSUMER_ITERATOR_TIMEOUT_MS_DOC =
@@ -487,6 +496,12 @@ public class KafkaRestConfig extends RestConfig {
             PRODUCE_GRACE_PERIOD_MS_VALIDATOR,
             Importance.LOW,
             PRODUCE_GRACE_PERIOD_MS_DOC)
+        .define(
+            PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS,
+            Type.INT,
+            PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DEFAULT,
+            Importance.LOW,
+            PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS_DOC)
         .define(
             CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -169,6 +169,17 @@ public class KafkaRestConfig extends RestConfig {
   public static final ConfigDef.Range PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR =
       ConfigDef.Range.between(1, Integer.MAX_VALUE);
 
+  public static final String PRODUCE_MAX_BYTES_PER_SECOND =
+      "api.v3.produce.rate.limit.max.bytes.per.sec";
+  private static final String PRODUCE_MAX_BYTES_PER_SECOND_DOC =
+      "Maximum number of bytes per second before the grace period for producer rate limiting "
+          + "comes into force. Within the grace period, the wait_for_ms field of the response "
+          + "suggests to the client how long to wait before attempting to produce again. "
+          + "Once the grace period has expired the client is disconnected.";
+  public static final String PRODUCE_MAX_BYTES_PER_SECOND_DEFAULT = "10000";
+  public static final ConfigDef.Range PRODUCE_MAX_BYTES_PER_SECOND_VALIDATOR =
+      ConfigDef.Range.between(1, Integer.MAX_VALUE);
+
   public static final String PRODUCE_GRACE_PERIOD_MS = "api.v3.produce.rate.limit.grace.period.ms";
   private static final String PRODUCE_GRACE_PERIOD_MS_DOC =
       "The grace period over which clients are allowed to exceed the produce request rate limit "
@@ -489,6 +500,13 @@ public class KafkaRestConfig extends RestConfig {
             PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR,
             Importance.LOW,
             PRODUCE_MAX_REQUESTS_PER_SECOND_DOC)
+        .define(
+            PRODUCE_MAX_BYTES_PER_SECOND,
+            Type.INT,
+            PRODUCE_MAX_BYTES_PER_SECOND_DEFAULT,
+            PRODUCE_MAX_BYTES_PER_SECOND_VALIDATOR,
+            Importance.LOW,
+            PRODUCE_MAX_BYTES_PER_SECOND_DOC)
         .define(
             PRODUCE_GRACE_PERIOD_MS,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -79,22 +79,6 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new CrnAuthorityConfigImpl())
         .to(String.class);
 
-    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
-        .qualifiedBy(new ProduceRateLimitConfigImpl())
-        .to(Integer.class);
-
-    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS)))
-        .qualifiedBy(new ProduceGracePeriodConfigImpl())
-        .to(Duration.class);
-
-    bind(config.getBoolean(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED))
-        .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
-        .to(Boolean.class);
-
-    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
-        .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
-        .to(Duration.class);
-
     bind(config.getString(KafkaRestConfig.HOST_NAME_CONFIG))
         .qualifiedBy(new HostNameConfigImpl())
         .to(String.class);
@@ -123,9 +107,17 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new ProduceGracePeriodConfigImpl())
         .to(Duration.class);
 
-    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
-        .qualifiedBy(new ProduceRateLimitConfigImpl())
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_BYTES_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitBytesConfigImpl())
         .to(Integer.class);
+
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitCountConfigImpl())
+        .to(Integer.class);
+
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
+        .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
+        .to(Duration.class);
 
     bind(config.getBoolean(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED))
         .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
@@ -288,13 +280,20 @@ public final class ConfigModule extends AbstractBinder {
       extends AnnotationLiteral<ProduceRateLimitCacheExpiryConfig>
       implements ProduceRateLimitCacheExpiryConfig {}
 
+  public @interface ProduceRateLimitCountConfig {}
+
+  private static final class ProduceRateLimitCountConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitCountConfig>
+      implements ProduceRateLimitCountConfig {}
+
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
-  public @interface ProduceRateLimitConfig {}
+  public @interface ProduceRateLimitBytesConfig {}
 
-  private static final class ProduceRateLimitConfigImpl
-      extends AnnotationLiteral<ProduceRateLimitConfig> implements ProduceRateLimitConfig {}
+  private static final class ProduceRateLimitBytesConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitBytesConfig>
+      implements ProduceRateLimitBytesConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -79,6 +79,22 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new CrnAuthorityConfigImpl())
         .to(String.class);
 
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitConfigImpl())
+        .to(Integer.class);
+
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS)))
+        .qualifiedBy(new ProduceGracePeriodConfigImpl())
+        .to(Duration.class);
+
+    bind(config.getBoolean(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED))
+        .qualifiedBy(new ProduceRateLimitEnabledConfigImpl())
+        .to(Boolean.class);
+
+    bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
+        .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
+        .to(Duration.class);
+
     bind(config.getString(KafkaRestConfig.HOST_NAME_CONFIG))
         .qualifiedBy(new HostNameConfigImpl())
         .to(String.class);
@@ -262,6 +278,15 @@ public final class ConfigModule extends AbstractBinder {
 
   private static final class ProduceGracePeriodConfigImpl
       extends AnnotationLiteral<ProduceGracePeriodConfig> implements ProduceGracePeriodConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceRateLimitCacheExpiryConfig {}
+
+  private static final class ProduceRateLimitCacheExpiryConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitCacheExpiryConfig>
+      implements ProduceRateLimitCacheExpiryConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ProduceRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ProduceRequest.java
@@ -66,8 +66,7 @@ public abstract class ProduceRequest {
   @JsonInclude(Include.NON_ABSENT)
   public abstract Optional<Instant> getTimestamp();
 
-  @JsonProperty("originalSize")
-  @JsonInclude(Include.NON_ABSENT)
+  @JsonIgnore
   public abstract Optional<Long> getOriginalSize();
 
   @JsonCreator()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
@@ -28,6 +28,6 @@ public final class RateLimitGracePeriodExceededException extends StatusCodeExcep
             + " messages per second exceeded within the grace period of "
             + gracePeriod.toMillis()
             + " ms ",
-        "connection will be closed.");
+        "Connection will be closed.");
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
@@ -20,14 +20,8 @@ import javax.ws.rs.core.Response.Status;
 
 public final class RateLimitGracePeriodExceededException extends StatusCodeException {
 
-  public RateLimitGracePeriodExceededException(int maxRequestsPerSec, Duration gracePeriod) {
-    super(
-        Status.TOO_MANY_REQUESTS,
-        "Rate limit of "
-            + maxRequestsPerSec
-            + " messages per second exceeded within the grace period of "
-            + gracePeriod.toMillis()
-            + " ms ",
-        "Connection will be closed.");
+  public RateLimitGracePeriodExceededException(
+      int maxRequestsPerSec, int maxBytesPerSec, Duration gracePeriod) {
+    super(Status.TOO_MANY_REQUESTS, "Rate limit exceeded ", "Connection will be closed.");
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -118,9 +118,17 @@ public final class ProduceAction {
         .from(requests)
         .compose(
             request -> {
-              Optional<Duration> waitFor =
-                  produceRateLimiters.calculateGracePeriodExceeded(clusterId);
-              return produce(clusterId, topicName, request, controller, waitFor);
+              Optional<Long> messageSize = request.getOriginalSize();
+              if (messageSize.isPresent()) {
+                return produce(
+                    clusterId,
+                    topicName,
+                    request,
+                    controller,
+                    produceRateLimiters.calculateGracePeriodExceeded(clusterId, messageSize.get()));
+              } else {
+                return produce(clusterId, topicName, request, controller, Optional.empty());
+              }
             })
         .resume(asyncResponse);
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiter.java
@@ -19,7 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafkarest.config.ConfigModule.ProduceGracePeriodConfig;
-import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitBytesConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitCountConfig;
 import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitEnabledConfig;
 import io.confluent.kafkarest.exceptions.RateLimitGracePeriodExceededException;
 import java.time.Clock;
@@ -35,34 +36,40 @@ final class ProduceRateLimiter {
   private static final int ONE_SECOND_MS = 1000;
 
   private final int maxRequestsPerSecond;
+  private final int maxBytesPerSecond;
   private final long gracePeriod;
   private final boolean rateLimitingEnabled;
   private final Clock clock;
   private final AtomicInteger rateCounterSize = new AtomicInteger(0);
+  private final AtomicLong byteCounterSize = new AtomicLong(0);
 
-  private final ConcurrentLinkedDeque<Long> rateCounter = new ConcurrentLinkedDeque<>();
+  private final ConcurrentLinkedDeque<TimeAndSize> rateCounter = new ConcurrentLinkedDeque<>();
   private final AtomicLong gracePeriodStart = new AtomicLong(-1);
 
   @Inject
   ProduceRateLimiter(
       @ProduceGracePeriodConfig Duration produceGracePeriodConfig,
-      @ProduceRateLimitConfig Integer produceRateLimitConfig,
+      @ProduceRateLimitCountConfig Integer produceRateLimitCountConfig,
+      @ProduceRateLimitBytesConfig Integer produceRateLimitBytesConfig,
       @ProduceRateLimitEnabledConfig Boolean produceRateLimitEnabledConfig,
       Clock clock) {
-    this.maxRequestsPerSecond = requireNonNull(produceRateLimitConfig);
+    this.maxRequestsPerSecond = requireNonNull(produceRateLimitCountConfig);
+    this.maxBytesPerSecond = requireNonNull(produceRateLimitBytesConfig);
     this.gracePeriod = produceGracePeriodConfig.toMillis();
     this.rateLimitingEnabled = requireNonNull(produceRateLimitEnabledConfig);
     this.clock = requireNonNull(clock);
   }
 
-  Optional<Duration> calculateGracePeriodExceeded() throws RateLimitGracePeriodExceededException {
+  Optional<Duration> calculateGracePeriodExceeded(final long requestSize)
+      throws RateLimitGracePeriodExceededException {
     if (!rateLimitingEnabled) {
       return Optional.empty();
     }
-
     long nowMs = clock.millis();
-    int currentRate = addAndGetRate(nowMs);
-    Optional<Duration> waitFor = getWaitFor(currentRate);
+
+    TimeAndSize thisMessage = new TimeAndSize(nowMs, requestSize);
+    addToRateLimiter(thisMessage);
+    Optional<Duration> waitFor = getWaitFor(rateCounterSize.get(), byteCounterSize.get());
 
     if (!waitFor.isPresent()) {
       resetGracePeriodStart();
@@ -71,7 +78,7 @@ final class ProduceRateLimiter {
 
     if (isOverGracePeriod(nowMs)) {
       throw new RateLimitGracePeriodExceededException(
-          maxRequestsPerSecond, Duration.ofMillis(gracePeriod));
+          maxRequestsPerSecond, maxBytesPerSecond, Duration.ofMillis(gracePeriod));
     }
     return waitFor;
   }
@@ -98,29 +105,48 @@ final class ProduceRateLimiter {
     return false;
   }
 
-  private int addAndGetRate(long nowMs) {
-    rateCounter.add(nowMs);
+  private void addToRateLimiter(TimeAndSize thisMessage) {
+    rateCounter.add(thisMessage);
     rateCounterSize.incrementAndGet();
+    byteCounterSize.addAndGet(thisMessage.size);
 
     synchronized (rateCounter) {
-      if (rateCounter.peekLast() < nowMs - ONE_SECOND_MS) {
+      if ((rateCounter.peekLast().time < thisMessage.time - ONE_SECOND_MS)) {
         rateCounter.clear();
         rateCounterSize.set(0);
       } else {
-        while (rateCounter.peek() < nowMs - ONE_SECOND_MS) {
-          rateCounter.poll();
+        while (rateCounter.peek().time < thisMessage.time - ONE_SECOND_MS) {
+          TimeAndSize messageToRemove = rateCounter.poll();
+          byteCounterSize.addAndGet(-messageToRemove.size);
           rateCounterSize.decrementAndGet();
         }
       }
     }
-    return rateCounterSize.get();
+    return;
   }
 
-  private Optional<Duration> getWaitFor(int currentRate) {
-    if (currentRate <= maxRequestsPerSecond) {
+  private Optional<Duration> getWaitFor(int currentCountRate, long currentByteRate) {
+    if (currentCountRate <= maxRequestsPerSecond && currentByteRate <= maxBytesPerSecond) {
       return Optional.empty();
     }
-    double waitForMs = ((double) currentRate / (double) maxRequestsPerSecond - 1) * 1000;
+
+    double waitForMs;
+    if (currentCountRate > maxRequestsPerSecond) {
+      waitForMs = ((double) currentCountRate / (double) maxRequestsPerSecond - 1) * 1000;
+    } else {
+      waitForMs = ((double) currentByteRate / (double) maxBytesPerSecond - 1) * 1000;
+    }
+
     return Optional.of((Duration.ofMillis((long) waitForMs)));
+  }
+
+  private static final class TimeAndSize {
+    private long time;
+    private long size;
+
+    TimeAndSize(long time, long size) {
+      this.time = time;
+      this.size = size;
+    }
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.confluent.kafkarest.config.ConfigModule.ProduceGracePeriodConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitCacheExpiryConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitConfig;
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitEnabledConfig;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+
+public class ProduceRateLimiters {
+
+  private final int maxRequestsPerSecond;
+  private final Duration gracePeriod;
+  private final boolean rateLimitingEnabled;
+  private final LoadingCache<String, ProduceRateLimiter> cache;
+
+  @Inject
+  public ProduceRateLimiters(
+      @ProduceGracePeriodConfig Duration produceGracePeriodConfig,
+      @ProduceRateLimitConfig Integer produceRateLimitConfig,
+      @ProduceRateLimitEnabledConfig Boolean produceRateLimitEnabledConfig,
+      @ProduceRateLimitCacheExpiryConfig Duration produceRateLimitCacheExpiryConfig,
+      Clock time) {
+    this.maxRequestsPerSecond = requireNonNull(produceRateLimitConfig);
+    this.gracePeriod = requireNonNull(produceGracePeriodConfig);
+    this.rateLimitingEnabled = requireNonNull(produceRateLimitEnabledConfig);
+    requireNonNull(time);
+
+    cache =
+        CacheBuilder.newBuilder()
+            .expireAfterAccess(produceRateLimitCacheExpiryConfig.toMillis(), TimeUnit.MILLISECONDS)
+            .build(
+                new CacheLoader<String, ProduceRateLimiter>() {
+                  @Override
+                  public ProduceRateLimiter load(String key) {
+                    return new ProduceRateLimiter(
+                        gracePeriod, maxRequestsPerSecond, produceRateLimitEnabledConfig, time);
+                  }
+                });
+  }
+
+  public Optional<Duration> calculateGracePeriodExceeded(String clusterId) {
+    if (!rateLimitingEnabled) {
+      return Optional.empty();
+    }
+    ProduceRateLimiter rateLimiter = cache.getUnchecked(clusterId);
+    Optional<Duration> waitTime = rateLimiter.calculateGracePeriodExceeded();
+    return waitTime;
+  }
+
+  public void clear() {
+    cache.invalidateAll();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
@@ -25,7 +25,7 @@ public final class V3ResourcesModule extends AbstractBinder {
 
   @Override
   protected void configure() {
-    bindAsContract(ProduceRateLimiter.class).in(Singleton.class);
+    bindAsContract(ProduceRateLimiters.class).in(Singleton.class);
     bindAsContract(ChunkedOutputFactory.class);
     bindAsContract(StreamingResponseFactory.class);
     bind(Clock.systemUTC()).to(Clock.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -1,0 +1,172 @@
+package io.confluent.kafkarest.resources;
+
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.confluent.kafkarest.exceptions.RateLimitGracePeriodExceededException;
+import io.confluent.kafkarest.resources.v3.ProduceRateLimiters;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProduceRateLimitersTest {
+
+  @Test
+  public void rateLimitingDisabledNoWaitTimeGiven() {
+    Clock clock = mock(Clock.class);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "false");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
+            clock);
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+
+    assertFalse(waitTime.isPresent());
+  }
+
+  @Test
+  public void newRateLimiterReturnsNoWait() {
+    Clock clock = mock(Clock.class);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
+            clock);
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+
+    assertFalse(waitTime.isPresent());
+  }
+
+  @Test
+  public void waitTimesReturnedForMultipleClusters() {
+    Clock clock = mock(Clock.class);
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+    expect(clock.millis()).andReturn(2L);
+    replay(clock);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
+            clock);
+
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+    waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertTrue(waitTime.isPresent());
+    assertEquals(waitTime.get().toMillis(), 1000);
+    Optional<Duration> waitTime2 = produceRateLimiters.calculateGracePeriodExceeded("clusterId2");
+    assertFalse(waitTime2.isPresent());
+    assertTrue(waitTime.isPresent());
+    assertEquals(waitTime.get().toMillis(), 1000);
+  }
+
+  @Test
+  public void gracePeriodExceptionThrown() {
+    Clock clock = mock(Clock.class);
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+    replay(clock);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(0));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
+            clock);
+
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+    try {
+      produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+      fail("RateLimitGracePeriodExceededException should be thrown");
+    } catch (RateLimitGracePeriodExceededException e) {
+      assertEquals("Connection will be closed.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void cacheExpiresforeRateLimit() throws InterruptedException {
+    Clock clock = mock(Clock.class);
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+    expect(clock.millis()).andReturn(8L);
+    replay(clock);
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(100));
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(5));
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
+            clock);
+
+    Optional<Duration> waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+    waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertTrue(waitTime.isPresent());
+    assertEquals(waitTime.get().toMillis(), 1000);
+    Thread.sleep(6);
+    waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId");
+    assertFalse(waitTime.isPresent());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -1,6 +1,7 @@
 package io.confluent.kafkarest.resources.v3;
 
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_GRACE_PERIOD_MS;
+import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_BYTES_PER_SECOND;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS;
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
@@ -47,6 +48,7 @@ public class ProduceActionTest {
     Properties properties = new Properties();
     properties.put(PRODUCE_GRACE_PERIOD_MS, "0");
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, "1");
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, "3600000");
 
@@ -67,10 +69,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 0 ms "
-                + ": Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorFail = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorFail); // failing second produce
@@ -100,6 +99,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD1 = 3;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -117,6 +117,7 @@ public class ProduceActionTest {
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_BYTES_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),
@@ -161,10 +162,7 @@ public class ProduceActionTest {
     mockedChunkedOutput0.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorOKProd5 = ResultOrError.error(err);
     expect(mockedChunkedOutput1.isClosed()).andReturn(false);
     mockedChunkedOutput1.write(resultOrErrorOKProd5);
@@ -208,6 +206,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD = 7;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -255,10 +254,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.close();
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -310,6 +306,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_STREAMING_CALLS = 4;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(10000));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(30000));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -369,6 +366,7 @@ public class ProduceActionTest {
     final int TOTAL_NUMBER_OF_PRODUCE_CALLS_PROD = 5;
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
+    properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(999999999));
     properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -412,10 +410,7 @@ public class ProduceActionTest {
     mockedChunkedOutput.write(resultOrErrorOKProd5);
 
     ErrorResponse err =
-        ErrorResponse.create(
-            429,
-            "Rate limit of 1 messages per second exceeded within the grace period of 10 "
-                + "ms : Connection will be closed.");
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
     ResultOrError resultOrErrorProd6 = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorProd6);
@@ -427,6 +422,58 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse1 = new FakeAsyncResponse();
     produceAction.produce(fakeAsyncResponse1, "clusterId", "topicName", requests);
+
+    // check results
+    EasyMock.verify(requests);
+    EasyMock.verify(mockedChunkedOutput);
+  }
+
+  @Test
+  public void produceWithByteLimit() throws Exception {
+    // config
+    final int TOTAL_NUMBER_OF_PRODUCE_CALLS = 2;
+    Properties properties = new Properties();
+    properties.put(PRODUCE_GRACE_PERIOD_MS, "0");
+    properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, "100");
+    properties.put(
+        PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(30)); // first record is 25 bytes long
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, "3600000");
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+
+    // setup
+    ChunkedOutputFactory chunkedOutputFactory = mock(ChunkedOutputFactory.class);
+    ChunkedOutput<ResultOrError> mockedChunkedOutput =
+        getChunkedOutput(chunkedOutputFactory, TOTAL_NUMBER_OF_PRODUCE_CALLS);
+    Clock clock = mock(Clock.class);
+    ProduceAction produceAction = getProduceAction(properties, chunkedOutputFactory, clock, 1);
+    MappingIterator<ProduceRequest> requests =
+        getProduceRequestsMappingIterator(TOTAL_NUMBER_OF_PRODUCE_CALLS);
+
+    // expected results
+    ProduceResponse produceResponse = getProduceResponse(0);
+    ResultOrError resultOrErrorOK = ResultOrError.result(produceResponse);
+    expect(mockedChunkedOutput.isClosed()).andReturn(false);
+    mockedChunkedOutput.write(resultOrErrorOK); // successful first produce
+    mockedChunkedOutput.close();
+
+    ErrorResponse err =
+        ErrorResponse.create(429, "Rate limit exceeded : Connection will be closed.");
+    ResultOrError resultOrErrorFail = ResultOrError.error(err);
+    expect(mockedChunkedOutput.isClosed()).andReturn(false);
+    mockedChunkedOutput.write(resultOrErrorFail); // failing second produce
+    mockedChunkedOutput.close(); // error close
+    mockedChunkedOutput.close(); // second close always happens on tidy up
+
+    expect(clock.millis()).andReturn(0L);
+    expect(clock.millis()).andReturn(1L);
+
+    replay(mockedChunkedOutput, chunkedOutputFactory, clock);
+
+    // run test
+    FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
+    produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests);
+    FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
+    produceAction.produce(fakeAsyncResponse2, "clusterId", "topicName", requests);
 
     // check results
     EasyMock.verify(requests);
@@ -455,14 +502,13 @@ public class ProduceActionTest {
   private static MappingIterator<ProduceRequest> getProduceRequestsMappingIterator(int times)
       throws IOException {
     MappingIterator<ProduceRequest> requests = mock(MappingIterator.class);
-    ProduceRequest request = ProduceRequest.builder().build();
+    ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
     for (int i = 0; i < times; i++) {
       expect(requests.hasNext()).andReturn(true).times(1);
       expect(requests.nextValue()).andReturn(request).times(1);
       expect(requests.hasNext()).andReturn(false).times(1);
       requests.close();
     }
-    // requests.close();
     replay(requests);
     return requests;
   }
@@ -472,7 +518,7 @@ public class ProduceActionTest {
     MappingIterator<ProduceRequest> requests = mock(MappingIterator.class);
 
     for (int i = 0; i < times; i++) {
-      ProduceRequest request = ProduceRequest.builder().build();
+      ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
       expect(requests.hasNext()).andReturn(true).times(1);
       expect(requests.nextValue()).andReturn(request).times(1);
     }
@@ -494,7 +540,7 @@ public class ProduceActionTest {
     expect(clock.millis()).andReturn(1015L);
     replay(clock);
 
-    ProduceRequest request = ProduceRequest.builder().build();
+    ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
     expect(requests.hasNext()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
@@ -594,6 +640,7 @@ public class ProduceActionTest {
         new ProduceRateLimiters(
             Duration.ofMillis(Integer.parseInt(properties.getProperty(PRODUCE_GRACE_PERIOD_MS))),
             Integer.parseInt(properties.getProperty(PRODUCE_MAX_REQUESTS_PER_SECOND)),
+            Integer.parseInt(properties.getProperty(PRODUCE_MAX_BYTES_PER_SECOND)),
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))),


### PR DESCRIPTION
Cherry pick https://github.com/confluentinc/kafka-rest/commit/90e8db21eeeba8b8fb9f1734f105e28f9fff08af and https://github.com/confluentinc/kafka-rest/commit/fd9b2263b86ad0c228d60fb05428ff094c88a881 into the release branch