### PR TITLE
KREST-4112 Fix Create ACL request example.

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1793,9 +1793,6 @@ components:
           schema:
             $ref: '#/components/schemas/CreateAclRequestData'
           example:
-            kind: 'KafkaAcl'
-            metadata:
-              self: 'http://localhost:9391/v3/clusters/cluster-1/acls?resource_type=CLUSTER&resource_name=cluster-1&pattern_type=LITERAL&principal=bob&host=*&operation=DESCRIBE&permission=DENY'
             resource_type: 'CLUSTER'
             resource_name: 'cluster-1'
             pattern_type: 'LITERAL'


### PR DESCRIPTION
This fixes a problem in the example request for the Create ACL API (thanks, @nicolasguyomar for raising this) - the request should not contain the typical response fields "kind" and "metadata", which refer to an already existing resource.

The interesting question here is how did this go through the very rigorous OpenAPI validation that we do, which includes `openapi-examples-validator`. The answer is that by default that tool doesn't validate unspecified additional properties - we need the `-n` option for that (see https://github.com/codekie/openapi-examples-validator#usage). With that option, the problem is detected (along with a couple of others, that should be addressed separately).
I'll update our OpenAPI testing guidelines with that tidbit.