### PR TITLE
Ignore a flaky rate-limit test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/Resilience4jRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/Resilience4jRateLimitTest.java
@@ -16,6 +16,8 @@
 package io.confluent.kafkarest.ratelimit;
 
 import java.time.Duration;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -45,5 +47,13 @@ public final class Resilience4jRateLimitTest extends AbstractRateLimitEnabledTes
   @Override
   int getSlack() {
     return 0;
+  }
+
+  // TODO ddimitrov This continues being way too flaky.
+  //  Until we fix it (KREST-3850), we should ignore it, as it might be hiding even worse errors.
+  @Ignore
+  @Test
+  public void rateLimitWithClassCost() {
+    super.rateLimitWithClassCost();
   }
 }


### PR DESCRIPTION
This test flakes out both locally and on Jenkins. We should fix it, but as I'm preoccupied with other high priority problems (KREST-3001) right now, it makes sense to at least prevent this from adding noise to our build results.

See https://jenkins.confluent.io/job/confluentinc/job/kafka-rest/job/7.1.x/175/testReport/junit/io.confluent.kafkarest.ratelimit/Resilience4jRateLimitTest/rateLimitWithClassCost/history/ and https://jenkins.confluent.io/job/confluentinc/job/kafka-rest/job/master/6720/testReport/io.confluent.kafkarest.ratelimit/Resilience4jRateLimitTest/rateLimitWithClassCost/history/ for context.