### PR TITLE
KREST-3836 update maven to pull from https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 


### PR DESCRIPTION
I've tested on a non-confluent laptop (which has a brand new maven version) and the build failed UNLESS I used https, as mvn refused to resolve the unsecure repository :)

Build pulls artefacts successfully with https.