### PR TITLE
Disable the very flaky Guava rate-limiter tests.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/ratelimit/GuavaRateLimitTest.java
@@ -16,9 +16,13 @@
 package io.confluent.kafkarest.ratelimit;
 
 import java.time.Duration;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+// TODO ddimitrov This continues being way too flaky.
+//  Until we fix it (KREST-3850), we should ignore it, as it might be hiding even worse errors.
+@Ignore
 @RunWith(JUnit4.class)
 public final class GuavaRateLimitTest extends AbstractRateLimitEnabledTest {
 


### PR DESCRIPTION
Also see #967.
This targets specifically the 7.1.x branch, where JUnit 4 is still used. It should not be merged (it should be `-s ours`-ed) in master.