### PR TITLE
KREST-3255 fix missing annotations for produce limit

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -280,6 +280,9 @@ public final class ConfigModule extends AbstractBinder {
       extends AnnotationLiteral<ProduceRateLimitCacheExpiryConfig>
       implements ProduceRateLimitCacheExpiryConfig {}
 
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
   public @interface ProduceRateLimitCountConfig {}
 
   private static final class ProduceRateLimitCountConfigImpl


### PR DESCRIPTION
The counter limit for rest produce was being set to 1000, regardless of what the config set it to.  It's not clear where the 1000 default config comes from as we would have expected an error here, but it was due to missing annotations in ConfigModule.