### PR TITLE
Add a Fake Kafka/SR test environment.

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -153,11 +153,6 @@
            <artifactId>bcprov-ext-jdk15on</artifactId>
            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -46,12 +46,13 @@ import io.confluent.kafkarest.entities.v3.ProduceRequest.ProduceRequestData;
 import io.confluent.kafkarest.entities.v3.ProduceRequest.ProduceRequestHeader;
 import io.confluent.kafkarest.entities.v3.ProduceResponse;
 import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
-import io.confluent.kafkarest.testing.DefaultKafkaRestTestEnvironment;
-import io.confluent.kafkarest.testing.SchemaRegistryFixture.SchemaKey;
+import io.confluent.kafkarest.testing.AbstractSchemaRegistry.SchemaKey;
+import io.confluent.kafkarest.testing.fake.FakeKafkaRestTestEnvironment;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
@@ -64,14 +65,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-// TODO ddimitrov This continues being way too flaky.
-//  Until we fix it (KREST-1542), we should ignore it, as it might be hiding even worse errors.
-@Disabled
 @Tag("IntegrationTest")
 public class ProduceActionIntegrationTest {
 
@@ -80,15 +77,15 @@ public class ProduceActionIntegrationTest {
   private static final String DEFAULT_VALUE_SUBJECT = "topic-1-value";
 
   @RegisterExtension
-  public final DefaultKafkaRestTestEnvironment testEnv = new DefaultKafkaRestTestEnvironment();
+  public final FakeKafkaRestTestEnvironment testEnv = new FakeKafkaRestTestEnvironment();
 
   @BeforeEach
   public void setUp() throws Exception {
-    testEnv.kafkaCluster().createTopic(TOPIC_NAME, 3, (short) 1);
+    testEnv.kafkaCluster().createTopic(TOPIC_NAME, Optional.empty(), Optional.empty());
   }
 
   @Test
-  public void produceBinary() throws Exception {
+  public void produceBinary() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ByteString key = ByteString.copyFromUtf8("foo");
     ByteString value = ByteString.copyFromUtf8("bar");
@@ -132,7 +129,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithNullData() throws Exception {
+  public void produceBinaryWithNullData() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -174,7 +171,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithInvalidData_throwsBadRequest() throws Exception {
+  public void produceBinaryWithInvalidData_throwsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -206,7 +203,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJson() throws Exception {
+  public void produceJson() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String key = "foo";
     String value = "bar";
@@ -252,7 +249,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJsonWithNullData() throws Exception {
+  public void produceJsonWithNullData() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -296,7 +293,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchema() throws Exception {
+  public void produceAvroWithRawSchema() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String key = "foo";
     String value = "bar";
@@ -342,7 +339,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchemaAndNullData_throwsBadRequest() throws Exception {
+  public void produceAvroWithRawSchemaAndNullData_throwsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -386,7 +383,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchemaAndInvalidData() throws Exception {
+  public void produceAvroWithRawSchemaAndInvalidData() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -566,7 +563,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchemaAndSubject() throws Exception {
+  public void produceAvroWithRawSchemaAndSubject() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String key = "foo";
     String value = "bar";
@@ -772,7 +769,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchemaAndSubjectStrategy() throws Exception {
+  public void produceAvroWithRawSchemaAndSubjectStrategy() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String keyRawSchema =
         "{\"type\": \"record\", \"name\": \"MyKey\", \"fields\": [{\"name\": \"foo\", \"type\": "
@@ -1029,7 +1026,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJsonschemaWithRawSchema() throws Exception {
+  public void produceJsonschemaWithRawSchema() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     TextNode key = TextNode.valueOf("foo");
     TextNode value = TextNode.valueOf("bar");
@@ -1075,7 +1072,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJsonschemaWithRawSchemaAndNullData() throws Exception {
+  public void produceJsonschemaWithRawSchemaAndNullData() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -1119,7 +1116,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJsonschemaWithRawSchemaAndInvalidData_throwsBadRequest() throws Exception {
+  public void produceJsonschemaWithRawSchemaAndInvalidData_throwsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request =
         ProduceRequest.builder()
@@ -1299,7 +1296,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJsonschemaWithRawSchemaAndSubject() throws Exception {
+  public void produceJsonschemaWithRawSchemaAndSubject() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     TextNode key = TextNode.valueOf("foo");
     TextNode value = TextNode.valueOf("bar");
@@ -1498,7 +1495,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceJsonschemaWithRawSchemaAndSubjectStrategy() throws Exception {
+  public void produceJsonschemaWithRawSchemaAndSubjectStrategy() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String keyRawSchema =
         "{\"type\": \"object\", \"title\": \"MyKey\", \"properties\": {\"foo\": "
@@ -1738,7 +1735,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceProtobufWithRawSchema() throws Exception {
+  public void produceProtobufWithRawSchema() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProtobufSchema keySchema =
         new ProtobufSchema("syntax = \"proto3\"; message MyKey { string foo = 1; }");
@@ -1794,7 +1791,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceProtobufWithRawSchemaAndNullData() throws Exception {
+  public void produceProtobufWithRawSchemaAndNullData() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProtobufSchema keySchema =
         new ProtobufSchema("syntax = \"proto3\"; message MyKey { string foo = 1; }");
@@ -1842,7 +1839,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceProtobufWithRawSchemaAndInvalidData_throwsBadRequest() throws Exception {
+  public void produceProtobufWithRawSchemaAndInvalidData_throwsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProtobufSchema keySchema =
         new ProtobufSchema("syntax = \"proto3\"; message MyKey { string foo = 1; }");
@@ -2042,7 +2039,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceProtobufWithRawSchemaAndSubject() throws Exception {
+  public void produceProtobufWithRawSchemaAndSubject() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProtobufSchema keySchema =
         new ProtobufSchema("syntax = \"proto3\"; message MyKey { string foo = 1; }");
@@ -2270,7 +2267,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceProtobufWithRawSchemaAndSubjectStrategy() throws Exception {
+  public void produceProtobufWithRawSchemaAndSubjectStrategy() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProtobufSchema keySchema =
         new ProtobufSchema("syntax = \"proto3\"; message MyKey { string foo = 1; }");
@@ -2390,7 +2387,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithPartitionId() throws Exception {
+  public void produceBinaryWithPartitionId() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     int partitionId = 1;
     ByteString key = ByteString.copyFromUtf8("foo");
@@ -2436,7 +2433,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithTimestamp() throws Exception {
+  public void produceBinaryWithTimestamp() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     Instant timestamp = Instant.ofEpochMilli(1000);
     ByteString key = ByteString.copyFromUtf8("foo");
@@ -2483,7 +2480,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithHeaders() throws Exception {
+  public void produceBinaryWithHeaders() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ByteString key = ByteString.copyFromUtf8("foo");
     ByteString value = ByteString.copyFromUtf8("bar");
@@ -2541,7 +2538,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryAndAvro() throws Exception {
+  public void produceBinaryAndAvro() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ByteString key = ByteString.copyFromUtf8("foo");
     String value = "bar";
@@ -2586,7 +2583,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryKeyOnly() throws Exception {
+  public void produceBinaryKeyOnly() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ByteString key = ByteString.copyFromUtf8("foo");
     ProduceRequest request =
@@ -2624,7 +2621,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryValueOnly() throws Exception {
+  public void produceBinaryValueOnly() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ByteString value = ByteString.copyFromUtf8("bar");
     ProduceRequest request =
@@ -2662,7 +2659,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceNothing() throws Exception {
+  public void produceNothing() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     ProduceRequest request = ProduceRequest.builder().setOriginalSize(0L).build();
 
@@ -2804,7 +2801,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithSchemaSubject_returnsBadRequest() throws Exception {
+  public void produceBinaryWithSchemaSubject_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"BINARY\", \"subject\": \"foobar\" } }";
 
@@ -2823,7 +2820,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithSchemaSubjectStrategy_returnsBadRequest() throws Exception {
+  public void produceBinaryWithSchemaSubjectStrategy_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"BINARY\", \"subject_name_strategy\": \"TOPIC\" } }";
 
@@ -2842,7 +2839,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithRawSchema_returnsBadRequest() throws Exception {
+  public void produceBinaryWithRawSchema_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request =
         "{ \"key\": { \"type\": \"BINARY\", \"schema\": \"{ \\\"type\\\": \\\"string\\\" }\" } }";
@@ -2862,7 +2859,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithSchemaId_returnsBadRequest() throws Exception {
+  public void produceBinaryWithSchemaId_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"BINARY\", \"schema_id\": 1 } }";
 
@@ -2881,7 +2878,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceBinaryWithSchemaVersion_returnsBadRequest() throws Exception {
+  public void produceBinaryWithSchemaVersion_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"BINARY\", \"schema_version\": 1 } }";
 
@@ -2900,7 +2897,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithTypeAndSchemaVersion_returnsBadRequest() throws Exception {
+  public void produceAvroWithTypeAndSchemaVersion_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"AVRO\", \"schema_version\": 1 } }";
 
@@ -2919,7 +2916,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithTypeAndSchemaId_returnsBadRequest() throws Exception {
+  public void produceAvroWithTypeAndSchemaId_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"AVRO\", \"schema_id\": 1 } }";
 
@@ -2938,7 +2935,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithTypeAndLatestSchema_returnsBadRequest() throws Exception {
+  public void produceAvroWithTypeAndLatestSchema_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"type\": \"AVRO\" } }";
 
@@ -2957,8 +2954,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithSchemaSubjectAndSchemaSubjectStrategy_returnsBadRequest()
-      throws Exception {
+  public void produceAvroWithSchemaSubjectAndSchemaSubjectStrategy_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request =
         "{ \"key\": { \"subject\": \"foobar\", \"subject_name_strategy\": \"TOPIC\" } }";
@@ -2978,7 +2974,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithSchemaIdAndSchemaVersion_returnsBadRequest() throws Exception {
+  public void produceAvroWithSchemaIdAndSchemaVersion_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"schema_id\": 1, \"schema_version\": 1 } }";
 
@@ -2997,7 +2993,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchemaAndSchemaId_returnsBadRequest() throws Exception {
+  public void produceAvroWithRawSchemaAndSchemaId_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request =
         "{ \"key\": { \"schema\": \"{ \\\"type\\\": \\\"string\\\" }\", \"schema_id\": 1 } }";
@@ -3017,7 +3013,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRawSchemaAndSchemaVersion_returnsBadRequest() throws Exception {
+  public void produceAvroWithRawSchemaAndSchemaVersion_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request =
         "{ \"key\": { \"schema\": \"{ \\\"type\\\": \\\"string\\\" }\", \"schema_version\": 1 } }";
@@ -3037,8 +3033,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRecordSchemaSubjectStrategyAndSchemaVersion_returnsBadRequest()
-      throws Exception {
+  public void produceAvroWithRecordSchemaSubjectStrategyAndSchemaVersion_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request =
         "{ \"key\": { \"subject_name_strategy\": \"RECORD_NAME\", \"schema_version\": 1 } }";
@@ -3058,8 +3053,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
-  public void produceAvroWithRecordSchemaSubjectStrategyAndLatestVersion_returnsBadRequest()
-      throws Exception {
+  public void produceAvroWithRecordSchemaSubjectStrategyAndLatestVersion_returnsBadRequest() {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String request = "{ \"key\": { \"subject_name_strategy\": \"RECORD_NAME\" } }";
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/AbstractSchemaRegistry.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/AbstractSchemaRegistry.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing;
+
+import com.google.auto.value.AutoValue;
+import com.google.protobuf.Message;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+
+public abstract class AbstractSchemaRegistry {
+
+  public abstract SchemaRegistryClient getClient();
+
+  public final SchemaKey createSchema(String subject, ParsedSchema schema) throws Exception {
+    int schemaId = getClient().register(subject, schema);
+    int schemaVersion = getClient().getVersion(subject, schema);
+    return SchemaKey.create(subject, schemaId, schemaVersion);
+  }
+
+  public final KafkaAvroDeserializer createAvroDeserializer() {
+    return new KafkaAvroDeserializer(getClient());
+  }
+
+  public final KafkaJsonSchemaDeserializer<Object> createJsonSchemaDeserializer() {
+    return new KafkaJsonSchemaDeserializer<>(getClient());
+  }
+
+  public final KafkaProtobufDeserializer<Message> createProtobufDeserializer() {
+    return new KafkaProtobufDeserializer<>(getClient());
+  }
+
+  @AutoValue
+  public abstract static class SchemaKey {
+
+    SchemaKey() {}
+
+    public abstract String getSubject();
+
+    public abstract int getSchemaId();
+
+    public abstract int getSchemaVersion();
+
+    public static SchemaKey create(String subject, int schemaId, int schemaVersion) {
+      return new AutoValue_AbstractSchemaRegistry_SchemaKey(subject, schemaId, schemaVersion);
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Broker.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Broker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.kafka.common.Node;
+
+final class Broker {
+  private final int brokerId;
+  private final ConfigStore configs;
+
+  Broker(int brokerId, ConfigStore configs) {
+    this.brokerId = brokerId;
+    this.configs = requireNonNull(configs);
+  }
+
+  int getBrokerId() {
+    return brokerId;
+  }
+
+  ConfigStore getConfigs() {
+    return configs;
+  }
+
+  Node toNode() {
+    return new Node(brokerId, "localhost", brokerId);
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/ConfigDef.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/ConfigDef.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+
+final class ConfigDef<T> {
+  private final ConfigResource.Type resource;
+  private final String name;
+  private final String defaultValue;
+  private final Function<String, T> parser;
+  private final Predicate<T> validator;
+
+  private ConfigDef(
+      ConfigResource.Type resource,
+      String name,
+      String defaultValue,
+      Function<String, T> parser,
+      Predicate<T> validator) {
+    this.resource = requireNonNull(resource);
+    this.name = requireNonNull(name);
+    this.defaultValue = requireNonNull(defaultValue);
+    this.parser = requireNonNull(parser);
+    this.validator = requireNonNull(validator);
+    parse(defaultValue);
+  }
+
+  ConfigResource.Type getResource() {
+    return resource;
+  }
+
+  String getName() {
+    return name;
+  }
+
+  String getDefaultValue() {
+    return defaultValue;
+  }
+
+  T parse(String value) {
+    T parsed;
+    try {
+      parsed = parser.apply(value);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidConfigurationException(
+          String.format("`%s' is an invalid value for config `%s'", value, name), e);
+    }
+    if (!validator.test(parsed)) {
+      throw new InvalidConfigurationException(
+          String.format("`%s' is an invalid value for config `%s'", value, name));
+    }
+    return parsed;
+  }
+
+  static ConfigDef<Integer> intConfig(
+      ConfigResource.Type resource, String name, int defaultValue, Predicate<Integer> validator) {
+    return new ConfigDef<>(
+        resource, name, Integer.toString(defaultValue), Integer::parseInt, validator);
+  }
+
+  static ConfigDef<Short> shortConfig(
+      ConfigResource.Type resource, String name, short defaultValue, Predicate<Short> validator) {
+    return new ConfigDef<>(
+        resource, name, Short.toString(defaultValue), Short::parseShort, validator);
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/ConfigStore.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/ConfigStore.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.kafka.common.config.ConfigResource;
+
+final class ConfigStore {
+
+  private static final ConfigDef<Short> DEFAULT_REPLICATION_FACTOR =
+      ConfigDef.shortConfig(
+          ConfigResource.Type.BROKER,
+          "default.replication.factor",
+          (short) 1,
+          (value) -> value > 0);
+  private static final ConfigDef<Integer> NUM_PARTITIONS =
+      ConfigDef.intConfig(ConfigResource.Type.BROKER, "num.partitions", 1, (value) -> value > 0);
+
+  private static final ImmutableMap<String, ConfigDef<?>> CONFIG_DEFS_BY_NAME =
+      Stream.of(DEFAULT_REPLICATION_FACTOR, NUM_PARTITIONS)
+          .collect(toImmutableMap(ConfigDef::getName, Function.identity()));
+
+  private final ConfigResource.Type resource;
+
+  ConfigStore(ConfigResource.Type resource) {
+    this.resource = requireNonNull(resource);
+  }
+
+  /** Returns the default replication factor for automatically created topics. */
+  short getDefaultReplicationFactor() {
+    return DEFAULT_REPLICATION_FACTOR.parse(getConfig(DEFAULT_REPLICATION_FACTOR.getName()));
+  }
+
+  /** Returns the default number of log partitions per topic. */
+  int getNumPartitions() {
+    return NUM_PARTITIONS.parse(getConfig(NUM_PARTITIONS.getName()));
+  }
+
+  /** Returns the current value for the config with the given {@code name}. */
+  private String getConfig(String name) {
+    ConfigDef<?> configDef = CONFIG_DEFS_BY_NAME.get(name);
+    checkArgument(
+        configDef != null && configDef.getResource().equals(resource),
+        "Config `%s' doesn't exist.",
+        name);
+    return configDef.getDefaultValue();
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeKafkaCluster.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeKafkaCluster.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.emptySet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.protobuf.ByteString;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import kafka.admin.AdminOperationException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public final class FakeKafkaCluster {
+  private static final int NUM_BROKERS = 3;
+
+  private final String clusterId = UUID.randomUUID().toString();
+  private final Broker controller;
+  private final ConcurrentMap<Integer, Broker> brokers = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Topic> topics = new ConcurrentHashMap<>();
+  private final AtomicInteger nextReplica = new AtomicInteger(0);
+
+  FakeKafkaCluster() {
+    controller = new Broker(/* brokerId= */ 1, new ConfigStore(ConfigResource.Type.BROKER));
+    brokers.put(controller.getBrokerId(), controller);
+    for (int brokerId = 2; brokerId <= NUM_BROKERS; brokerId++) {
+      brokers.put(brokerId, new Broker(brokerId, new ConfigStore(ConfigResource.Type.BROKER)));
+    }
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  Broker getBroker(int brokerId) {
+    Broker broker = brokers.get(brokerId);
+    checkArgument(broker != null, "Broker %s does not exist.", brokerId);
+    return broker;
+  }
+
+  Topic getTopic(String topicName) {
+    Topic topic = topics.get(topicName);
+    if (topic == null) {
+      throw new UnknownTopicOrPartitionException(
+          String.format("Topic %s doesn't exist.", topicName));
+    }
+    return topic;
+  }
+
+  public synchronized Topic createTopic(
+      String topicName, Optional<Integer> numPartitions, Optional<Short> replicationFactor) {
+    short actualReplicationFactor =
+        replicationFactor.orElse(controller.getConfigs().getDefaultReplicationFactor());
+    if (actualReplicationFactor > brokers.size()) {
+      throw new AdminOperationException(
+          String.format(
+              "replication factor: %d larger than available brokers: %d",
+              actualReplicationFactor, brokers.size()));
+    }
+    return createTopic(
+        topicName,
+        assignReplicas(
+            numPartitions.orElse(controller.getConfigs().getNumPartitions()),
+            replicationFactor.orElse(controller.getConfigs().getDefaultReplicationFactor())));
+  }
+
+  private ImmutableListMultimap<Integer, Integer> assignReplicas(
+      int numPartitions, short replicationFactor) {
+    ImmutableList<Integer> brokerIds = ImmutableList.sortedCopyOf(brokers.keySet());
+    int firstReplica = nextReplica.getAndAdd(numPartitions * replicationFactor);
+    ImmutableListMultimap.Builder<Integer, Integer> assignments = ImmutableListMultimap.builder();
+    for (int partitionId = 1; partitionId <= numPartitions; partitionId++) {
+      for (int replicaIdx = 0; replicaIdx < replicationFactor; replicaIdx++) {
+        int brokerId = firstReplica + (partitionId - 1) * replicationFactor + replicaIdx;
+        assignments.put(partitionId, brokerIds.get(brokerId % brokerIds.size()));
+      }
+    }
+    return assignments.build();
+  }
+
+  public synchronized Topic createTopic(
+      String topicName, ListMultimap<Integer, Integer> replicaAssignments) {
+    ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
+    for (int partitionId : replicaAssignments.keySet()) {
+      checkArgument(
+          !replicaAssignments.get(partitionId).isEmpty(),
+          "Partition %d needs at least one replica.",
+          partitionId);
+      Replica leader = new Replica(replicaAssignments.get(partitionId).get(0));
+      List<Replica> followers =
+          replicaAssignments.get(partitionId).stream()
+              .skip(1)
+              .map(Replica::new)
+              .collect(toImmutableList());
+      partitions.add(new Partition(topicName, partitionId, leader, followers));
+    }
+    Topic topic = new Topic(partitions.build());
+    topics.put(topicName, topic);
+    return topic;
+  }
+
+  public synchronized RecordMetadata produce(
+      String topicName,
+      int partitionId,
+      List<Header> headers,
+      Optional<ByteString> key,
+      Optional<ByteString> value,
+      Instant timestamp) {
+    Partition partition = getTopic(topicName).getPartition(partitionId);
+    Record record = new Record(headers, key, value, timestamp);
+    int offset = partition.getLeader().addRecord(record);
+    partition.getFollowers().forEach(replica -> replica.addRecord(record));
+    return new RecordMetadata(
+        new TopicPartition(topicName, partition.getPartitionId()),
+        offset,
+        0,
+        timestamp.toEpochMilli(),
+        key.map(ByteString::size).orElse(0),
+        value.map(ByteString::size).orElse(0));
+  }
+
+  public <K, V> ConsumerRecord<K, V> getRecord(
+      String topicName,
+      int partitionId,
+      long offset,
+      Deserializer<K> keyDeserializer,
+      Deserializer<V> valueDeserializer) {
+    Record record =
+        getTopic(topicName)
+            .getPartition(partitionId)
+            .getLeader()
+            .getRecords()
+            .get(Math.toIntExact(offset));
+    return new ConsumerRecord<>(
+        topicName,
+        partitionId,
+        offset,
+        record.getTimestamp().toEpochMilli(),
+        TimestampType.NO_TIMESTAMP_TYPE,
+        record.getKey().map(ByteString::size).orElse(0),
+        record.getValue().map(ByteString::size).orElse(0),
+        keyDeserializer.deserialize(
+            topicName, record.getKey().map(ByteString::toByteArray).orElse(null)),
+        valueDeserializer.deserialize(
+            topicName, record.getValue().map(ByteString::toByteArray).orElse(null)),
+        new RecordHeaders(
+            record.getHeaders().stream()
+                .map(
+                    header ->
+                        new RecordHeader(
+                            header.getKey(),
+                            header.getValue().map(ByteString::toByteArray).orElse(null)))
+                .collect(toImmutableList())),
+        Optional.empty());
+  }
+
+  Cluster toClusterMetadata() {
+    return new Cluster(
+        clusterId,
+        brokers.values().stream().map(Broker::toNode).collect(toImmutableList()),
+        topics.values().stream()
+            .flatMap(topic -> topic.getPartitions().stream())
+            .map(partition -> partition.toPartitionInfo(this))
+            .collect(toImmutableList()),
+        emptySet(),
+        emptySet());
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeKafkaProducer.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeKafkaProducer.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+import com.google.protobuf.ByteString;
+import io.confluent.kafkarest.common.KafkaFutures;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.clients.producer.RoundRobinPartitioner;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.serialization.Serializer;
+
+final class FakeKafkaProducer<K, V> implements Producer<K, V> {
+  private final FakeKafkaCluster cluster;
+  private final Serializer<K> keySerializer;
+  private final Serializer<V> valueSerializer;
+  private final Partitioner partitioner = new RoundRobinPartitioner();
+
+  FakeKafkaProducer(
+      FakeKafkaCluster cluster, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+    this.cluster = requireNonNull(cluster);
+    this.keySerializer = requireNonNull(keySerializer);
+    this.valueSerializer = requireNonNull(valueSerializer);
+  }
+
+  @Override
+  public void initTransactions() {
+    throw new UnsupportedOperationException("initTransactions is not supported");
+  }
+
+  @Override
+  public void beginTransaction() throws ProducerFencedException {
+    throw new UnsupportedOperationException("beginTransaction is not supported");
+  }
+
+  @Override
+  public void sendOffsetsToTransaction(
+      Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId) {
+    throw new UnsupportedOperationException("sendOffsetsToTransaction is not supported");
+  }
+
+  @Override
+  public void sendOffsetsToTransaction(
+      Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) {
+    throw new UnsupportedOperationException("sendOffsetsToTransaction is not supported");
+  }
+
+  @Override
+  public void commitTransaction() {
+    throw new UnsupportedOperationException("commitTransaction is not supported");
+  }
+
+  @Override
+  public void abortTransaction() throws ProducerFencedException {
+    throw new UnsupportedOperationException("abortTransaction is not supported");
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
+    return send(record, (metadata, exception) -> {});
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+    Optional<ByteString> key =
+        Optional.ofNullable(record.key())
+            .map(k -> ByteString.copyFrom(keySerializer.serialize(record.topic(), k)));
+    Optional<ByteString> value =
+        Optional.ofNullable(record.value())
+            .map(v -> ByteString.copyFrom(valueSerializer.serialize(record.topic(), v)));
+    int partition;
+    if (record.partition() != null) {
+      partition = record.partition();
+    } else {
+      partition =
+          partitioner.partition(
+              record.topic(),
+              record.key(),
+              key.map(ByteString::toByteArray).orElse(null),
+              record.value(),
+              value.map(ByteString::toByteArray).orElse(null),
+              cluster.toClusterMetadata());
+    }
+    List<Header> headers =
+        Stream.of(record.headers().toArray())
+            .map(
+                header ->
+                    new Header(
+                        header.key(),
+                        Optional.ofNullable(header.value()).map(ByteString::copyFrom)))
+            .collect(toImmutableList());
+    Instant timestamp =
+        Optional.ofNullable(record.timestamp()).map(Instant::ofEpochMilli).orElse(Instant.now());
+    RecordMetadata metadata;
+    Exception exception;
+    try {
+      metadata = cluster.produce(record.topic(), partition, headers, key, value, timestamp);
+      exception = null;
+    } catch (RuntimeException e) {
+      metadata =
+          new RecordMetadata(new TopicPartition(record.topic(), partition), -1, -1, -1, -1, -1);
+      exception = e;
+    }
+    callback.onCompletion(metadata, exception);
+    if (exception == null) {
+      return KafkaFuture.completedFuture(metadata);
+    } else {
+      return KafkaFutures.failedFuture(exception);
+    }
+  }
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    return cluster.getTopic(topic).getPartitions().stream()
+        .map(partition -> partition.toPartitionInfo(cluster))
+        .collect(toImmutableList());
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    throw new UnsupportedOperationException("metrics is not supported");
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void close(Duration timeout) {}
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeKafkaRestTestEnvironment.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeKafkaRestTestEnvironment.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.KafkaRestContext;
+import io.confluent.kafkarest.ProducerPool;
+import io.confluent.kafkarest.testing.KafkaRestFixture;
+import io.confluent.kafkarest.v2.KafkaConsumerManager;
+import javax.inject.Inject;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public final class FakeKafkaRestTestEnvironment implements AfterEachCallback, BeforeEachCallback {
+  private final FakeKafkaCluster kafkaCluster = new FakeKafkaCluster();
+  private final FakeSchemaRegistry schemaRegistry = new FakeSchemaRegistry();
+  private final KafkaRestFixture kafkaRest =
+      KafkaRestFixture.builder()
+          .setConfig("bootstrap.servers", "foobar")
+          .addModule(new FakeKafkaModule(kafkaCluster, schemaRegistry))
+          .build();
+
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    kafkaRest.beforeEach(extensionContext);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) {
+    kafkaRest.afterEach(extensionContext);
+  }
+
+  public FakeKafkaCluster kafkaCluster() {
+    return kafkaCluster;
+  }
+
+  public FakeSchemaRegistry schemaRegistry() {
+    return schemaRegistry;
+  }
+
+  public KafkaRestFixture kafkaRest() {
+    return kafkaRest;
+  }
+
+  private static final class FakeKafkaModule extends AbstractBinder {
+    private final FakeKafkaCluster kafkaCluster;
+    private final FakeSchemaRegistry schemaRegistry;
+
+    private FakeKafkaModule(FakeKafkaCluster kafkaCluster, FakeSchemaRegistry schemaRegistry) {
+      this.kafkaCluster = requireNonNull(kafkaCluster);
+      this.schemaRegistry = requireNonNull(schemaRegistry);
+    }
+
+    @Override
+    protected void configure() {
+      bind(kafkaCluster).to(FakeKafkaCluster.class).ranked(1);
+      bind(schemaRegistry).to(FakeSchemaRegistry.class).ranked(1);
+      bind(FakeKafkaRestContext.class).to(KafkaRestContext.class).ranked(1);
+    }
+  }
+
+  private static final class FakeKafkaRestContext implements KafkaRestContext {
+    private final KafkaRestConfig config;
+    private final FakeKafkaCluster kafkaCluster;
+    private final FakeSchemaRegistry schemaRegistry;
+
+    @Inject
+    FakeKafkaRestContext(
+        KafkaRestConfig config, FakeKafkaCluster kafkaCluster, FakeSchemaRegistry schemaRegistry) {
+      this.config = requireNonNull(config);
+      this.kafkaCluster = requireNonNull(kafkaCluster);
+      this.schemaRegistry = requireNonNull(schemaRegistry);
+    }
+
+    @Override
+    public KafkaRestConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public ProducerPool getProducerPool() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KafkaConsumerManager getKafkaConsumerManager() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Admin getAdmin() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Producer<byte[], byte[]> getProducer() {
+      return new FakeKafkaProducer<>(
+          kafkaCluster, new ByteArraySerializer(), new ByteArraySerializer());
+    }
+
+    @Override
+    public SchemaRegistryClient getSchemaRegistryClient() {
+      return schemaRegistry.getClient();
+    }
+
+    @Override
+    public void shutdown() {}
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeSchemaRegistry.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/FakeSchemaRegistry.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.confluent.kafkarest.testing.AbstractSchemaRegistry;
+
+public final class FakeSchemaRegistry extends AbstractSchemaRegistry {
+  private final MockSchemaRegistryClient schemaRegistry =
+      new MockSchemaRegistryClient(
+          ImmutableList.of(
+              new AvroSchemaProvider(), new JsonSchemaProvider(), new ProtobufSchemaProvider()));
+
+  @Override
+  public MockSchemaRegistryClient getClient() {
+    return schemaRegistry;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Header.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Header.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.protobuf.ByteString;
+import java.util.Optional;
+
+final class Header {
+  private final String key;
+  private final Optional<ByteString> value;
+
+  Header(String key, Optional<ByteString> value) {
+    this.key = requireNonNull(key);
+    this.value = requireNonNull(value);
+  }
+
+  String getKey() {
+    return key;
+  }
+
+  Optional<ByteString> getValue() {
+    return value;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Partition.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Partition.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+
+final class Partition {
+  private final String topicName;
+  private final int partitionId;
+  private final Replica leader;
+  private final ImmutableList<Replica> followers;
+
+  Partition(String topicName, int partitionId, Replica leader, List<Replica> followers) {
+    this.topicName = requireNonNull(topicName);
+    this.partitionId = partitionId;
+    this.leader = requireNonNull(leader);
+    this.followers = ImmutableList.copyOf(followers);
+  }
+
+  int getPartitionId() {
+    return partitionId;
+  }
+
+  Replica getLeader() {
+    return leader;
+  }
+
+  ImmutableList<Replica> getFollowers() {
+    return followers;
+  }
+
+  ImmutableList<Replica> getReplicas() {
+    return ImmutableList.<Replica>builder().add(leader).addAll(followers).build();
+  }
+
+  PartitionInfo toPartitionInfo(FakeKafkaCluster cluster) {
+    Node[] replicas =
+        getReplicas().stream()
+            .map(Replica::getBrokerId)
+            .map(cluster::getBroker)
+            .map(Broker::toNode)
+            .toArray(Node[]::new);
+    return new PartitionInfo(
+        topicName,
+        partitionId,
+        cluster.getBroker(leader.getBrokerId()).toNode(),
+        replicas,
+        replicas);
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Record.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Record.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+final class Record {
+  private final ImmutableList<Header> headers;
+  private final Optional<ByteString> key;
+  private final Optional<ByteString> value;
+  private final Instant timestamp;
+
+  Record(
+      List<Header> headers,
+      Optional<ByteString> key,
+      Optional<ByteString> value,
+      Instant timestamp) {
+    this.headers = ImmutableList.copyOf(headers);
+    this.key = requireNonNull(key);
+    this.value = requireNonNull(value);
+    this.timestamp = requireNonNull(timestamp);
+  }
+
+  ImmutableList<Header> getHeaders() {
+    return headers;
+  }
+
+  Optional<ByteString> getKey() {
+    return key;
+  }
+
+  Optional<ByteString> getValue() {
+    return value;
+  }
+
+  Instant getTimestamp() {
+    return timestamp;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Replica.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Replica.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import com.google.common.collect.ImmutableList;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+final class Replica {
+  private final int brokerId;
+  private final CopyOnWriteArrayList<Record> records = new CopyOnWriteArrayList<>();
+
+  Replica(int brokerId) {
+    this.brokerId = brokerId;
+  }
+
+  int getBrokerId() {
+    return brokerId;
+  }
+
+  ImmutableList<Record> getRecords() {
+    return ImmutableList.copyOf(records);
+  }
+
+  synchronized int addRecord(Record record) {
+    int offset = records.size();
+    records.add(record);
+    return offset;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Topic.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/fake/Topic.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.testing.fake;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+
+final class Topic {
+  private final ConcurrentMap<Integer, Partition> partitions = new ConcurrentHashMap<>();
+
+  Topic(List<Partition> partitions) {
+    partitions.forEach(partition -> this.partitions.put(partition.getPartitionId(), partition));
+  }
+
+  Partition getPartition(int partitionId) {
+    Partition partition = partitions.get(partitionId);
+    if (partition == null) {
+      throw new UnknownTopicOrPartitionException(
+          String.format("Partition %d doesn't exist.", partitionId));
+    }
+    return partition;
+  }
+
+  ImmutableList<Partition> getPartitions() {
+    return ImmutableList.copyOf(partitions.values());
+  }
+}


### PR DESCRIPTION
Also convert ProduceActionIntegrationTest to use the new environment.

Using a real Kafka/SR implementation in our tests has the benefit that we can actually do an end-to-end test from Kafka REST to Kafka/SR. In the other hand, because of the distributed nature of Kafka, the tests become non-deterministic. This causes flakiness, which oftentimes we have to resort to sleep/retry to "fix".

This PR adds a fake Kafka/SR environment to address the aforementioned issues. The main design points are:

 1. No disk.
 2. No networking.
 3. No async.

By implementing Kafka following the above requirements, we can ensure tests are fully deterministic and fast(!!).

Note: I was mid-way implementing an AdminClient, until I noticed I didn't have to. This might explain some of the design decisions. I deleted all the code that was not used anymore, but the way the code is structured still reflects the extras needed for implementing the Admin operations. Eventually we will need to implement Admin anyway, so I think leaving the structure as is, without the extra code, is a good compromise.