### PR TITLE
KREST-4687 avro consume still fails

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -570,7 +570,10 @@ public abstract class ClusterTestHarness {
             if (result.hasOffset()) {
               sent = true;
             } else {
-              log.info("Failed to get offset back from produce {}", result);
+              log.info(
+                  "Failed to get offset back from produce for record {}.  Result is {}",
+                  rec,
+                  result);
             }
           } catch (Exception e) {
             log.info("Produce failed within testWithRetry", e);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -68,6 +68,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
@@ -565,8 +566,12 @@ public abstract class ClusterTestHarness {
           final KafkaProducer<T, T> producer = createProducer.get();
           boolean sent = false;
           try {
-            producer.send(rec).get();
-            sent = true;
+            RecordMetadata result = producer.send(rec).get();
+            if (result.hasOffset()) {
+              sent = true;
+            } else {
+              log.info("Failed to get offset back from produce {}", result);
+            }
           } catch (Exception e) {
             log.info("Produce failed within testWithRetry", e);
           }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerAvroTest.java
@@ -88,7 +88,7 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   public void testConsumeOnlyValues() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO);
+            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO, "earliest");
     produceAvroMessages(recordsOnlyValues);
     consumeMessages(
         instanceUri,
@@ -105,7 +105,7 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   public void testConsumeWithKeys() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO);
+            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO, "earliest");
     produceAvroMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -122,7 +122,7 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   public void testConsumeTimeout() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO);
+            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO, "earliest");
     produceAvroMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -143,7 +143,7 @@ public class ConsumerAvroTest extends AbstractConsumerTest {
   public void testDeleteConsumer() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO);
+            groupName, topicName, EmbeddedFormat.AVRO, Versions.KAFKA_V2_JSON_AVRO, "earliest");
     produceAvroMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
@@ -68,7 +68,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
     // so we can test that both will result in binary consumers. We also us varying accept
     // parameters to test that we default to Binary for various values.
     String instanceUri =
-        startConsumeMessages(groupName, topicName, null, Versions.KAFKA_V2_JSON_BINARY);
+        startConsumeMessages(groupName, topicName, null, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     produceBinaryMessages(recordsOnlyValues);
     consumeMessages(
         instanceUri,
@@ -85,7 +85,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   public void testConsumeWithKeys() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY);
+            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -103,7 +103,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
     // This test ensures that Accept: */* defaults to binary
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY);
+            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -120,7 +120,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   public void testConsumeTimeout() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY);
+            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -140,7 +140,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testDeleteConsumer() {
     String instanceUri =
-        startConsumeMessages(groupName, topicName, null, Versions.KAFKA_V2_JSON_BINARY);
+        startConsumeMessages(groupName, topicName, null, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     produceBinaryMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -179,12 +179,12 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
   @Test
   public void testDuplicateConsumerID() {
     String instanceUrl =
-        startConsumeMessages(groupName, topicName, null, Versions.KAFKA_V2_JSON_BINARY);
+        startConsumeMessages(groupName, topicName, null, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     produceBinaryMessages(recordsWithKeys);
 
     // Duplicate the same instance, which should cause a conflict
     String name = consumerNameFromInstanceUrl(instanceUrl);
-    Response createResponse = createConsumerInstance(groupName, null, name, null);
+    Response createResponse = createConsumerInstance(groupName, null, name, null, "earliest");
     assertErrorResponse(
         Response.Status.CONFLICT,
         createResponse,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerJsonTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerJsonTest.java
@@ -84,7 +84,7 @@ public class ConsumerJsonTest extends AbstractConsumerTest {
   public void testConsumeWithKeys() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.JSON, Versions.KAFKA_V2_JSON_JSON);
+            groupName, topicName, EmbeddedFormat.JSON, Versions.KAFKA_V2_JSON_JSON, "earliest");
     produceJsonMessages(recordsWithKeys);
     consumeMessages(
         instanceUri,
@@ -101,7 +101,7 @@ public class ConsumerJsonTest extends AbstractConsumerTest {
   public void testConsumeOnlyValues() {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.JSON, Versions.KAFKA_V2_JSON_JSON);
+            groupName, topicName, EmbeddedFormat.JSON, Versions.KAFKA_V2_JSON_JSON, "earliest");
     produceJsonMessages(recordsOnlyValues);
     consumeMessages(
         instanceUri,

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -52,7 +52,7 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
   public void testConsumerTimeout() throws InterruptedException {
     String instanceUri =
         startConsumeMessages(
-            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY);
+            groupName, topicName, EmbeddedFormat.BINARY, Versions.KAFKA_V2_JSON_BINARY, "earliest");
     // Even with identical timeouts, should be able to consume multiple times without the
     // instance timing out
     consumeForTimeout(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/SchemaProduceConsumeTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/SchemaProduceConsumeTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.validation.ConstraintViolationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -29,6 +30,8 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Tag("IntegrationTest")
 public abstract class SchemaProduceConsumeTest {
@@ -36,6 +39,8 @@ public abstract class SchemaProduceConsumeTest {
   private static final String TOPIC = "topic-1";
 
   private static final String CONSUMER_GROUP = "group-1";
+
+  private static final Logger log = LoggerFactory.getLogger(SchemaProduceConsumeTest.class);
 
   @RegisterExtension
   public final DefaultKafkaRestTestEnvironment testEnv = new DefaultKafkaRestTestEnvironment();
@@ -115,14 +120,30 @@ public abstract class SchemaProduceConsumeTest {
             getValueSchema().canonicalString(),
             null);
 
-    ProduceResponse produceResponse =
+    Response genericResponse =
         testEnv
             .kafkaRest()
             .target()
             .path(String.format("/topics/%s", TOPIC))
             .request()
-            .post(Entity.entity(produceRequest, getContentType()))
-            .readEntity(ProduceResponse.class);
+            .post(Entity.entity(produceRequest, getContentType()));
+
+    ProduceResponse produceResponse;
+    try {
+      produceResponse = genericResponse.readEntity(ProduceResponse.class);
+    } catch (ConstraintViolationException e) {
+      // Debug for jenkins only, intermittent failure where the response contains a field called
+      // error_response that isn't part of a v2 ProduceResponse (probably from a v2 ErrorResponse)
+      log.error(
+          "Can't parse produce response class: {} status: {} ",
+          genericResponse.getClass(),
+          genericResponse.getStatus());
+      log.error(
+          "Reading entity using actual class: {}",
+          genericResponse.readEntity(genericResponse.getClass()));
+      e.printStackTrace();
+      throw e;
+    }
     assertEquals(Status.OK, produceResponse.getRequestStatus());
 
     Response readRecordsResponse =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/SeekToTimestampTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v2/SeekToTimestampTest.java
@@ -42,7 +42,11 @@ public class SeekToTimestampTest extends AbstractConsumerTest {
   public void testConsumeOnlyValues() throws Exception {
     String consumerUri =
         startConsumeMessages(
-            CONSUMER_GROUP_ID, TOPIC_NAME, /* format= */ null, Versions.KAFKA_V2_JSON_BINARY);
+            CONSUMER_GROUP_ID,
+            TOPIC_NAME,
+            /* format= */ null,
+            Versions.KAFKA_V2_JSON_BINARY,
+            "latest");
 
     produceBinaryMessages(RECORDS_BEFORE_TIMESTAMP);
 

--- a/kafka-rest/src/test/resources/log4j.properties
+++ b/kafka-rest/src/test/resources/log4j.properties
@@ -6,6 +6,9 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
+log4j.logger.org.apache.kafka.clients.producer=TRACE
+log4j.logger.org.apache.kafka.clients.consumer=TRACE
+
 
 # zkclient can be verbose, during debugging it is common to adjust is separately
 log4j.logger.org.I0Itec.zkclient=ERROR

--- a/kafka-rest/src/test/resources/log4j.properties
+++ b/kafka-rest/src/test/resources/log4j.properties
@@ -6,9 +6,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
-log4j.logger.org.apache.kafka.clients.producer=TRACE
-log4j.logger.org.apache.kafka.clients.consumer=TRACE
-
 
 # zkclient can be verbose, during debugging it is common to adjust is separately
 log4j.logger.org.I0Itec.zkclient=ERROR


### PR DESCRIPTION
Looking at the logs for this intermittent failure, the consumer attempts to consume messages 4 times, over a course of 15 seconds, but only gets one record, from the second attempt.  Each GET returns a 200, the failed consumes just time out, not finding any records.

There are no logs relating to the produce (these are only written at trace level for the produce client) so it’s not possible to tell if the produces all went through - is it the produce failing or the consume that's causing the problem here?

Produce is acks=all, the consumer’s auto.offset.reset is the default, which is latest.

I’ve added in diagnostics plus some guesses at fixing the problem:

trace level logging for the produce and consume clients so we can diagnose failures more easily

logging of which offset we are getting back on the consume, so that we can see if it’s first, last or something else.  As part of this tidied up a set of nested try/catches into a while loop in consumeMessage

auto.offset.reset can now be set, and in the majority of cases is set to earliest.  This means that a new consumer group will read from the beginning, rather than there being the potential of missing some messages.  It’s not clear which is the single message being consumed, so I’ve added this in as a guess as to one reason that the other three messages are not got.  (The one case it isn’t set to earliest is the consume by timestamp test, where it is set to default).

In case it’s the produce going awry, I check that the record metadata that is returned by the produce has an offset, and try again if it doesn’t.