### PR TITLE
KREST-4605 Deflake all the tests that extend AbstractConsumerTest

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
@@ -186,7 +186,7 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
     } catch (Throwable t) {
       // This protects the worker thread from any issues with the callback code. Nothing to be
       // done here but log it since it indicates a bug in the calling code.
-      log.error("Consumer read callback threw an unhandled exception id={}", this, e);
+      log.error("Consumer read callback threw an unhandled exception id={} exception={}", this, e);
     }
     finished = true;
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -19,6 +19,7 @@ import static io.confluent.kafkarest.TestUtils.assertOKResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -48,6 +49,8 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 public class AbstractConsumerTest extends ClusterTestHarness {
+
+  private static final long ONE_SECOND_MS = 1000L;
 
   public AbstractConsumerTest() {}
 
@@ -100,8 +103,20 @@ public class AbstractConsumerTest extends ClusterTestHarness {
 
   protected String startConsumeMessages(
       String groupName, List<String> topics, EmbeddedFormat format, String expectedMediatype) {
-    Response createResponse = createConsumerInstance(groupName, null, null, format);
-    assertOKResponse(createResponse, Versions.KAFKA_V2_JSON);
+    Response createResponse = null;
+    try {
+      createResponse = createConsumerInstance(groupName, null, null, format);
+      assertOKResponse(createResponse, Versions.KAFKA_V2_JSON);
+    } catch (AssertionError e) {
+      if (createResponse != null
+          && createResponse.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
+        pause();
+        createResponse = createConsumerInstance(groupName, null, null, format);
+        assertOKResponse(createResponse, Versions.KAFKA_V2_JSON);
+      } else {
+        fail("Create consumer instance failed.", e);
+      }
+    }
 
     CreateConsumerInstanceResponse instanceResponse =
         TestUtils.tryReadEntityOrLog(createResponse, CreateConsumerInstanceResponse.class);
@@ -119,15 +134,25 @@ public class AbstractConsumerTest extends ClusterTestHarness {
             .post(Entity.entity(subscribeRequest, Versions.KAFKA_V2_JSON));
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), subscribeResponse.getStatus());
 
+    Response response = null;
     // Start consuming. Since production hasn't started yet, this is expected to timeout.
-    Response response =
-        request(instanceResponse.getBaseUri() + "/records").accept(expectedMediatype).get();
-
-    assertOKResponse(response, expectedMediatype);
+    try {
+      response =
+          request(instanceResponse.getBaseUri() + "/records").accept(expectedMediatype).get();
+      assertOKResponse(response, expectedMediatype);
+    } catch (AssertionError e) {
+      if (response != null && response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
+        pause();
+        response =
+            request(instanceResponse.getBaseUri() + "/records").accept(expectedMediatype).get();
+        assertOKResponse(response, Versions.KAFKA_V2_JSON);
+      } else {
+        fail("Consume of records failed", e);
+      }
+    }
     List<BinaryConsumerRecord> consumed =
         TestUtils.tryReadEntityOrLog(response, new GenericType<List<BinaryConsumerRecord>>() {});
     assertEquals(0, consumed.size());
-
     return instanceResponse.getBaseUri();
   }
 
@@ -184,10 +209,40 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     Response response = request(instanceUri + "/records").accept(accept).get();
     assertOKResponse(response, responseMediatype);
     List<RecordType> consumed = TestUtils.tryReadEntityOrLog(response, responseEntityType);
-    assertEquals(records.size(), consumed.size());
+    try {
+      assertEquals(records.size(), consumed.size());
+    } catch (AssertionError e) {
+      pause();
+      Response response2 = request(instanceUri + "/records").accept(accept).get();
+      assertOKResponse(response2, responseMediatype);
+      List<RecordType> consumed2 = TestUtils.tryReadEntityOrLog(response2, responseEntityType);
+      consumed.addAll(consumed2);
+      try {
+        assertEquals(records.size(), consumed.size());
+      } catch (AssertionError e2) {
+        pause(2);
+        Response response3 = request(instanceUri + "/records").accept(accept).get();
+        assertOKResponse(response3, responseMediatype);
+        List<RecordType> consumed3 = TestUtils.tryReadEntityOrLog(response3, responseEntityType);
+        consumed.addAll(consumed3);
+        assertEquals(records.size(), consumed.size());
+      }
+    }
 
     assertEqualsMessages(
         records, consumed.stream().map(fromJsonWrapper).collect(Collectors.toList()), converter);
+  }
+
+  private final void pause() {
+    pause(1);
+  }
+
+  private final void pause(int times) {
+    try {
+      Thread.sleep(times * ONE_SECOND_MS);
+    } catch (InterruptedException e) {
+
+    }
   }
 
   protected <RecordType> void consumeForTimeout(
@@ -208,10 +263,11 @@ public class AbstractConsumerTest extends ClusterTestHarness {
     // as some extra slack for general overhead (which apparently mostly comes from running the
     // request and can be quite substantial).
     final int TIMEOUT = restConfig.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG);
-    final int TIMEOUT_SLACK =
+    final long TIMEOUT_SLACK =
         restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG)
             + restConfig.getInt(KafkaRestConfig.CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG)
-            + 500;
+            + ONE_SECOND_MS; // This test is inherently flakey, and probably needs a mocked back
+    // end, but for now we can give it lots of slack
     long elapsed = finished - started;
     assertTrue(
         elapsed > TIMEOUT,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -145,7 +145,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
         pause();
         response =
             request(instanceResponse.getBaseUri() + "/records").accept(expectedMediatype).get();
-        assertOKResponse(response, Versions.KAFKA_V2_JSON);
+        assertOKResponse(response, expectedMediatype);
       } else {
         fail("Consume of records failed", e);
       }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -14,9 +14,11 @@
  */
 package io.confluent.kafkarest.integration;
 
+import static io.confluent.kafkarest.TestUtils.testWithRetry;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
@@ -42,6 +44,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -63,7 +66,6 @@ import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Node;
@@ -89,8 +91,6 @@ import scala.collection.JavaConverters;
 public abstract class ClusterTestHarness {
 
   private static final Logger log = LoggerFactory.getLogger(ClusterTestHarness.class);
-  private static final long ONE_SECOND_MS = 1000l;
-  private static final int RETRY_COUNT = 3;
 
   public static final int DEFAULT_NUM_BROKERS = 1;
 
@@ -528,12 +528,9 @@ public abstract class ClusterTestHarness {
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
 
-    KafkaProducer<Object, Object> producer =
-        new KafkaProducer<Object, Object>(props, avroKeySerializer, avroValueSerializer);
     for (ProducerRecord<Object, Object> rec : records) {
-      doProduce(producer, rec);
+      doProduce(rec, () -> new KafkaProducer<>(props, avroKeySerializer, avroValueSerializer));
     }
-    producer.close();
   }
 
   protected final void produceBinaryMessages(List<ProducerRecord<byte[], byte[]>> records) {
@@ -542,11 +539,10 @@ public abstract class ClusterTestHarness {
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
     props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.setProperty(ProducerConfig.ACKS_CONFIG, "all");
-    Producer<byte[], byte[]> producer = new KafkaProducer<byte[], byte[]>(props);
+
     for (ProducerRecord<byte[], byte[]> rec : records) {
-      doProduce(producer, rec);
+      doProduce(rec, () -> new KafkaProducer<>(props));
     }
-    producer.close();
   }
 
   protected final void produceJsonMessages(List<ProducerRecord<Object, Object>> records) {
@@ -555,37 +551,28 @@ public abstract class ClusterTestHarness {
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaJsonSerializer.class);
     props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.setProperty(ProducerConfig.ACKS_CONFIG, "all");
-    Producer<Object, Object> producer = new KafkaProducer<Object, Object>(props);
 
     for (ProducerRecord<Object, Object> rec : records) {
-      doProduce(producer, rec);
-    }
-    producer.close();
-  }
-
-  private <T, R extends Producer> void doProduce(R producer, ProducerRecord<T, T> rec) {
-    boolean sent = false;
-    int errorCount = 0;
-    while (!sent) {
-      try {
-        producer.send(rec).get();
-        sent = true;
-      } catch (Exception e) {
-        errorCount++;
-        if (errorCount > RETRY_COUNT) {
-          fail("Couldn't produce input messages to Kafka: " + e);
-        }
-        pause(errorCount);
-      }
+      doProduce(rec, () -> new KafkaProducer<>(props));
     }
   }
 
-  private final void pause(int times) {
-    try {
-      Thread.sleep(ONE_SECOND_MS * times);
-    } catch (InterruptedException e) {
+  private <T> void doProduce(
+      ProducerRecord<T, T> rec, Supplier<KafkaProducer<T, T>> createProducer) {
 
-    }
+    testWithRetry(
+        () -> {
+          final KafkaProducer<T, T> producer = createProducer.get();
+          boolean sent = false;
+          try {
+            producer.send(rec).get();
+            sent = true;
+          } catch (Exception e) {
+            log.info("Produce failed within testWithRetry", e);
+          }
+          producer.close();
+          assertTrue(sent);
+        });
   }
 
   protected Map<Integer, List<Integer>> createAssignment(


### PR DESCRIPTION
KafkaConsumerReadTask
- exception stack trace not logged, added in so we have a starting point for debugging the intermittently failing test

AbstractConsumerTest
 - a 404 is returned somewhere in startConsumerMessages (can't prove where, but one of the assertOKResponses fails with a 404) so check for the 404 on both, and then retry after a pause if it is returned.  Fail the second time
 - The number of messages consumed doesn't always match how many we expect.  I could reproduce this locally, and a single retry didn't always help, so I've added in two.  If it still fails we can look at reworking this a different way
 - consumeForTimeout is inherently flakey as it is so reliant on times.  I've doubled the wait period slack to 1s, from 501ms to see if that helps at all, but otherwise we will need to look at a mocked back end.

ClusterTestHarness
 - Made a generic produce method, as this was repeated with different object types
 - The produce was also failing in some cases so I've added some retry logic to try and resend each message 3 times with a pause each time before failure