### PR TITLE
KREST-3636 all repos need a codeowners file - kafka-rest-eng set

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @confluentinc/kafka-rest-eng


### PR DESCRIPTION
Email from Mayuri Shinkar

By 02/01/2022 - Please ensure that your repo has a CODEOWNERS file defined and present in your repository Note: (If your repo does not have a CODEOWNERS file you need to create one by 02/01/2022 else you won’t be able to commit to your repo after this change)