### PR TITLE
KREST-4608 unflake consumergroup tests

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -153,6 +153,11 @@
            <artifactId>bcprov-ext-jdk15on</artifactId>
            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
@@ -16,6 +16,9 @@
 package io.confluent.kafkarest.integration.v3;
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.AnyOf.anyOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
@@ -62,7 +65,7 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     consumer2.poll(Duration.ofSeconds(1));
     consumer3.poll(Duration.ofSeconds(1));
 
-    ListConsumerGroupsResponse expected =
+    ListConsumerGroupsResponse expected1 =
         ListConsumerGroupsResponse.create(
             ConsumerGroupDataList.builder()
                 .setMetadata(
@@ -107,12 +110,58 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
                             .build()))
                 .build());
 
+    ListConsumerGroupsResponse expected2 =
+        ListConsumerGroupsResponse.create(
+            ConsumerGroupDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder()
+                        .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups")
+                        .build())
+                .setData(
+                    singletonList(
+                        ConsumerGroupData.builder()
+                            .setMetadata(
+                                Resource.Metadata.builder()
+                                    .setSelf(
+                                        baseUrl
+                                            + "/v3/clusters/"
+                                            + clusterId
+                                            + "/consumer-groups/consumer-group-1")
+                                    .setResourceName(
+                                        "crn:///kafka="
+                                            + clusterId
+                                            + "/consumer-group=consumer-group-1")
+                                    .build())
+                            .setClusterId(clusterId)
+                            .setConsumerGroupId("consumer-group-1")
+                            .setSimple(false)
+                            .setPartitionAssignor("range")
+                            .setState(State.STABLE)
+                            .setCoordinator(
+                                Relationship.create(
+                                    baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
+                            .setConsumers(
+                                Relationship.create(
+                                    baseUrl
+                                        + "/v3/clusters/"
+                                        + clusterId
+                                        + "/consumer-groups/consumer-group-1/consumers"))
+                            .setLagSummary(
+                                Relationship.create(
+                                    baseUrl
+                                        + "/v3/clusters/"
+                                        + clusterId
+                                        + "/consumer-groups/consumer-group-1/lag-summary"))
+                            .build()))
+                .build());
+
     Response response =
         request("/v3/clusters/" + clusterId + "/consumer-groups")
             .accept(MediaType.APPLICATION_JSON)
             .get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    assertEquals(expected, response.readEntity(ListConsumerGroupsResponse.class));
+    assertThat(
+        response.readEntity(ListConsumerGroupsResponse.class), anyOf(is(expected1), is(expected2)));
   }
 
   @Test
@@ -153,7 +202,41 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     consumer2.poll(Duration.ofSeconds(1));
     consumer3.poll(Duration.ofSeconds(1));
 
-    GetConsumerGroupResponse expected =
+    GetConsumerGroupResponse expected1 =
+        GetConsumerGroupResponse.create(
+            ConsumerGroupData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(
+                            baseUrl
+                                + "/v3/clusters/"
+                                + clusterId
+                                + "/consumer-groups/consumer-group-1")
+                        .setResourceName(
+                            "crn:///kafka=" + clusterId + "/consumer-group=consumer-group-1")
+                        .build())
+                .setClusterId(clusterId)
+                .setConsumerGroupId("consumer-group-1")
+                .setSimple(false)
+                .setPartitionAssignor("range")
+                .setState(State.STABLE)
+                .setCoordinator(
+                    Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
+                .setConsumers(
+                    Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/consumer-groups/consumer-group-1/consumers"))
+                .setLagSummary(
+                    Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/consumer-groups/consumer-group-1/lag-summary"))
+                .build());
+
+    GetConsumerGroupResponse expected2 =
         GetConsumerGroupResponse.create(
             ConsumerGroupData.builder()
                 .setMetadata(
@@ -192,7 +275,8 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    assertEquals(expected, response.readEntity(GetConsumerGroupResponse.class));
+    assertThat(
+        response.readEntity(GetConsumerGroupResponse.class), anyOf(is(expected1), is(expected2)));
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
@@ -65,95 +65,11 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     consumer2.poll(Duration.ofSeconds(1));
     consumer3.poll(Duration.ofSeconds(1));
 
-    ListConsumerGroupsResponse expected1 =
-        ListConsumerGroupsResponse.create(
-            ConsumerGroupDataList.builder()
-                .setMetadata(
-                    ResourceCollection.Metadata.builder()
-                        .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups")
-                        .build())
-                .setData(
-                    singletonList(
-                        ConsumerGroupData.builder()
-                            .setMetadata(
-                                Resource.Metadata.builder()
-                                    .setSelf(
-                                        baseUrl
-                                            + "/v3/clusters/"
-                                            + clusterId
-                                            + "/consumer-groups/consumer-group-1")
-                                    .setResourceName(
-                                        "crn:///kafka="
-                                            + clusterId
-                                            + "/consumer-group=consumer-group-1")
-                                    .build())
-                            .setClusterId(clusterId)
-                            .setConsumerGroupId("consumer-group-1")
-                            .setSimple(false)
-                            .setPartitionAssignor("")
-                            .setState(State.PREPARING_REBALANCE)
-                            .setCoordinator(
-                                Relationship.create(
-                                    baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
-                            .setConsumers(
-                                Relationship.create(
-                                    baseUrl
-                                        + "/v3/clusters/"
-                                        + clusterId
-                                        + "/consumer-groups/consumer-group-1/consumers"))
-                            .setLagSummary(
-                                Relationship.create(
-                                    baseUrl
-                                        + "/v3/clusters/"
-                                        + clusterId
-                                        + "/consumer-groups/consumer-group-1/lag-summary"))
-                            .build()))
-                .build());
+    ListConsumerGroupsResponse expectedPreparingRebalance =
+        getExpectedListResponse(baseUrl, clusterId, "", State.PREPARING_REBALANCE);
 
-    ListConsumerGroupsResponse expected2 =
-        ListConsumerGroupsResponse.create(
-            ConsumerGroupDataList.builder()
-                .setMetadata(
-                    ResourceCollection.Metadata.builder()
-                        .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups")
-                        .build())
-                .setData(
-                    singletonList(
-                        ConsumerGroupData.builder()
-                            .setMetadata(
-                                Resource.Metadata.builder()
-                                    .setSelf(
-                                        baseUrl
-                                            + "/v3/clusters/"
-                                            + clusterId
-                                            + "/consumer-groups/consumer-group-1")
-                                    .setResourceName(
-                                        "crn:///kafka="
-                                            + clusterId
-                                            + "/consumer-group=consumer-group-1")
-                                    .build())
-                            .setClusterId(clusterId)
-                            .setConsumerGroupId("consumer-group-1")
-                            .setSimple(false)
-                            .setPartitionAssignor("range")
-                            .setState(State.STABLE)
-                            .setCoordinator(
-                                Relationship.create(
-                                    baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
-                            .setConsumers(
-                                Relationship.create(
-                                    baseUrl
-                                        + "/v3/clusters/"
-                                        + clusterId
-                                        + "/consumer-groups/consumer-group-1/consumers"))
-                            .setLagSummary(
-                                Relationship.create(
-                                    baseUrl
-                                        + "/v3/clusters/"
-                                        + clusterId
-                                        + "/consumer-groups/consumer-group-1/lag-summary"))
-                            .build()))
-                .build());
+    ListConsumerGroupsResponse expectedStable =
+        getExpectedListResponse(baseUrl, clusterId, "range", State.STABLE);
 
     Response response =
         request("/v3/clusters/" + clusterId + "/consumer-groups")
@@ -161,7 +77,8 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
             .get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     assertThat(
-        response.readEntity(ListConsumerGroupsResponse.class), anyOf(is(expected1), is(expected2)));
+        response.readEntity(ListConsumerGroupsResponse.class),
+        anyOf(is(expectedPreparingRebalance), is(expectedStable)));
   }
 
   @Test
@@ -202,73 +119,11 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     consumer2.poll(Duration.ofSeconds(1));
     consumer3.poll(Duration.ofSeconds(1));
 
-    GetConsumerGroupResponse expected1 =
-        GetConsumerGroupResponse.create(
-            ConsumerGroupData.builder()
-                .setMetadata(
-                    Resource.Metadata.builder()
-                        .setSelf(
-                            baseUrl
-                                + "/v3/clusters/"
-                                + clusterId
-                                + "/consumer-groups/consumer-group-1")
-                        .setResourceName(
-                            "crn:///kafka=" + clusterId + "/consumer-group=consumer-group-1")
-                        .build())
-                .setClusterId(clusterId)
-                .setConsumerGroupId("consumer-group-1")
-                .setSimple(false)
-                .setPartitionAssignor("range")
-                .setState(State.STABLE)
-                .setCoordinator(
-                    Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
-                .setConsumers(
-                    Relationship.create(
-                        baseUrl
-                            + "/v3/clusters/"
-                            + clusterId
-                            + "/consumer-groups/consumer-group-1/consumers"))
-                .setLagSummary(
-                    Relationship.create(
-                        baseUrl
-                            + "/v3/clusters/"
-                            + clusterId
-                            + "/consumer-groups/consumer-group-1/lag-summary"))
-                .build());
+    GetConsumerGroupResponse expectedStable =
+        getExpectedGroupResponse(baseUrl, clusterId, "range", State.STABLE);
 
-    GetConsumerGroupResponse expected2 =
-        GetConsumerGroupResponse.create(
-            ConsumerGroupData.builder()
-                .setMetadata(
-                    Resource.Metadata.builder()
-                        .setSelf(
-                            baseUrl
-                                + "/v3/clusters/"
-                                + clusterId
-                                + "/consumer-groups/consumer-group-1")
-                        .setResourceName(
-                            "crn:///kafka=" + clusterId + "/consumer-group=consumer-group-1")
-                        .build())
-                .setClusterId(clusterId)
-                .setConsumerGroupId("consumer-group-1")
-                .setSimple(false)
-                .setPartitionAssignor("")
-                .setState(State.PREPARING_REBALANCE)
-                .setCoordinator(
-                    Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
-                .setConsumers(
-                    Relationship.create(
-                        baseUrl
-                            + "/v3/clusters/"
-                            + clusterId
-                            + "/consumer-groups/consumer-group-1/consumers"))
-                .setLagSummary(
-                    Relationship.create(
-                        baseUrl
-                            + "/v3/clusters/"
-                            + clusterId
-                            + "/consumer-groups/consumer-group-1/lag-summary"))
-                .build());
+    GetConsumerGroupResponse expectedRebalance =
+        getExpectedGroupResponse(baseUrl, clusterId, "", State.PREPARING_REBALANCE);
 
     Response response =
         request("/v3/clusters/" + clusterId + "/consumer-groups/consumer-group-1")
@@ -276,7 +131,8 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
             .get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     assertThat(
-        response.readEntity(GetConsumerGroupResponse.class), anyOf(is(expected1), is(expected2)));
+        response.readEntity(GetConsumerGroupResponse.class),
+        anyOf(is(expectedStable), is(expectedRebalance)));
   }
 
   @Test
@@ -330,5 +186,85 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
     properties.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
     return new KafkaConsumer<>(properties, new BytesDeserializer(), new BytesDeserializer());
+  }
+
+  private ListConsumerGroupsResponse getExpectedListResponse(
+      String baseUrl, String clusterId, String partitionAssignor, State state) {
+    return ListConsumerGroupsResponse.create(
+        ConsumerGroupDataList.builder()
+            .setMetadata(
+                ResourceCollection.Metadata.builder()
+                    .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups")
+                    .build())
+            .setData(
+                singletonList(
+                    ConsumerGroupData.builder()
+                        .setMetadata(
+                            Resource.Metadata.builder()
+                                .setSelf(
+                                    baseUrl
+                                        + "/v3/clusters/"
+                                        + clusterId
+                                        + "/consumer-groups/consumer-group-1")
+                                .setResourceName(
+                                    "crn:///kafka="
+                                        + clusterId
+                                        + "/consumer-group=consumer-group-1")
+                                .build())
+                        .setClusterId(clusterId)
+                        .setConsumerGroupId("consumer-group-1")
+                        .setSimple(false)
+                        .setPartitionAssignor(partitionAssignor)
+                        .setState(state)
+                        .setCoordinator(
+                            Relationship.create(
+                                baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
+                        .setConsumers(
+                            Relationship.create(
+                                baseUrl
+                                    + "/v3/clusters/"
+                                    + clusterId
+                                    + "/consumer-groups/consumer-group-1/consumers"))
+                        .setLagSummary(
+                            Relationship.create(
+                                baseUrl
+                                    + "/v3/clusters/"
+                                    + clusterId
+                                    + "/consumer-groups/consumer-group-1/lag-summary"))
+                        .build()))
+            .build());
+  }
+
+  private GetConsumerGroupResponse getExpectedGroupResponse(
+      String baseUrl, String clusterId, String partitionAssignor, State state) {
+    return GetConsumerGroupResponse.create(
+        ConsumerGroupData.builder()
+            .setMetadata(
+                Resource.Metadata.builder()
+                    .setSelf(
+                        baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups/consumer-group-1")
+                    .setResourceName(
+                        "crn:///kafka=" + clusterId + "/consumer-group=consumer-group-1")
+                    .build())
+            .setClusterId(clusterId)
+            .setConsumerGroupId("consumer-group-1")
+            .setSimple(false)
+            .setPartitionAssignor(partitionAssignor)
+            .setState(state)
+            .setCoordinator(
+                Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
+            .setConsumers(
+                Relationship.create(
+                    baseUrl
+                        + "/v3/clusters/"
+                        + clusterId
+                        + "/consumer-groups/consumer-group-1/consumers"))
+            .setLagSummary(
+                Relationship.create(
+                    baseUrl
+                        + "/v3/clusters/"
+                        + clusterId
+                        + "/consumer-groups/consumer-group-1/lag-summary"))
+            .build());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
                 <artifactId>bcprov-ext-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>$(hamcrest.version)</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
ConsumerGroupLagSummariesResourceIntegrationTest saw consumerGroupId=consumer-group-1, maxLag=3, totalLag=3 when it was expecting consumerGroupId=consumer-group-1, maxLag=6, totalLag=9

I can't reproduce locally but my best guess is that the lags just haven't been updated yet (see the issue for an explanation of the test flow), so give it another chance

listConsumerGroups_returnsConsumerGroups saw partitionAssignor=range, state=STABLE when it was expecting partitionAssignor=, state=PREPARING_REBALANCE

I would say that either is valid, so I've added in the "anyOf" matcher