### PR TITLE
KREST-4577 Fix Metadata API Test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -225,9 +225,15 @@ public abstract class ClusterTestHarness {
     try {
       startRest();
     } catch (IOException e) { // sometimes we get an address already in use exception
+      log.warn("IOException when attempting to start rest, trying again", e);
       stopRest();
       Thread.sleep(ONE_SECOND_MS);
-      startRest();
+      try {
+        startRest();
+      } catch (IOException e2) {
+        log.error("Restart of rest server failed", e2);
+        throw e2;
+      }
     }
     log.info("Completed setup of {}", getClass().getSimpleName());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -143,7 +143,7 @@ public abstract class ClusterTestHarness {
   protected Server restServer = null;
   protected String restConnect = null;
 
-  private static final long SLEEP_MS = 1000;
+  private static final long ONE_SECOND_MS = 1000L;
 
   public ClusterTestHarness() {
     this(DEFAULT_NUM_BROKERS, false);
@@ -226,7 +226,7 @@ public abstract class ClusterTestHarness {
       startRest();
     } catch (IOException e) { // sometimes we get an address already in use exception
       stopRest();
-      Thread.sleep(SLEEP_MS);
+      Thread.sleep(ONE_SECOND_MS);
       startRest();
     }
     log.info("Completed setup of {}", getClass().getSimpleName());


### PR DESCRIPTION
Fix typo where we were checking the wrong response object

restServer sees "address already in use" very occasionally - if this happens shut down, wait and try again

On a restart, the original metrics have already been registered and may be be cleared up yet, so we need to clear them from the application.  I've gone belt and braces approach in clearing the metrics.

Sometimes the Kafka metric server is still left behind - so we close this off explicitly too with server.metrics().close();

Sometimes kafka hasn't quite finished making the topics, so when we get the topics, only the first is returned, so these components are run with a testWithRetry. There is an analysis of the Kafka debug logs in the jira that describes this in more detail.