### PR TITLE
Close produce stream on idle time and unauthenticated.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -438,6 +438,13 @@ public class KafkaRestConfig extends RestConfig {
           + "\"api.v3.clusters.*=1,api.v3.brokers.list=2\". A cost of zero means no rate-limit.";
   private static final String RATE_LIMIT_COSTS_DEFAULT = "";
 
+  private static final String STREAMING_RESPONSE_MAX_IDLE_TIME_MS_CONFIG =
+      "streaming.response.max.idle.time.ms";
+  private static final String STREAMING_RESPONSE_MAX_IDLE_TIME_MS_DOC =
+      "Maximum time that a chunked-encoding stream will be kept open without seeing a complete "
+          + "input message.";
+  private static final long STREAMING_RESPONSE_MAX_IDLE_TIME_MS_DEFAULT = 30000L;
+
   private static final ConfigDef config;
 
   static {
@@ -796,7 +803,13 @@ public class KafkaRestConfig extends RestConfig {
             Type.STRING,
             RATE_LIMIT_COSTS_DEFAULT,
             Importance.LOW,
-            RATE_LIMIT_COSTS_DOC);
+            RATE_LIMIT_COSTS_DOC)
+        .define(
+            STREAMING_RESPONSE_MAX_IDLE_TIME_MS_CONFIG,
+            Type.LONG,
+            STREAMING_RESPONSE_MAX_IDLE_TIME_MS_DEFAULT,
+            Importance.LOW,
+            STREAMING_RESPONSE_MAX_IDLE_TIME_MS_DOC);
   }
 
   private static Properties getPropsFromFile(String propsFile) throws RestConfigException {
@@ -1029,6 +1042,10 @@ public class KafkaRestConfig extends RestConfig {
             toImmutableMap(
                 entry -> entry.substring(0, entry.indexOf('=')).trim(),
                 entry -> Integer.valueOf(entry.substring(entry.indexOf('=') + 1).trim())));
+  }
+
+  public final Duration getStreamingResponseMaxIdleTime() {
+    return Duration.ofMillis(getLong(STREAMING_RESPONSE_MAX_IDLE_TIME_MS_CONFIG));
   }
 
   public void addTelemetryReporterProperties(Properties props) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -172,6 +172,10 @@ public final class ConfigModule extends AbstractBinder {
         .to(new TypeLiteral<List<URI>>() {});
 
     bind(schemaRegistryConfig.getSubjectNameStrategy()).to(SubjectNameStrategy.class);
+
+    bind(config.getStreamingResponseMaxIdleTime())
+        .qualifiedBy(new StreamingResponseMaxIdleTimeConfigImpl())
+        .to(Duration.class);
   }
 
   @Qualifier
@@ -401,5 +405,14 @@ public final class ConfigModule extends AbstractBinder {
 
   private static final class SchemaRegistryUrlsConfigImpl
       extends AnnotationLiteral<SchemaRegistryUrlsConfig> implements SchemaRegistryUrlsConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface StreamingResponseMaxIdleTimeConfig {}
+
+  private static final class StreamingResponseMaxIdleTimeConfigImpl
+      extends AnnotationLiteral<StreamingResponseMaxIdleTimeConfig>
+      implements StreamingResponseMaxIdleTimeConfig {}
 }
 // CHECKSTYLE:ON:ClassDataAbstractionCoupling

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesModule.java
@@ -15,15 +15,21 @@
 
 package io.confluent.kafkarest.resources.v3;
 
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.confluent.kafkarest.config.ConfigModule.ProduceResponseThreadPoolSizeConfig;
+import io.confluent.kafkarest.config.ConfigModule.StreamingResponseMaxIdleTimeConfig;
 import io.confluent.kafkarest.response.ChunkedOutputFactory;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
+import io.confluent.kafkarest.response.StreamingResponseIdleTimeLimiter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -42,9 +48,18 @@ public final class V3ResourcesModule extends AbstractBinder {
     bindAsContract(ProduceRateLimiters.class).in(Singleton.class);
     bindAsContract(ChunkedOutputFactory.class);
     bindAsContract(StreamingResponseFactory.class);
+    bindFactory(StreamingResponseIdleTimeLimiterFactory.class)
+        .to(StreamingResponseIdleTimeLimiter.class)
+        .in(Singleton.class);
+
     bind(Clock.systemUTC()).to(Clock.class);
+
     bindFactory(ProduceResponseExecutorServiceFactory.class)
         .qualifiedBy(new ProduceResponseThreadPoolImpl())
+        .to(ExecutorService.class)
+        .in(Singleton.class);
+    bindFactory(StreamingResponseIdleTimeExecutorFactory.class)
+        .qualifiedBy(new StreamingResponseIdleTimeExecutorImpl())
         .to(ExecutorService.class)
         .in(Singleton.class);
   }
@@ -56,6 +71,15 @@ public final class V3ResourcesModule extends AbstractBinder {
 
   private static final class ProduceResponseThreadPoolImpl
       extends AnnotationLiteral<ProduceResponseThreadPool> implements ProduceResponseThreadPool {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface StreamingResponseIdleTimeExecutor {}
+
+  private static final class StreamingResponseIdleTimeExecutorImpl
+      extends AnnotationLiteral<StreamingResponseIdleTimeExecutor>
+      implements StreamingResponseIdleTimeExecutor {}
 
   private static final class ProduceResponseExecutorServiceFactory
       implements Factory<ExecutorService> {
@@ -71,7 +95,7 @@ public final class V3ResourcesModule extends AbstractBinder {
     @Override
     public ExecutorService provide() {
       ThreadFactory namedThreadFactory =
-          new ThreadFactoryBuilder().setNameFormat("Produce-response-thread-%d").build();
+          new ThreadFactoryBuilder().setNameFormat("kafka-rest-produce-response-thread-%d").build();
       return Executors.newFixedThreadPool(produceResponseThreadPoolSize, namedThreadFactory);
     }
 
@@ -86,5 +110,51 @@ public final class V3ResourcesModule extends AbstractBinder {
         executorService.shutdownNow();
       }
     }
+  }
+
+  private static final class StreamingResponseIdleTimeExecutorFactory
+      implements Factory<ExecutorService> {
+
+    @Override
+    public ExecutorService provide() {
+      return Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder()
+              .setNameFormat("kafka-rest-streaming-response-idle-time-thread-%d")
+              .build());
+    }
+
+    @Override
+    public void dispose(ExecutorService executorService) {
+      executorService.shutdown();
+      try {
+        if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+          executorService.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        executorService.shutdownNow();
+      }
+    }
+  }
+
+  private static final class StreamingResponseIdleTimeLimiterFactory
+      implements Factory<StreamingResponseIdleTimeLimiter> {
+    private final ExecutorService executor;
+    private final Duration maxIdleTime;
+
+    @Inject
+    StreamingResponseIdleTimeLimiterFactory(
+        @StreamingResponseIdleTimeExecutor ExecutorService executor,
+        @StreamingResponseMaxIdleTimeConfig Duration maxIdleTime) {
+      this.executor = requireNonNull(executor);
+      this.maxIdleTime = requireNonNull(maxIdleTime);
+    }
+
+    @Override
+    public StreamingResponseIdleTimeLimiter provide() {
+      return new StreamingResponseIdleTimeLimiter(SimpleTimeLimiter.create(executor), maxIdleTime);
+    }
+
+    @Override
+    public void dispose(StreamingResponseIdleTimeLimiter idleTimeLimiter) {}
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseFactory.java
@@ -23,13 +23,16 @@ import javax.inject.Inject;
 public final class StreamingResponseFactory {
 
   private final ChunkedOutputFactory chunkedOutputFactory;
+  private final StreamingResponseIdleTimeLimiter idleTimeLimiter;
 
   @Inject
-  public StreamingResponseFactory(ChunkedOutputFactory chunkedOutputFactory) {
+  public StreamingResponseFactory(
+      ChunkedOutputFactory chunkedOutputFactory, StreamingResponseIdleTimeLimiter idleTimeLimiter) {
     this.chunkedOutputFactory = requireNonNull(chunkedOutputFactory);
+    this.idleTimeLimiter = requireNonNull(idleTimeLimiter);
   }
 
   public <T> StreamingResponse<T> from(MappingIterator<T> input) {
-    return StreamingResponse.from(input, chunkedOutputFactory);
+    return StreamingResponse.from(input, chunkedOutputFactory, idleTimeLimiter);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseIdleTimeLimiter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseIdleTimeLimiter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.response;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.util.concurrent.TimeLimiter;
+import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public final class StreamingResponseIdleTimeLimiter {
+  private final TimeLimiter delegate;
+  private final Duration maxIdleTime;
+
+  public StreamingResponseIdleTimeLimiter(TimeLimiter delegate, Duration maxIdleTime) {
+    this.delegate = requireNonNull(delegate);
+    this.maxIdleTime = requireNonNull(maxIdleTime);
+  }
+
+  <T> T callWithTimeout(Callable<T> callable)
+      throws ExecutionException, InterruptedException, MaxIdleTimeExceededException {
+    try {
+      return delegate.callWithTimeout(callable, maxIdleTime);
+    } catch (TimeoutException e) {
+      throw new MaxIdleTimeExceededException(e);
+    }
+  }
+
+  static final class MaxIdleTimeExceededException extends RuntimeException {
+
+    MaxIdleTimeExceededException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  static final class MaxIdleTimeExceededExceptionMapper
+      implements ExceptionMapper<MaxIdleTimeExceededException> {
+
+    @Override
+    public Response toResponse(MaxIdleTimeExceededException exception) {
+      return Response.status(Response.Status.REQUEST_TIMEOUT)
+          .entity(
+              ErrorResponse.create(
+                  Response.Status.REQUEST_TIMEOUT.getStatusCode(),
+                  "Timeout while reading from inputStream"))
+          .build();
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -64,6 +64,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,7 +72,7 @@ import org.junit.runners.JUnit4;
 
 // TODO ddimitrov This continues being way too flaky.
 //  Until we fix it (KREST-1542), we should ignore it, as it might be hiding even worse errors.
-// @Ignore
+@Ignore
 @RunWith(JUnit4.class)
 public class ProduceActionIntegrationTest {
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -64,7 +64,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +71,7 @@ import org.junit.runners.JUnit4;
 
 // TODO ddimitrov This continues being way too flaky.
 //  Until we fix it (KREST-1542), we should ignore it, as it might be hiding even worse errors.
-@Ignore
+// @Ignore
 @RunWith(JUnit4.class)
 public class ProduceActionIntegrationTest {
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -12,6 +12,7 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 
 import com.fasterxml.jackson.databind.MappingIterator;
+import com.google.common.util.concurrent.FakeTimeLimiter;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.confluent.kafkarest.ProducerMetrics;
 import io.confluent.kafkarest.controllers.ProduceController;
@@ -25,6 +26,7 @@ import io.confluent.kafkarest.response.ChunkedOutputFactory;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.StreamingResponse.ResultOrError;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
+import io.confluent.kafkarest.response.StreamingResponseIdleTimeLimiter;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
@@ -668,7 +670,9 @@ public class ProduceActionTest {
     replay(producerMetricsProvider, produceControllerProvider, produceController);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(chunkedOutputFactory);
+        new StreamingResponseFactory(
+            chunkedOutputFactory,
+            new StreamingResponseIdleTimeLimiter(new FakeTimeLimiter(), Duration.ZERO));
 
     // get the current thread so that the call counts can be seen by easy mock
     ExecutorService executorService = MoreExecutors.newDirectExecutorService();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -508,10 +508,9 @@ public class ProduceActionTest {
     MappingIterator<ProduceRequest> requests = mock(MappingIterator.class);
     ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
     for (int i = 0; i < times; i++) {
-      expect(requests.hasNext()).andReturn(true).times(1);
+      expect(requests.hasNextValue()).andReturn(true).times(1);
       expect(requests.nextValue()).andReturn(request).times(1);
-      expect(requests.hasNext()).andReturn(false).times(1);
-      requests.close();
+      expect(requests.hasNextValue()).andReturn(false).times(1);
     }
     replay(requests);
     return requests;
@@ -523,11 +522,10 @@ public class ProduceActionTest {
 
     for (int i = 0; i < times; i++) {
       ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
-      expect(requests.hasNext()).andReturn(true).times(1);
+      expect(requests.hasNextValue()).andReturn(true).times(1);
       expect(requests.nextValue()).andReturn(request).times(1);
     }
-    expect(requests.hasNext()).andReturn(false).times(1);
-    requests.close();
+    expect(requests.hasNextValue()).andReturn(false).times(1);
     replay(requests);
     return requests;
   }
@@ -545,26 +543,25 @@ public class ProduceActionTest {
     replay(clock);
 
     ProduceRequest request = ProduceRequest.builder().setOriginalSize(25L).build();
-    expect(requests.hasNext()).andReturn(true);
+    expect(requests.hasNextValue()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
-    expect(requests.hasNext()).andReturn(true);
+    expect(requests.hasNextValue()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
-    expect(requests.hasNext()).andReturn(true);
+    expect(requests.hasNextValue()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
-    expect(requests.hasNext()).andReturn(true);
+    expect(requests.hasNextValue()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
-    expect(requests.hasNext()).andReturn(true);
+    expect(requests.hasNextValue()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
-    expect(requests.hasNext()).andReturn(true);
+    expect(requests.hasNextValue()).andReturn(true);
     expect(requests.nextValue()).andReturn(request);
 
-    expect(requests.hasNext()).andReturn(false).times(1);
-    requests.close();
+    expect(requests.hasNextValue()).andReturn(false).times(1);
     replay(requests);
 
     return requests;

--- a/testing/environments/minimal/docker-compose.yml
+++ b/testing/environments/minimal/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3.7"
 
 services:
   zookeeper:
-    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-zookeeper:master-latest
+    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-zookeeper:7.1.x-latest
     hostname: zookeeper
     container_name: minimal-zookeeper
     environment:
@@ -26,7 +26,7 @@ services:
       - "9091:9091"
 
   kafka-1:
-    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:master-latest
+    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:7.1.x-latest
     hostname: kafka-1
     container_name: minimal-kafka-1
     depends_on:
@@ -43,7 +43,7 @@ services:
       - "9291:9291"
 
   kafka-2:
-    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:master-latest
+    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:7.1.x-latest
     hostname: kafka-2
     container_name: minimal-kafka-2
     depends_on:
@@ -60,7 +60,7 @@ services:
       - "9292:9292"
 
   kafka-3:
-    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:master-latest
+    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:7.1.x-latest
     hostname: kafka-3
     container_name: minimal-kafka-3
     depends_on:
@@ -77,7 +77,7 @@ services:
       - "9293:9293"
 
   schema-registry:
-    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-schema-registry:master-latest
+    image: 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-schema-registry:7.1.x-latest
     hostname: schema-registry
     container_name: minimal-schema-registry
     depends_on:

--- a/testing/environments/minimal/run.sh
+++ b/testing/environments/minimal/run.sh
@@ -37,16 +37,15 @@ aws ecr get-login-password --region us-west-2 \
  | docker login --username AWS --password-stdin 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/
 
 # Download latest cp-zookeeper image.
-docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-zookeeper:master-latest
-
+docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-zookeeper:7.1.x-latest
 # Download latest cp-server image.
-docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:master-latest
+docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-server:7.1.x-latest
 
 # Download latest cp-schema-registry image.
-docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-schema-registry:master-latest
+docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-schema-registry:7.1.x-latest
 
 # Download latest cp-kafka-rest image.
-docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-kafka-rest:master-latest
+docker pull 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-kafka-rest:7.1.x-latest
 
 # Make sure kafka-rest is packaged.
 mvn -f "$base_dir"/kafka-rest/pom.xml -DskipTests=true clean package

--- a/testing/image/Dockerfile
+++ b/testing/image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-kafka-rest:master-latest
+FROM 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-kafka-rest:7.1.x-latest
 
 COPY bin /usr/bin/
 


### PR DESCRIPTION
When handling produce requests, the request handling thread is held for as long as the input stream is open. Seeing we use a fixed size thread pool for request handling, a bad user could potentially deny any request from being handled by starving all request handling threads with open produce streams. That's attack is made worse by:

 1) we don't close the stream on unauthenticated from Kafka, so the user doesn't even need to have valid credentials
 2) we don't close the stream on idle time, so the user doesn't even need to send any data

This PR closes the two holes mentioned above. The server will now close the stream both if it hasn't seen requests in the stream within some or if any request produces an unauthenticated response from Kafka. Effectively, what that achieves is that we are forcing now each stream to authenticate with Kafka within some predefined time.

You can configure the idle time for the stream using the property `streaming.response.max.idle.time.ms` (default to 30s). Notice that there's an initial negotiation step where the stream is open but no bytes have actually been sent over the stream. In this case, the idle time is controlled not by Kafka REST, by Jetty, which already defaults it to 30s. A follow up PR will be done in `rest-utils` to add a way to configure this other Jetty idle time. It's strongly recomended that both idle times to be configured to the same value.