### PR TITLE
Disable the very flaky Guava rate-limiter tests.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
@@ -16,7 +16,11 @@
 package io.confluent.kafkarest.ratelimit;
 
 import java.time.Duration;
+import org.junit.jupiter.api.Disabled;
 
+// TODO ddimitrov This continues being way too flaky.
+//  Until we fix it (KREST-3850), we should ignore it, as it might be hiding even worse errors.
+@Disabled
 public final class GuavaRateLimitTest extends AbstractRateLimitEnabledTest {
 
   @Override


### PR DESCRIPTION
Unfortunately the GuavaRateLimitTest is also failing a lot - 4 out of 15 times on master - so it also needs to be disabled first, and at some point - fixed.