### PR TITLE
KREST-4577 Fix Metadata API Test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -143,6 +143,8 @@ public abstract class ClusterTestHarness {
   protected Server restServer = null;
   protected String restConnect = null;
 
+  private static final long SLEEP_MS = 1000;
+
   public ClusterTestHarness() {
     this(DEFAULT_NUM_BROKERS, false);
   }
@@ -219,10 +221,30 @@ public abstract class ClusterTestHarness {
     restProperties.put("producer." + ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
 
     restConfig = new KafkaRestConfig(restProperties);
-    restApp = new KafkaRestApplication(restConfig);
-    restServer = restApp.createServer();
-    restServer.start();
+
+    try {
+      restApp = new KafkaRestApplication(restConfig);
+      restServer = restApp.createServer();
+      restServer.start();
+    } catch (IOException e) { // sometimes we get an address already in use exception
+      stopRestServer();
+      Thread.sleep(SLEEP_MS);
+      restServer = restApp.createServer();
+      restServer.start();
+    }
     log.info("Completed setup of {}", getClass().getSimpleName());
+  }
+
+  private void stopRestServer() throws Exception {
+    if (restApp != null) {
+      restApp.stop();
+      restApp.getMetrics().close();
+      restApp.getMetrics().metrics().clear();
+    }
+    if (restServer != null) {
+      restServer.stop();
+      restServer.join();
+    }
   }
 
   private void startBrokersConcurrently(int numBrokers) {
@@ -298,10 +320,7 @@ public abstract class ClusterTestHarness {
   @AfterEach
   public void tearDown() throws Exception {
     log.info("Starting teardown of {}", getClass().getSimpleName());
-    if (restServer != null) {
-      restServer.stop();
-      restServer.join();
-    }
+    stopRestServer();
 
     if (schemaRegServer != null) {
       schemaRegServer.stop();
@@ -310,6 +329,7 @@ public abstract class ClusterTestHarness {
 
     for (KafkaServer server : servers) {
       server.shutdown();
+      server.metrics().close();
     }
     for (KafkaServer server : servers) {
       CoreUtils.delete(server.config().logDirs());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataAPITest.java
@@ -16,6 +16,7 @@ package io.confluent.kafkarest.integration;
 
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static io.confluent.kafkarest.TestUtils.testWithRetry;
 import static io.confluent.kafkarest.TestUtils.tryReadEntityOrLog;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
@@ -43,6 +44,8 @@ import org.junit.jupiter.api.Test;
  * corner cases; rather it verifies the basic functionality works against a real cluster.
  */
 public class MetadataAPITest extends ClusterTestHarness {
+
+  private static final long SLEEP_MS = 500;
 
   private static final String topic1Name = "topic1";
   private static final List<Partition> topic1Partitions =
@@ -92,6 +95,7 @@ public class MetadataAPITest extends ClusterTestHarness {
     super.setUp();
     createTopic(topic1Name, topic1Partitions.size(), numReplicas);
     createTopic(topic2Name, topic2Partitions.size(), numReplicas);
+    // Thread.sleep(1000);
   }
 
   @Test
@@ -124,15 +128,11 @@ public class MetadataAPITest extends ClusterTestHarness {
   @Test
   public void testTopicsList() throws InterruptedException {
     // Listing
-    Response response = request("/topics").get();
-    assertOKResponse(response, Versions.KAFKA_V2_JSON);
-    final List<String> topicsResponse =
-        tryReadEntityOrLog(response, new GenericType<List<String>>() {});
-    assertEquals(Arrays.asList(topic1Name, topic2Name), topicsResponse);
+    testWithRetry(() -> verifyTopicGet());
 
     // Get topic
     Response response1 = request("/topics/{topic}", "topic", topic1Name).get();
-    assertOKResponse(response, Versions.KAFKA_V2_JSON);
+    assertOKResponse(response1, Versions.KAFKA_V2_JSON);
     final GetTopicResponse topic1Response = tryReadEntityOrLog(response1, GetTopicResponse.class);
     // Just verify some basic properties because the exact values can vary based on replica
     // assignment, leader election
@@ -155,25 +155,14 @@ public class MetadataAPITest extends ClusterTestHarness {
   @Test
   public void testPartitionsList() throws InterruptedException {
     // Listing
-    Response response = request("/topics/" + topic1Name + "/partitions").get();
-    assertOKResponse(response, Versions.KAFKA_V2_JSON);
-    List<GetPartitionResponse> partitions1Response =
-        tryReadEntityOrLog(response, new GenericType<List<GetPartitionResponse>>() {});
-    // Just verify some basic properties because the exact values can vary based on replica
-    // assignment, leader election
-    assertEquals(topic1Partitions.size(), partitions1Response.size());
-    assertEquals(numReplicas, partitions1Response.get(0).getReplicas().size());
 
-    response = request("/topics/" + topic2Name + "/partitions").get();
-    assertOKResponse(response, Versions.KAFKA_V2_JSON);
-    List<GetPartitionResponse> partitions2Response =
-        tryReadEntityOrLog(response, new GenericType<List<GetPartitionResponse>>() {});
-    assertEquals(topic2Partitions.size(), partitions2Response.size());
-    assertEquals(numReplicas, partitions2Response.get(0).getReplicas().size());
-    assertEquals(numReplicas, partitions2Response.get(1).getReplicas().size());
+    testWithRetry(() -> verifyPartitionGet(topic1Name, topic1Partitions.size(), 1));
+    testWithRetry(() -> verifyPartitionGet(topic2Name, topic2Partitions.size(), 2));
 
     // Get single partition
-    response = request("/topics/" + topic1Name + "/partitions/0").get();
+    // No need to retry, because we know the topic has been made by this point as the above
+    // assertions pass
+    Response response = request("/topics/" + topic1Name + "/partitions/0").get();
     assertOKResponse(response, Versions.KAFKA_V2_JSON);
     final GetPartitionResponse getPartitionResponse =
         tryReadEntityOrLog(response, GetPartitionResponse.class);
@@ -188,5 +177,26 @@ public class MetadataAPITest extends ClusterTestHarness {
         Errors.PARTITION_NOT_FOUND_ERROR_CODE,
         Errors.PARTITION_NOT_FOUND_MESSAGE,
         Versions.KAFKA_V2_JSON);
+  }
+
+  private void verifyTopicGet() {
+    Response response = request("/topics").get();
+    assertOKResponse(response, Versions.KAFKA_V2_JSON);
+    final List<String> topicsResponse =
+        tryReadEntityOrLog(response, new GenericType<List<String>>() {});
+    assertEquals(Arrays.asList(topic1Name, topic2Name), topicsResponse);
+  }
+
+  private void verifyPartitionGet(String topicName, int size, int numPartitions) {
+    Response response = request("/topics/" + topicName + "/partitions").get();
+    assertOKResponse(response, Versions.KAFKA_V2_JSON);
+    List<GetPartitionResponse> partitions1Response =
+        tryReadEntityOrLog(response, new GenericType<List<GetPartitionResponse>>() {});
+    // Just verify some basic properties because the exact values can vary based on replica
+    // assignment, leader election
+    assertEquals(size, partitions1Response.size());
+    for (int i = 0; i < numPartitions; i++) {
+      assertEquals(numReplicas, partitions1Response.get(i).getReplicas().size());
+    }
   }
 }


### PR DESCRIPTION
Fix typo where we were checking the wrong response object

restServer sees "address already in use" very occassionally - if this happens shut down, wait and try again

On a restart, the original metrics have already been registered and may be be cleared up yet, so we need to clear them from the application.  I've gone belt and braces approach.

Sometimes the Kafka metric server is still left behind - so we close this off explicitly too with server.metrics().close();

Sometimes kafka hasn't quite finished making the topics, so when we get the topics, only the first is returned, so these components are run with a testWithRetry. There is an analysis of the Kafka debug logs in the jira that describes this in more detail.