### PR TITLE
Disable producer idempotency until KAFKA-13668 is fixed.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -873,6 +873,14 @@ public class KafkaRestConfig extends RestConfig {
 
     Properties producerProperties = new Properties();
     producerProperties.putAll(producerConfigs);
+
+    // KREST-4606: Disable idempotency until KAFKA-13668 is fixed.
+    if (Boolean.parseBoolean(producerProperties.getProperty("enable.idempotence"))) {
+      log.warn(
+          "Idempotent producers are not supported in Kafka REST. Ignoring enable.idempotence'.");
+    }
+    producerProperties.put("enable.idempotence", "false");
+
     addTelemetryReporterProperties(producerProperties);
 
     return producerProperties;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -874,7 +874,8 @@ public class KafkaRestConfig extends RestConfig {
     Properties producerProperties = new Properties();
     producerProperties.putAll(producerConfigs);
 
-    // KREST-4606: Disable idempotency until KAFKA-13668 is fixed.
+    // KREST-4606: Disable idempotency until at the very least KAFKA-13668 is fixed, but maybe
+    // forever.
     if (Boolean.parseBoolean(producerProperties.getProperty("enable.idempotence"))) {
       log.warn(
           "Idempotent producers are not supported in Kafka REST. Ignoring 'enable.idempotence'.");

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -877,7 +877,7 @@ public class KafkaRestConfig extends RestConfig {
     // KREST-4606: Disable idempotency until KAFKA-13668 is fixed.
     if (Boolean.parseBoolean(producerProperties.getProperty("enable.idempotence"))) {
       log.warn(
-          "Idempotent producers are not supported in Kafka REST. Ignoring enable.idempotence'.");
+          "Idempotent producers are not supported in Kafka REST. Ignoring 'enable.idempotence'.");
     }
     producerProperties.put("enable.idempotence", "false");
 


### PR DESCRIPTION
For the idempotent producer, some errors are permanent, meaning the producer instance becomes unusable afterwards. Authorization errors are one of these. This behaviour disagrees with the Kafka REST model, which assumes the producer to be stateless across requests. Until we either adapt Kafka REST to the idempotent model, or authorization errors become non-fatal, we will disable idempotent producers in Kafka REST.