### PR TITLE
KREST-3430 Optimize rate-limiting exceptions

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RateLimitGracePeriodExceededException.java
@@ -24,4 +24,11 @@ public final class RateLimitGracePeriodExceededException extends StatusCodeExcep
       int maxRequestsPerSec, int maxBytesPerSec, Duration gracePeriod) {
     super(Status.TOO_MANY_REQUESTS, "Rate limit exceeded ", "Connection will be closed.");
   }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    // Skipping stack-trace filling, as these exceptions are being used as a specific signal with
+    // well-known origin (our rate-limiting infrastructure).
+    return this;
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitExceededException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitExceededException.java
@@ -31,4 +31,11 @@ public final class RateLimitExceededException extends StatusCodeException {
         "Request rate limit exceeded",
         "The rate limit of requests per second has been exceeded.");
   }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    // Skipping stack-trace filling, as these exceptions are being used as a specific signal with
+    // well-known origin (our rate-limiting infrastructure).
+    return this;
+  }
 }


### PR DESCRIPTION
The `StatusCodeExceptions` that we throw in great numbers when rate-limiting can take a significant amount of time for filling their stack traces (up to 1% of a flamegraph taken during rate-limiting). These stack traces however are not really interesting for us, as the exceptions themselves always originate from our rate-limiting infrastructure.

The change overrides `fillInStackTrace()` instead of utilizing the `RuntimeException` ctor that takes a `writableStackTrace` flag, because while slightly more efficient, the latter approach is much more cumbersome.

Tested vs a local Kafka REST instance loaded using JMeter, by checking that the `java/lang/RuntimeException.<init>` -> `java/lang/Exception.<init>` -> `java/lang/Throwable.<init>` -> `java/lang/Throwable.fillInStackTrace` stack trace was optimized away from the captured flamegraph after this change.