### PR TITLE
RCCA-5716 Cherry-pick "KREST-3537: Fix HTTP 500 errors in Produce V3. (#960)" into v0.2621.x

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
@@ -92,9 +92,13 @@ public class DefaultKafkaRestContext implements KafkaRestContext {
 
   @Override
   public SchemaRegistryClient getSchemaRegistryClient() {
+    if (!config.isSchemaRegistryEnabled()) {
+      return null;
+    }
     if (schemaRegistryClient == null) {
       SchemaRegistryConfig schemaRegistryConfig =
           new SchemaRegistryConfig(config.getSchemaRegistryConfigs());
+
       List<String> schemaRegistryUrls =
           schemaRegistryConfig.getSchemaRegistryUrls().stream()
               .map(URI::create)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
@@ -162,6 +162,29 @@ public class Errors {
         INVALID_SCHEMA_MESSAGE + schema, INVALID_SCHEMA_ERROR_CODE);
   }
 
+  public static final String INVALID_PAYLOAD_MESSAGE = "Payload error. ";
+  public static final int INVALID_PAYLOAD_ERROR_CODE = 42206;
+
+  public static RestConstraintViolationException invalidPayloadException(String cause) {
+    return new RestConstraintViolationException(
+        INVALID_PAYLOAD_MESSAGE + cause, INVALID_PAYLOAD_ERROR_CODE);
+  }
+
+  public static final String SERIALIZATION_EXCEPTION_MESSAGE = "Error serializing message. ";
+  public static final int SERIALIZATION_EXCEPTION_ERROR_CODE = 42207;
+
+  public static RestConstraintViolationException messageSerializationException(String cause) {
+    return new RestConstraintViolationException(
+        SERIALIZATION_EXCEPTION_MESSAGE + cause, SERIALIZATION_EXCEPTION_ERROR_CODE);
+  }
+
+  public static RestConstraintViolationException messageSerializationException(
+      String cause, Exception e) {
+    return new RestConstraintViolationException(
+        SERIALIZATION_EXCEPTION_MESSAGE + cause + "\n" + e.getMessage(),
+        SERIALIZATION_EXCEPTION_ERROR_CODE);
+  }
+
   public static final String ZOOKEEPER_ERROR_MESSAGE = "Zookeeper error: ";
   public static final int ZOOKEEPER_ERROR_ERROR_CODE = 50001;
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -130,7 +130,8 @@ public class KafkaRestConfig extends RestConfig {
 
   public static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
   private static final String SCHEMA_REGISTRY_URL_DOC =
-      "The base URL for the schema registry that should be used by the Avro serializer.";
+      "The base URL for the Schema Registry that should be used by the Avro serializer. "
+          + "An empty value means that use of a schema registry is disabled.";
   private static final String SCHEMA_REGISTRY_URL_DEFAULT = "http://localhost:8081";
 
   public static final String PROXY_FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
@@ -857,10 +858,11 @@ public class KafkaRestConfig extends RestConfig {
 
     if (!configs.containsKey(SCHEMA_REGISTRY_URL_CONFIG)) {
       log.warn(
-          "Using default value {} for config {}. In a future release this config won't have a"
-              + "default value anymore. If you are using Schema Registry, please, specify {}"
+          "Using default value {} for config {}. In a future release this config won't have a "
+              + "default value anymore. If you are using Schema Registry, please, specify {} "
               + "explicitly. Requests will fail in a future release if you try to use Schema "
-              + "Registry but have not specified a value for {}.",
+              + "Registry but have not specified a value for {}. An empty value for this property "
+              + "means that the Schema Registry is disabled.",
           SCHEMA_REGISTRY_URL_DEFAULT,
           SCHEMA_REGISTRY_URL_CONFIG,
           SCHEMA_REGISTRY_URL_CONFIG,
@@ -871,8 +873,8 @@ public class KafkaRestConfig extends RestConfig {
     // Disable auto-registration of schemas.
     if (configs.containsKey(AUTO_REGISTER_SCHEMAS)) {
       log.warn(
-          "Config {} is not support in REST Proxy and will be ignored. Please, remove this config. "
-              + "Configuration will fail in a future release for such cases.",
+          "Config {} is not supported in Kafka REST and will be ignored. Please remove this "
+              + "config. Configuration will fail in a future release for such cases.",
           AUTO_REGISTER_SCHEMAS);
     }
     configs.put(AUTO_REGISTER_SCHEMAS, false);
@@ -880,8 +882,8 @@ public class KafkaRestConfig extends RestConfig {
     // Disable latest-version fetching of schemas.
     if (configs.containsKey(USE_LATEST_VERSION)) {
       log.warn(
-          "Config {} is not support in REST Proxy and will be ignored. Please, remove this config. "
-              + "Configuration will fail in a future release for such cases.",
+          "Config {} is not supported in Kafka REST and will be ignored. Please remove this "
+              + "config. Configuration will fail in a future release for such cases.",
           USE_LATEST_VERSION);
     }
     configs.put(USE_LATEST_VERSION, false);
@@ -989,6 +991,10 @@ public class KafkaRestConfig extends RestConfig {
 
   public final boolean isRateLimitEnabled() {
     return getBoolean(RATE_LIMIT_ENABLE_CONFIG);
+  }
+
+  public final boolean isSchemaRegistryEnabled() {
+    return !getSchemaRegistryConfigs().get(SCHEMA_REGISTRY_URL_CONFIG).equals("");
   }
 
   public final RateLimitBackend getRateLimitBackend() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/backends/schemaregistry/SchemaRegistryModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/backends/schemaregistry/SchemaRegistryModule.java
@@ -19,9 +19,11 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafkarest.KafkaRestContext;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 
@@ -30,11 +32,12 @@ public final class SchemaRegistryModule extends AbstractBinder {
   @Override
   protected void configure() {
     bindFactory(SchemaRegistryClientFactory.class)
-        .to(SchemaRegistryClient.class)
+        .to(new TypeLiteral<Optional<SchemaRegistryClient>>() {})
         .in(RequestScoped.class);
   }
 
-  private static final class SchemaRegistryClientFactory implements Factory<SchemaRegistryClient> {
+  private static final class SchemaRegistryClientFactory
+      implements Factory<Optional<SchemaRegistryClient>> {
 
     private final Provider<KafkaRestContext> context;
 
@@ -44,11 +47,11 @@ public final class SchemaRegistryModule extends AbstractBinder {
     }
 
     @Override
-    public SchemaRegistryClient provide() {
-      return context.get().getSchemaRegistryClient();
+    public Optional<SchemaRegistryClient> provide() {
+      return Optional.ofNullable(context.get().getSchemaRegistryClient());
     }
 
     @Override
-    public void dispose(SchemaRegistryClient schemaRegistryClient) {}
+    public void dispose(Optional<SchemaRegistryClient> schemaRegistryClient) {}
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/RecordSerializerFacade.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/RecordSerializerFacade.java
@@ -28,14 +28,14 @@ import javax.inject.Provider;
 final class RecordSerializerFacade implements RecordSerializer {
 
   private final NoSchemaRecordSerializer noSchemaRecordSerializer;
-  private final Provider<SchemaRecordSerializer> schemaRecordSerializer;
+  private final Provider<SchemaRecordSerializer> schemaRecordSerializerProvider;
 
   @Inject
   RecordSerializerFacade(
       NoSchemaRecordSerializer noSchemaRecordSerializer,
-      Provider<SchemaRecordSerializer> schemaRecordSerializer) {
+      Provider<SchemaRecordSerializer> schemaRecordSerializerProvider) {
     this.noSchemaRecordSerializer = requireNonNull(noSchemaRecordSerializer);
-    this.schemaRecordSerializer = requireNonNull(schemaRecordSerializer);
+    this.schemaRecordSerializerProvider = requireNonNull(schemaRecordSerializerProvider);
   }
 
   @Override
@@ -46,7 +46,7 @@ final class RecordSerializerFacade implements RecordSerializer {
       JsonNode data,
       boolean isKey) {
     if (format.requiresSchema()) {
-      return schemaRecordSerializer.get().serialize(format, topicName, schema, data, isKey);
+      return schemaRecordSerializerProvider.get().serialize(format, topicName, schema, data, isKey);
     } else {
       return noSchemaRecordSerializer.serialize(format, data);
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaManagerImpl.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
@@ -28,16 +29,15 @@ import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.RegisteredSchema;
+import io.confluent.kafkarest.exceptions.BadRequestException;
 import java.io.IOException;
 import java.util.Optional;
-import javax.inject.Inject;
-import org.apache.kafka.common.errors.SerializationException;
+import org.apache.avro.SchemaParseException;
 
 final class SchemaManagerImpl implements SchemaManager {
   private final SchemaRegistryClient schemaRegistryClient;
   private final SubjectNameStrategy defaultSubjectNameStrategy;
 
-  @Inject
   SchemaManagerImpl(
       SchemaRegistryClient schemaRegistryClient, SubjectNameStrategy defaultSubjectNameStrategy) {
     this.schemaRegistryClient = requireNonNull(schemaRegistryClient);
@@ -55,30 +55,31 @@ final class SchemaManagerImpl implements SchemaManager {
       Optional<String> rawSchema,
       boolean isKey) {
     // (subject|subjectNameStrategy)?, schemaId
+
     if (schemaId.isPresent()) {
-      checkArgument(!format.isPresent());
-      checkArgument(!schemaVersion.isPresent());
-      checkArgument(!rawSchema.isPresent());
+      checkArgumentWrapper(!format.isPresent());
+      checkArgumentWrapper(!schemaVersion.isPresent());
+      checkArgumentWrapper(!rawSchema.isPresent());
       return getSchemaFromSchemaId(topicName, subject, subjectNameStrategy, schemaId.get(), isKey);
     }
 
     // (subject|subjectNameStrategy)?, schemaVersion
     if (schemaVersion.isPresent()) {
-      checkArgument(!format.isPresent());
-      checkArgument(!rawSchema.isPresent());
+      checkArgumentWrapper(!format.isPresent());
+      checkArgumentWrapper(!rawSchema.isPresent());
       return getSchemaFromSchemaVersion(
           topicName, subject, subjectNameStrategy, schemaVersion.get(), isKey);
     }
 
     // format, (subject|subjectNameStrategy)?, rawSchema
     if (rawSchema.isPresent()) {
-      checkArgument(format.isPresent());
+      checkArgumentWrapper(format.isPresent());
       return getSchemaFromRawSchema(
           topicName, format.get(), subject, subjectNameStrategy, rawSchema.get(), isKey);
     }
 
     // (subject|subjectNameStrategy)?
-    checkArgument(!format.isPresent());
+    checkArgumentWrapper(!format.isPresent());
     return findLatestSchema(topicName, subject, subjectNameStrategy, isKey);
   }
 
@@ -92,8 +93,8 @@ final class SchemaManagerImpl implements SchemaManager {
     try {
       schema = schemaRegistryClient.getSchemaById(schemaId);
     } catch (IOException | RestClientException e) {
-      throw new SerializationException(
-          String.format("Error when fetching schema by id. schemaId = %d", schemaId), e);
+      throw Errors.messageSerializationException(
+          String.format("Error when fetching schema by id. schemaId = %d", schemaId));
     }
 
     String actualSubject =
@@ -111,7 +112,7 @@ final class SchemaManagerImpl implements SchemaManager {
     try {
       return schemaRegistryClient.getVersion(subject, schema);
     } catch (IOException | RestClientException e) {
-      throw new SerializationException(
+      throw Errors.messageSerializationException(
           String.format(
               "Error when fetching schema version. subject = %s, schema = %s",
               subject, schema.canonicalString()),
@@ -128,20 +129,41 @@ final class SchemaManagerImpl implements SchemaManager {
     String actualSubject =
         subject.orElse(getSchemaSubjectUnsafe(topicName, isKey, subjectNameStrategy));
 
-    Schema schema =
-        schemaRegistryClient.getByVersion(
-            actualSubject, schemaVersion, /* lookupDeletedSchema= */ false);
+    Schema schema;
+    try {
+      schema =
+          schemaRegistryClient.getByVersion(
+              actualSubject, schemaVersion, /* lookupDeletedSchema= */ false);
+    } catch (RuntimeException e) {
+      throw new BadRequestException(
+          String.format(
+              "Schema does not exist for subject: %s, version: %s", actualSubject, schemaVersion),
+          e);
+    }
 
-    ParsedSchema parsedSchema =
-        EmbeddedFormat.forSchemaType(schema.getSchemaType())
-            .getSchemaProvider()
-            .parseSchema(schema.getSchema(), schema.getReferences(), /* isNew= */ false)
-            .orElseThrow(
-                () ->
-                    Errors.invalidSchemaException(
-                        String.format(
-                            "Error when fetching schema by version. subject = %s, version = %d",
-                            actualSubject, schemaVersion)));
+    SchemaProvider schemaProvider;
+    try {
+      schemaProvider = EmbeddedFormat.forSchemaType(schema.getSchemaType()).getSchemaProvider();
+    } catch (UnsupportedOperationException e) {
+      throw new BadRequestException(
+          String.format("Schema version not supported for %s", schema.getSchemaType()), e);
+    }
+
+    ParsedSchema parsedSchema;
+    try {
+      parsedSchema =
+          schemaProvider
+              .parseSchema(schema.getSchema(), schema.getReferences(), /* isNew= */ false)
+              .orElseThrow(
+                  () ->
+                      Errors.invalidSchemaException(
+                          String.format(
+                              "Error when fetching schema by version. subject = %s, version = %d",
+                              actualSubject, schemaVersion)));
+    } catch (SchemaParseException e) {
+      throw new BadRequestException(
+          String.format("Error parsing schema for %s", schema.getSchemaType()), e);
+    }
 
     return RegisteredSchema.create(
         schema.getSubject(), schema.getId(), schemaVersion, parsedSchema);
@@ -154,18 +176,35 @@ final class SchemaManagerImpl implements SchemaManager {
       Optional<SubjectNameStrategy> subjectNameStrategy,
       String rawSchema,
       boolean isKey) {
-    checkArgument(format.requiresSchema(), "%s does not support schemas.", format);
+    try {
+      checkArgument(format.requiresSchema(), "%s does not support schemas.", format);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
 
-    ParsedSchema schema =
-        format
-            .getSchemaProvider()
-            .parseSchema(rawSchema, /* references= */ emptyList(), /* isNew= */ true)
-            .orElseThrow(
-                () ->
-                    Errors.invalidSchemaException(
-                        String.format(
-                            "Error when parsing raw schema. format = %s, schema = %s",
-                            format, rawSchema)));
+    SchemaProvider schemaProvider;
+    try {
+      schemaProvider = format.getSchemaProvider();
+    } catch (UnsupportedOperationException e) {
+      throw new BadRequestException(
+          String.format("Raw schema not supported with format = %s", format), e);
+    }
+
+    ParsedSchema schema;
+    try {
+      schema =
+          schemaProvider
+              .parseSchema(rawSchema, /* references= */ emptyList(), /* isNew= */ true)
+              .orElseThrow(
+                  () ->
+                      Errors.invalidSchemaException(
+                          String.format(
+                              "Error when parsing raw schema. format = %s, schema = %s",
+                              format, rawSchema)));
+    } catch (SchemaParseException e) {
+      throw new BadRequestException(
+          String.format("Error parsing schema with format = %s", format), e);
+    }
 
     String actualSubject =
         subject.orElse(
@@ -183,7 +222,7 @@ final class SchemaManagerImpl implements SchemaManager {
         schemaId = schemaRegistryClient.register(actualSubject, schema);
       }
     } catch (IOException | RestClientException e) {
-      throw new SerializationException(
+      throw Errors.messageSerializationException(
           String.format(
               "Error when registering schema. format = %s, subject = %s, schema = %s",
               format, actualSubject, schema.canonicalString()),
@@ -207,21 +246,36 @@ final class SchemaManagerImpl implements SchemaManager {
     try {
       metadata = schemaRegistryClient.getLatestSchemaMetadata(actualSubject);
     } catch (IOException | RestClientException e) {
-      throw new SerializationException(
+      throw Errors.messageSerializationException(
           String.format("Error when fetching latest schema version. subject = %s", actualSubject),
           e);
     }
 
-    ParsedSchema schema =
-        EmbeddedFormat.forSchemaType(metadata.getSchemaType())
-            .getSchemaProvider()
-            .parseSchema(metadata.getSchema(), metadata.getReferences(), /* isNew= */ false)
-            .orElseThrow(
-                () ->
-                    Errors.invalidSchemaException(
-                        String.format(
-                            "Error when fetching latest schema version. subject = %s",
-                            actualSubject)));
+    SchemaProvider schemaProvider;
+    try {
+      schemaProvider = EmbeddedFormat.forSchemaType(metadata.getSchemaType()).getSchemaProvider();
+    } catch (UnsupportedOperationException e) {
+      throw new BadRequestException(
+          String.format(
+              "Schema subject not supported for schema type = %s", metadata.getSchemaType()),
+          e);
+    }
+
+    ParsedSchema schema;
+    try {
+      schema =
+          schemaProvider
+              .parseSchema(metadata.getSchema(), metadata.getReferences(), /* isNew= */ false)
+              .orElseThrow(
+                  () ->
+                      Errors.invalidSchemaException(
+                          String.format(
+                              "Error when fetching latest schema version. subject = %s",
+                              actualSubject)));
+    } catch (SchemaParseException e) {
+      throw new BadRequestException(
+          String.format("Error parsing schema type = %s", metadata.getSchemaType()), e);
+    }
 
     return RegisteredSchema.create(actualSubject, metadata.getId(), metadata.getVersion(), schema);
   }
@@ -263,5 +317,13 @@ final class SchemaManagerImpl implements SchemaManager {
     }
 
     return subject;
+  }
+
+  private static void checkArgumentWrapper(boolean argument) {
+    try {
+      checkArgument(argument);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("Unsupported argument: ", e.getMessage(), e);
+    }
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaManagerThrowing.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaManagerThrowing.java
@@ -15,18 +15,25 @@
 
 package io.confluent.kafkarest.controllers;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.protobuf.ByteString;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.RegisteredSchema;
 import java.util.Optional;
 
-interface SchemaRecordSerializer {
+final class SchemaManagerThrowing implements SchemaManager {
 
-  Optional<ByteString> serialize(
-      EmbeddedFormat format,
+  @Override
+  public RegisteredSchema getSchema(
       String topicName,
-      Optional<RegisteredSchema> schema,
-      JsonNode data,
-      boolean isKey);
+      Optional<EmbeddedFormat> format,
+      Optional<String> subject,
+      Optional<SubjectNameStrategy> subjectNameStrategy,
+      Optional<Integer> schemaId,
+      Optional<Integer> schemaVersion,
+      Optional<String> rawSchema,
+      boolean isKey) {
+    throw Errors.invalidPayloadException(
+        String.format("Schema Registry must be configured when using schemas."));
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaUtils;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerializer;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.confluent.kafkarest.Errors;
+import io.confluent.kafkarest.config.ConfigModule.AvroSerializerConfigs;
+import io.confluent.kafkarest.config.ConfigModule.JsonschemaSerializerConfigs;
+import io.confluent.kafkarest.config.ConfigModule.ProtobufSerializerConfigs;
+import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.kafkarest.entities.RegisteredSchema;
+import io.confluent.kafkarest.exceptions.BadRequestException;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.avro.AvroTypeException;
+import org.everit.json.schema.ValidationException;
+
+final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
+
+  private final AvroSerializer avroSerializer;
+  private final JsonSchemaSerializer jsonschemaSerializer;
+  private final ProtobufSerializer protobufSerializer;
+
+  SchemaRecordSerializerImpl(
+      SchemaRegistryClient schemaRegistryClient,
+      @AvroSerializerConfigs Map<String, Object> avroSerializerConfigs,
+      @JsonschemaSerializerConfigs Map<String, Object> jsonschemaSerializerConfigs,
+      @ProtobufSerializerConfigs Map<String, Object> protobufSerializerConfigs) {
+    requireNonNull(schemaRegistryClient);
+    avroSerializer = new AvroSerializer(schemaRegistryClient, avroSerializerConfigs);
+    jsonschemaSerializer =
+        new JsonSchemaSerializer(schemaRegistryClient, jsonschemaSerializerConfigs);
+    protobufSerializer = new ProtobufSerializer(schemaRegistryClient, protobufSerializerConfigs);
+  }
+
+  @Override
+  public Optional<ByteString> serialize(
+      EmbeddedFormat format,
+      String topicName,
+      Optional<RegisteredSchema> schema,
+      JsonNode data,
+      boolean isKey) {
+    checkArgument(format.requiresSchema());
+    if (data.isNull()) {
+      return Optional.empty();
+    }
+    if (!schema.isPresent()) {
+      throw isKey ? Errors.keySchemaMissingException() : Errors.valueSchemaMissingException();
+    }
+
+    switch (format) {
+      case AVRO:
+        return Optional.of(serializeAvro(schema.get().getSubject(), schema.get(), data));
+
+      case JSONSCHEMA:
+        return Optional.of(serializeJsonschema(schema.get().getSubject(), schema.get(), data));
+
+      case PROTOBUF:
+        return Optional.of(
+            serializeProtobuf(schema.get().getSubject(), topicName, schema.get(), data, isKey));
+
+      default:
+        throw new AssertionError(String.format("Unexpected enum constant: %s", format));
+    }
+  }
+
+  private ByteString serializeAvro(String subject, RegisteredSchema schema, JsonNode data) {
+    AvroSchema avroSchema = (AvroSchema) schema.getSchema();
+    Object record;
+    try {
+      record = AvroSchemaUtils.toObject(data, avroSchema);
+    } catch (AvroTypeException | IOException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+    return ByteString.copyFrom(avroSerializer.serialize(subject, avroSchema, record));
+  }
+
+  private ByteString serializeJsonschema(String subject, RegisteredSchema schema, JsonNode data) {
+    JsonSchema jsonSchema = (JsonSchema) schema.getSchema();
+    Object record;
+    try {
+      record = JsonSchemaUtils.toObject(data, jsonSchema);
+    } catch (IOException | ValidationException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+    return ByteString.copyFrom(jsonschemaSerializer.serialize(subject, jsonSchema, record));
+  }
+
+  private ByteString serializeProtobuf(
+      String subject, String topicName, RegisteredSchema schema, JsonNode data, boolean isKey) {
+    ProtobufSchema protobufSchema = (ProtobufSchema) schema.getSchema();
+    Message record;
+    try {
+      record = (Message) ProtobufSchemaUtils.toObject(data, protobufSchema);
+    } catch (IOException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+    return ByteString.copyFrom(
+        protobufSerializer.serialize(subject, topicName, protobufSchema, record, isKey));
+  }
+
+  private static final class AvroSerializer extends AbstractKafkaAvroSerializer {
+
+    private AvroSerializer(SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
+      this.schemaRegistry = requireNonNull(schemaRegistryClient);
+      configure(serializerConfig(configs));
+    }
+
+    private byte[] serialize(String subject, AvroSchema schema, Object data) {
+      return serializeImpl(subject, data, schema);
+    }
+  }
+
+  private static final class JsonSchemaSerializer
+      extends AbstractKafkaJsonSchemaSerializer<Object> {
+
+    private JsonSchemaSerializer(
+        SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
+      this.schemaRegistry = requireNonNull(schemaRegistryClient);
+      configure(serializerConfig(configs));
+    }
+
+    private byte[] serialize(String subject, JsonSchema schema, Object data) {
+      return serializeImpl(subject, JsonSchemaUtils.getValue(data), schema);
+    }
+  }
+
+  private static final class ProtobufSerializer extends KafkaProtobufSerializer<Message> {
+
+    private ProtobufSerializer(
+        SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
+      this.schemaRegistry = requireNonNull(schemaRegistryClient);
+      configure(serializerConfig(configs));
+    }
+
+    private byte[] serialize(
+        String subject, String topicName, ProtobufSchema schema, Message data, boolean isKey) {
+      return serializeImpl(subject, topicName, isKey, data, schema);
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerThrowing.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerThrowing.java
@@ -17,16 +17,22 @@ package io.confluent.kafkarest.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.ByteString;
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.RegisteredSchema;
 import java.util.Optional;
 
-interface SchemaRecordSerializer {
+final class SchemaRecordSerializerThrowing implements SchemaRecordSerializer {
 
-  Optional<ByteString> serialize(
+  @Override
+  public Optional<ByteString> serialize(
       EmbeddedFormat format,
       String topicName,
       Optional<RegisteredSchema> schema,
       JsonNode data,
-      boolean isKey);
+      boolean isKey) {
+    throw Errors.messageSerializationException(
+        "Schema Registry not defined, no Schema "
+            + "Registry client available to serialize message.");
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RestConstraintViolationExceptionMapper.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/RestConstraintViolationExceptionMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.exceptions;
+
+import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public final class RestConstraintViolationExceptionMapper
+    implements ExceptionMapper<RestConstraintViolationException> {
+
+  @Override
+  public Response toResponse(RestConstraintViolationException exception) {
+    return Response.status(exception.getStatus())
+        .entity(
+            ErrorResponse.create(
+                exception.getStatus(),
+                String.format("Error: %s : %s", exception.getErrorCode(), exception.getMessage())))
+        .build();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -21,16 +21,20 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import com.fasterxml.jackson.jaxrs.base.JsonMappingExceptionMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafkarest.common.CompletableFutures;
+import io.confluent.kafkarest.exceptions.BadRequestException;
+import io.confluent.kafkarest.exceptions.RestConstraintViolationExceptionMapper;
 import io.confluent.kafkarest.exceptions.StatusCodeException;
 import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
 import io.confluent.kafkarest.exceptions.v3.V3ExceptionMapper;
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
 import java.io.IOException;
 import java.util.List;
@@ -80,6 +84,11 @@ public abstract class StreamingResponse<T> {
               response -> ((ErrorResponse) response.getEntity()).getErrorCode(),
               response -> ((ErrorResponse) response.getEntity()).getMessage())
           .putMapper(
+              RestConstraintViolationException.class,
+              new RestConstraintViolationExceptionMapper(),
+              response -> ((ErrorResponse) response.getEntity()).getErrorCode(),
+              response -> ((ErrorResponse) response.getEntity()).getMessage())
+          .putMapper(
               WebApplicationException.class,
               new WebApplicationExceptionMapper(/* restConfig= */ null),
               response -> ((ErrorMessage) response.getEntity()).getErrorCode(),
@@ -116,11 +125,19 @@ public abstract class StreamingResponse<T> {
     log.debug("Resuming StreamingResponse");
     AsyncResponseQueue responseQueue = new AsyncResponseQueue(chunkedOutputFactory);
     responseQueue.asyncResume(asyncResponse);
-    while (hasNext() && !responseQueue.isClosed()) {
-      responseQueue.push(next().handle(this::handleNext));
+    try {
+      while (hasNext() && !responseQueue.isClosed()) {
+        responseQueue.push(next().handle(this::handleNext));
+      }
+    } catch (Exception e) {
+      log.debug("Exception thrown when processing stream ", e);
+      responseQueue.push(
+          CompletableFuture.completedFuture(
+              ResultOrError.error(EXCEPTION_MAPPER.toErrorResponse(e))));
+    } finally {
+      close();
+      responseQueue.close();
     }
-    close();
-    responseQueue.close();
   }
 
   private ResultOrError handleNext(T result, @Nullable Throwable error) {
@@ -158,7 +175,16 @@ public abstract class StreamingResponse<T> {
 
     @Override
     public boolean hasNext() {
-      return mappingIteratorInput.hasNext();
+      try {
+        return mappingIteratorInput.hasNext();
+      } catch (RuntimeJsonMappingException jme) {
+        // jersey returns a 400 in both these cases first, so we should match this
+        throw new BadRequestException(
+            String.format("Error processing JSON: %s", jme.getMessage()), jme);
+      } catch (RuntimeException re) {
+        throw new BadRequestException(
+            String.format("Error processing message: %s", re.getMessage()), re);
+      }
     }
 
     @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/SchemaManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/SchemaManagerImplTest.java
@@ -15,13 +15,24 @@
 
 package io.confluent.kafkarest.controllers;
 
+import static java.util.Collections.emptyList;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
@@ -29,12 +40,14 @@ import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.RegisteredSchema;
+import io.confluent.kafkarest.exceptions.BadRequestException;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.kafka.common.errors.SerializationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +56,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class SchemaManagerImplTest {
+
   private static final String TOPIC_NAME = "topic-1";
   private static final String KEY_SUBJECT = "topic-1-key";
   private static final String VALUE_SUBJECT = "topic-1-value";
@@ -383,18 +397,23 @@ public class SchemaManagerImplTest {
 
   @Test
   public void getSchema_avro_schemaId_nonExistingSchemaId() {
-    assertThrows(
-        SerializationException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.empty(),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.empty(),
-                /* schemaId= */ Optional.of(1000),
-                /* schemaVersion= */ Optional.empty(),
-                /* rawSchema= */ Optional.empty(),
-                /* isKey= */ true));
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.of(1000),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Error serializing message. Error when fetching schema by id. schemaId = 1000",
+        rcve.getMessage());
+    assertEquals(42207, rcve.getErrorCode());
   }
 
   @Test
@@ -402,82 +421,109 @@ public class SchemaManagerImplTest {
     ParsedSchema schema = new AvroSchema("{\"type\": \"int\"}");
     int schemaId = schemaRegistryClient.register("foobar", schema);
 
-    assertThrows(
-        SerializationException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.empty(),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.empty(),
-                /* schemaId= */ Optional.of(schemaId),
-                /* schemaVersion= */ Optional.empty(),
-                /* rawSchema= */ Optional.empty(),
-                /* isKey= */ true));
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.of(schemaId),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Error serializing message. Error when fetching schema version. subject = topic-1-key, schema = \"int\"\n"
+            + "Subject Not Found; error code: 40401",
+        rcve.getMessage());
+    assertEquals(42207, rcve.getErrorCode());
   }
 
   @Test
   public void getSchema_avro_rawSchema_invalidSchema() {
-    assertThrows(
-        RestConstraintViolationException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.of(EmbeddedFormat.AVRO),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.empty(),
-                /* schemaId= */ Optional.empty(),
-                /* schemaVersion= */ Optional.empty(),
-                /* rawSchema= */ Optional.of("foobar"),
-                /* isKey= */ true));
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(EmbeddedFormat.AVRO),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of("foobar"),
+                    /* isKey= */ true));
+    assertEquals(
+        "Invalid schema: Error when parsing raw schema. format = AVRO, schema = foobar",
+        rcve.getMessage());
+    assertEquals(42205, rcve.getErrorCode());
   }
 
   @Test
   public void getSchema_jsonschema_rawSchema_invalidSchema() {
-    assertThrows(
-        RestConstraintViolationException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.of(EmbeddedFormat.JSONSCHEMA),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.empty(),
-                /* schemaId= */ Optional.empty(),
-                /* schemaVersion= */ Optional.empty(),
-                /* rawSchema= */ Optional.of("foobar"),
-                /* isKey= */ true));
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(EmbeddedFormat.JSONSCHEMA),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of("foobar"),
+                    /* isKey= */ true));
+    assertEquals(
+        "Invalid schema: Error when parsing raw schema. format = JSONSCHEMA, schema = foobar",
+        rcve.getMessage());
+    assertEquals(42205, rcve.getErrorCode());
   }
 
   @Test
   public void getSchema_protobuf_rawSchema_invalidSchema() {
-    assertThrows(
-        RestConstraintViolationException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.of(EmbeddedFormat.PROTOBUF),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.empty(),
-                /* schemaId= */ Optional.empty(),
-                /* schemaVersion= */ Optional.empty(),
-                /* rawSchema= */ Optional.of("foobar"),
-                /* isKey= */ true));
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(EmbeddedFormat.PROTOBUF),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of("foobar"),
+                    /* isKey= */ true));
+    assertEquals(
+        "Invalid schema: Error when parsing raw schema. format = PROTOBUF, schema = foobar",
+        rcve.getMessage());
+    assertEquals(42205, rcve.getErrorCode());
   }
 
   @Test
   public void getSchema_avro_latestSchema_noSchema() {
-    assertThrows(
-        SerializationException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.empty(),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.empty(),
-                /* schemaId= */ Optional.empty(),
-                /* schemaVersion= */ Optional.empty(),
-                /* rawSchema= */ Optional.empty(),
-                /* isKey= */ true));
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Error serializing message. Error when fetching latest schema version. subject = topic-1-key\n"
+            + "Subject Not Found; error code: 40401",
+        rcve.getMessage());
+    assertEquals(42207, rcve.getErrorCode());
   }
 
   @Test
@@ -489,18 +535,21 @@ public class SchemaManagerImplTest {
     schemaRegistryClient.register(subject, schema);
     int schemaVersion = schemaRegistryClient.getVersion(subject, schema);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.empty(),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.of(strategy),
-                /* schemaId= */ Optional.empty(),
-                /* schemaVersion= */ Optional.of(schemaVersion),
-                /* rawSchema= */ Optional.empty(),
-                /* isKey= */ true));
+    BadRequestException bre =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.of(strategy),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.of(schemaVersion),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals("Schema does not exist for subject: my-subject-, version: 1", bre.getMessage());
+    assertEquals(400, bre.getCode());
   }
 
   @Test
@@ -508,18 +557,374 @@ public class SchemaManagerImplTest {
     SubjectNameStrategy strategy = new NullReturningSubjectNameStrategy();
     strategy.subjectName(TOPIC_NAME, /* isKey= */ true, /* schema= */ null);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            schemaManager.getSchema(
-                TOPIC_NAME,
-                /* format= */ Optional.empty(),
-                /* subject= */ Optional.empty(),
-                /* subjectNameStrategy= */ Optional.of(strategy),
-                /* schemaId= */ Optional.empty(),
-                /* schemaVersion= */ Optional.of(100),
-                /* rawSchema= */ Optional.empty(),
-                /* isKey= */ true));
+    IllegalArgumentException rcve =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.of(strategy),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.of(100),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertTrue(
+        rcve.getMessage()
+            .startsWith(
+                "Cannot use schema_subject_strategy=io.confluent.kafkarest.controllers.SchemaManagerImplTest$NullReturningSubjectNameStrategy@"));
+    assertTrue(rcve.getMessage().endsWith(" without schema_id or schema."));
+  }
+
+  @Test
+  public void schemaRegistryDisabledReturnsError() {
+    SchemaManager mySchemaManager = new SchemaManagerThrowing();
+
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Payload error. Schema Registry must be configured when using schemas.", e.getMessage());
+    assertEquals(42206, e.getErrorCode());
+  }
+
+  @Test
+  public void rawSchemaWithUnsupportedSchemaVersionThrowsException() {
+    BadRequestException iae =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.of(0),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals("Schema does not exist for subject: topic-1-key, version: 0", iae.getMessage());
+    assertEquals(400, iae.getCode());
+  }
+
+  @Test
+  public void getSchemaFromSchemaVersionThrowsInvalidSchemaException() {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    Schema schemaMock = mock(Schema.class);
+
+    expect(schemaRegistryClientMock.getByVersion("subject1", 0, false)).andReturn(schemaMock);
+    expect(schemaMock.getSchemaType()).andReturn(EmbeddedFormat.AVRO.toString());
+    expect(schemaMock.getSchema()).andReturn(null);
+    expect(schemaMock.getReferences()).andReturn(Collections.emptyList());
+
+    replay(schemaRegistryClientMock, schemaMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    RestConstraintViolationException iae =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.of("subject1"),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.of(0),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Invalid schema: Error when fetching schema by version. subject = subject1, version = 0",
+        iae.getMessage());
+    assertEquals(42205, iae.getErrorCode());
+  }
+
+  @Test
+  public void getSchemaFromSchemaVersionThrowsInvalidBadRequestException() {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    Schema schemaMock = mock(Schema.class);
+
+    expect(schemaRegistryClientMock.getByVersion("subject1", 0, false)).andReturn(schemaMock);
+    expect(schemaMock.getSchemaType())
+        .andThrow(new UnsupportedOperationException("exception message"));
+    expect(schemaMock.getSchemaType()).andReturn("JSON");
+
+    replay(schemaRegistryClientMock, schemaMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    BadRequestException iae =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.of("subject1"),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.of(0),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals("Schema version not supported for JSON", iae.getMessage());
+    assertEquals(400, iae.getCode());
+  }
+
+  @Test
+  public void errorFetchingSchemaBySchemaVersion() {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    Schema schemaMock = mock(Schema.class);
+
+    expect(schemaRegistryClientMock.getByVersion("subject1", 123, false)).andReturn(schemaMock);
+    expect(schemaMock.getSchemaType()).andReturn(EmbeddedFormat.JSON.toString());
+    expect(schemaMock.getSchema()).andReturn(null);
+    expect(schemaMock.getReferences()).andReturn(Collections.emptyList());
+    replay(schemaRegistryClientMock, schemaMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    RestConstraintViolationException iae =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.of("subject1"),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.of(123),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Invalid schema: Error when fetching schema by version. subject = subject1, version = 123",
+        iae.getMessage());
+    assertEquals(42205, iae.getErrorCode());
+  }
+
+  @Test
+  public void errorRawSchemaNotSupportedWithFormat() {
+
+    BadRequestException iae =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(EmbeddedFormat.JSON),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of("rawSchema"),
+                    /* isKey= */ true));
+    assertEquals("JSON does not support schemas.", iae.getMessage());
+  }
+
+  @Test
+  public void errorRawSchemaCantParseSchema() {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    EmbeddedFormat embeddedFormatMock = mock(EmbeddedFormat.class);
+    SchemaProvider schemaProviderMock = mock(SchemaProvider.class);
+
+    expect(embeddedFormatMock.requiresSchema()).andReturn(true);
+    expect(embeddedFormatMock.getSchemaProvider())
+        .andThrow(new UnsupportedOperationException("Unsupported"));
+
+    replay(embeddedFormatMock, schemaProviderMock, schemaRegistryClientMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    BadRequestException rcve =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(embeddedFormatMock),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of(TextNode.valueOf("rawSchema").toString()),
+                    /* isKey= */ true));
+    assertEquals(
+        "Raw schema not supported with format = EasyMock for class io.confluent.kafkarest.entities.EmbeddedFormat",
+        rcve.getMessage());
+    assertEquals(400, rcve.getCode());
+  }
+
+  @Test
+  public void errorRawSchemaNotSupportedWithSchema() {
+
+    EmbeddedFormat embeddedFormatMock = mock(EmbeddedFormat.class);
+    SchemaProvider schemaProviderMock = mock(SchemaProvider.class);
+
+    expect(embeddedFormatMock.requiresSchema()).andReturn(true);
+    expect(embeddedFormatMock.getSchemaProvider())
+        .andThrow(new UnsupportedOperationException("Reason here"));
+    expect(
+            schemaProviderMock.parseSchema(
+                TextNode.valueOf("rawSchema").toString(), emptyList(), true))
+        .andReturn(Optional.empty());
+
+    replay(embeddedFormatMock, schemaProviderMock);
+
+    BadRequestException bre =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                schemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(embeddedFormatMock),
+                    /* subject= */ Optional.empty(),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of(TextNode.valueOf("rawSchema").toString()),
+                    /* isKey= */ true));
+    assertEquals(
+        "Raw schema not supported with format = EasyMock for class io.confluent.kafkarest.entities.EmbeddedFormat",
+        bre.getMessage());
+    assertEquals(400, bre.getCode());
+  }
+
+  @Test
+  public void errorRegisteringSchema() throws RestClientException, IOException {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    ParsedSchema parsedSchemaMock = mock(ParsedSchema.class);
+    EmbeddedFormat embeddedFormatMock = mock(EmbeddedFormat.class);
+    SchemaProvider schemaProviderMock = mock(SchemaProvider.class);
+
+    expect(embeddedFormatMock.requiresSchema()).andReturn(true);
+    expect(embeddedFormatMock.getSchemaProvider()).andReturn(schemaProviderMock);
+    expect(
+            schemaProviderMock.parseSchema(
+                TextNode.valueOf("rawString").toString(), emptyList(), true))
+        .andReturn(Optional.of(parsedSchemaMock));
+    expect(schemaRegistryClientMock.getId("subject1", parsedSchemaMock))
+        .andThrow(new IOException("Can't get Schema"));
+    expect(schemaRegistryClientMock.register("subject1", parsedSchemaMock))
+        .andThrow(new IOException("Can't register Schema"));
+
+    replay(schemaRegistryClientMock, embeddedFormatMock, schemaProviderMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.of(embeddedFormatMock),
+                    /* subject= */ Optional.of("subject1"),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.of(TextNode.valueOf("rawString").toString()),
+                    /* isKey= */ true));
+    assertEquals(
+        "Error serializing message. Error when registering schema. format = EasyMock for class io.confluent.kafkarest.entities.EmbeddedFormat, subject = subject1, schema = null\n"
+            + "Can't register Schema",
+        rcve.getMessage());
+    assertEquals(42207, rcve.getErrorCode());
+  }
+
+  @Test
+  public void errorFetchingLatestSchemaBySchemaVersionInvalidSchema()
+      throws RestClientException, IOException {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    SchemaMetadata schemaMetadataMock = mock(SchemaMetadata.class);
+
+    expect(schemaRegistryClientMock.getLatestSchemaMetadata("subject1"))
+        .andReturn(schemaMetadataMock);
+    expect(schemaMetadataMock.getSchemaType()).andReturn(EmbeddedFormat.AVRO.name());
+    expect(schemaMetadataMock.getSchema()).andReturn(TextNode.valueOf("schema").toString());
+    expect(schemaMetadataMock.getReferences()).andReturn(emptyList());
+    replay(schemaRegistryClientMock, schemaMetadataMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.of("subject1"),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals(
+        "Invalid schema: Error when fetching latest schema version. subject = subject1",
+        rcve.getMessage());
+    assertEquals(42205, rcve.getErrorCode());
+  }
+
+  @Test
+  public void errorFetchingLatestSchemaBySchemaVersionBadRequest()
+      throws RestClientException, IOException {
+
+    SchemaRegistryClient schemaRegistryClientMock = mock(SchemaRegistryClient.class);
+    SchemaMetadata schemaMetadataMock = mock(SchemaMetadata.class);
+
+    expect(schemaRegistryClientMock.getLatestSchemaMetadata("subject1"))
+        .andReturn(schemaMetadataMock);
+    expect(schemaMetadataMock.getSchemaType())
+        .andThrow(
+            new UnsupportedOperationException(
+                "testing exception")); // this is faking the UnsupportedOperationException but I
+    // can't see another way to do this.
+    expect(schemaMetadataMock.getSchemaType()).andReturn("schemaType");
+
+    replay(schemaRegistryClientMock, schemaMetadataMock);
+
+    SchemaManager mySchemaManager =
+        new SchemaManagerImpl(schemaRegistryClientMock, new TopicNameStrategy());
+
+    BadRequestException bre =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                mySchemaManager.getSchema(
+                    TOPIC_NAME,
+                    /* format= */ Optional.empty(),
+                    /* subject= */ Optional.of("subject1"),
+                    /* subjectNameStrategy= */ Optional.empty(),
+                    /* schemaId= */ Optional.empty(),
+                    /* schemaVersion= */ Optional.empty(),
+                    /* rawSchema= */ Optional.empty(),
+                    /* isKey= */ true));
+    assertEquals("Schema subject not supported for schema type = schemaType", bre.getMessage());
+    assertEquals(400, bre.getCode());
   }
 
   private static final class MySubjectNameStrategy implements SubjectNameStrategy {
@@ -537,7 +942,11 @@ public class SchemaManagerImplTest {
 
     @Override
     public String subjectName(String topicName, boolean isKey, ParsedSchema schema) {
-      return "my-subject-" + schema.toString();
+      if (schema != null) {
+        return "my-subject-" + schema.toString();
+      } else {
+        return "my-subject-";
+      }
     }
 
     @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.confluent.kafkarest.entities.EmbeddedFormat;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SchemaRecordSerializerTest {
+
+  @Test
+  public void errorWhenNoSchemaRegistryDefined() {
+    SchemaRecordSerializer schemaRecordSerializer = new SchemaRecordSerializerThrowing();
+    RestConstraintViolationException rcve =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                schemaRecordSerializer.serialize(
+                    EmbeddedFormat.AVRO, "topic", Optional.empty(), null, true));
+
+    assertEquals(42207, rcve.getErrorCode());
+    assertEquals(
+        "Error serializing message. Schema Registry not defined, no Schema Registry client available to serialize message.",
+        rcve.getMessage());
+  }
+}


### PR DESCRIPTION
This cherry-picks the changes addressing various HTTP 500 errors in Kafka REST, including correctly closing resources and the response sink if an unmapped exception happens during Jackson record iteration.

These changes address the resource leakage causing [RCCA-5716](https://confluentinc.atlassian.net/browse/RCCA-5716).

The only conflict during the cherry-picking was a fairly trivial one related to imports.
The cherry-pick has been tested locally by ensuring that producing the following malformed record:
```
{
    value":
    {
        "type": "JSON",
        "data": "A"
    }
}
```
- throws HTTP 500 and leaks a connection and Kafka network thread before the cherry-pick
- throws HTTP 400 and doesn't leak after the cherry-pick

P.S. While the commit and the old PR say [KREST-3537](https://confluentinc.atlassian.net/browse/KREST-3537), this is actually related to [KREST-3637](https://confluentinc.atlassian.net/browse/KREST-3637).