### PR TITLE
KREST-4591 add topic recreate logic to cluster test harness

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -178,7 +178,7 @@ public abstract class ClusterTestHarness {
   // Calling setup() in this class calls the setup() from the calling sub-class, which includes the
   // createTopic calls, which then causes an infinite loop on topic creation.
   // Pulling out the functionality to a separate method so we can call it without this behaviour
-  // getting in the way
+  // getting in the way.
   private void setupMethod() throws Exception {
     zookeeper = new EmbeddedZookeeper();
     zkConnect = String.format("127.0.0.1:%d", zookeeper.port());
@@ -518,11 +518,10 @@ public abstract class ClusterTestHarness {
           .findFirst()
           .isPresent()) {
         // The topic we are trying to make isn't the first topic to be created, the topic list isn't
-        // 0 length
-        // (that or an exception has been thrown, but the topic was created anyway).
+        // 0 length (that or an exception has been thrown, but the topic was created anyway).
         // We can't easily restart the environment as we will lose the existing topics.
         // While we could store them and recreate them all, for now, let's just wait a bit and have
-        // another go with the current topic
+        // another go with the current topic.
         log.warn("Topic creation failed the first time round, trying again.");
         result =
             createTopicCall(
@@ -532,7 +531,7 @@ public abstract class ClusterTestHarness {
       } else {
         log.warn(
             String.format(
-                "Exception thrown but topic has been created, carrying on: %s %s",
+                "Exception thrown but topic  %s has been created, carrying on: %s",
                 topicName, e.getMessage()));
       }
       if (!getTopicNames().stream()

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -91,7 +91,7 @@ import scala.collection.JavaConverters;
 public abstract class ClusterTestHarness {
 
   private static final Logger log = LoggerFactory.getLogger(ClusterTestHarness.class);
-  private static final long SLEEP_MS = 500;
+  private static final long HALF_SECOND_MILLIS = 500L;
 
   public static final int DEFAULT_NUM_BROKERS = 1;
 
@@ -370,7 +370,6 @@ public abstract class ClusterTestHarness {
     }
 
     zookeeper.shutdown();
-    log.info("Completed teardown of {}", getClass().getSimpleName());
   }
 
   protected Invocation.Builder request(String path) {
@@ -550,7 +549,7 @@ public abstract class ClusterTestHarness {
 
   private void pause() {
     try {
-      Thread.sleep(SLEEP_MS);
+      Thread.sleep(HALF_SECOND_MILLIS);
     } catch (InterruptedException ie3) {
     }
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -275,14 +275,16 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setAuthorizedOperations(emptySet())
                 .build());
 
-    Response response =
-        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1)
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
-
-    GetTopicResponse actual = response.readEntity(GetTopicResponse.class);
-    assertEquals(expected, actual);
+    testWithRetry(
+        () -> {
+          Response response =
+              request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), response.getStatus());
+          GetTopicResponse actual = response.readEntity(GetTopicResponse.class);
+          assertEquals(expected, actual);
+        });
   }
 
   @Test
@@ -678,15 +680,23 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
-    Response existingGetTopicConfigResponse =
-        request("/v3/clusters/" + clusterId + "/topics/" + topicName + "/configs/cleanup.policy")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), existingGetTopicConfigResponse.getStatus());
+    testWithRetry(
+        () -> {
+          Response existingGetTopicConfigResponse =
+              request(
+                      "/v3/clusters/"
+                          + clusterId
+                          + "/topics/"
+                          + topicName
+                          + "/configs/cleanup.policy")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          assertEquals(Status.OK.getStatusCode(), existingGetTopicConfigResponse.getStatus());
 
-    GetTopicConfigResponse actualGetTopicConfigResponse =
-        existingGetTopicConfigResponse.readEntity(GetTopicConfigResponse.class);
-    assertEquals(expectedExistingGetTopicConfigResponse, actualGetTopicConfigResponse);
+          GetTopicConfigResponse actualGetTopicConfigResponse =
+              existingGetTopicConfigResponse.readEntity(GetTopicConfigResponse.class);
+          assertEquals(expectedExistingGetTopicConfigResponse, actualGetTopicConfigResponse);
+        });
 
     Response deleteTopicResponse =
         request("/v3/clusters/" + clusterId + "/topics/" + topicName)


### PR DESCRIPTION
Most of the test flakes in this class are due to failures in the setup and the topics not being created.

I can't reproduce this locally unfortunately, but I have put in a pile of retry logic to allow more time, and then have another try at creating the environment.

Also add in a test retry for a flakey test.