### PR TITLE
Ignore all Resilience4jRateLimitTest tests.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/Resilience4jRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/Resilience4jRateLimitTest.java
@@ -17,10 +17,12 @@ package io.confluent.kafkarest.ratelimit;
 
 import java.time.Duration;
 import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+// TODO ddimitrov This continues being way too flaky.
+//  Until we fix it (KREST-3850), we should ignore it, as it might be hiding even worse errors.
+@Ignore
 @RunWith(JUnit4.class)
 public final class Resilience4jRateLimitTest extends AbstractRateLimitEnabledTest {
 
@@ -47,13 +49,5 @@ public final class Resilience4jRateLimitTest extends AbstractRateLimitEnabledTes
   @Override
   int getSlack() {
     return 0;
-  }
-
-  // TODO ddimitrov This continues being way too flaky.
-  //  Until we fix it (KREST-3850), we should ignore it, as it might be hiding even worse errors.
-  @Ignore
-  @Test
-  public void rateLimitWithClassCost() {
-    super.rateLimitWithClassCost();
   }
 }


### PR DESCRIPTION
See #958 and specifically https://github.com/confluentinc/kafka-rest/pull/958#issuecomment-1003126334.