### PR TITLE
KREST-4466 Run tests individually and repeatedly

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/README.md
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/README.md
@@ -1,0 +1,34 @@
+Kafka REST Proxy Tests
+================
+
+Unit Tests
+----------
+
+The unit tests can be run using `mvn test`
+
+To run an individual unit test class use, for example, `mvn -Dtest=ProduceRequestTest test`
+
+To run an individual unit test within a test class use, for example, `mvn -Dtest=ProduceRequestTest#testProduceRequestDeserializerAddsSizeFromString test`
+
+Integration Tests
+-----------------
+
+The integration tests live in the integration folder.
+
+They can be run using `mvn failsafe:integration-test`
+
+Individual test classes can be run using, for example, `mvn -Dit.test=ProduceActionIntegrationTest failsafe:integration-test`
+
+And individual tests within a test class can be run using, for example, ` mvn -Dit.test=ProduceActionIntegrationTest#produceBinary failsafe:integration-test`
+
+Notes
+-----
+
+To run individual tests you must be within the kafka-rest project folder (eg `~/git/kafka-rest/kafka-rest`) otherwise no tests will be found.
+
+If you make changes to the code, you will need to rebuild before running the tests for any code changes to be picked up. For example rebuild with `mvn package -DskipTests=true`
+
+To run the same test multiple times, there are several options, which include:
+
+- Replace `@Test` with `@RepeatedTest(5)` (remembering to rebuild)
+- Put a simple while loop around the mvn command `while true; do mvn -Dit.test=ProduceActionIntegrationTest failsafe:integration-test; done`

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/README.md
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/README.md
@@ -26,7 +26,7 @@ Notes
 
 To run individual tests you must be within the kafka-rest project folder (eg `~/git/kafka-rest/kafka-rest`) otherwise no tests will be found.
 
-If you make changes to the code, you will need to rebuild before running the tests for any code changes to be picked up. For example rebuild with `mvn package -DskipTests=true`
+If you make changes to the code, you will need to rebuild before running the tests for any code changes to be picked up. For example rebuild with `mvn clean package -DskipTests=true`
 
 To run the same test multiple times, there are several options, which include:
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaModuleOverridingTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/KafkaModuleOverridingTest.java
@@ -58,9 +58,11 @@ import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Tag("IntegrationTest")
 public class KafkaModuleOverridingTest {
   /** HTTP 418 I'm a teapot */
   private static final int I_M_A_TEAPOT_STATUS_CODE = 418;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
@@ -32,9 +32,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Tag("IntegrationTest")
 public class SchemaRegistrySaslInheritTest {
   private static final String TOPIC_NAME = "topic-1";
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/SchemaProduceConsumeTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/SchemaProduceConsumeTest.java
@@ -26,9 +26,11 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Tag("IntegrationTest")
 public abstract class SchemaProduceConsumeTest {
 
   private static final String TOPIC = "topic-1";

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -65,12 +65,14 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 // TODO ddimitrov This continues being way too flaky.
 //  Until we fix it (KREST-1542), we should ignore it, as it might be hiding even worse errors.
 @Disabled
+@Tag("IntegrationTest")
 public class ProduceActionIntegrationTest {
 
   private static final String TOPIC_NAME = "topic-1";


### PR DESCRIPTION
Some of our integration tests were missing the "IntegrationTest" tag, so it wasn't possible to run them individually.

I've added a testing readme to explain how to run the tests individually, and also how to run them repeatedly, as requested.
