### PR TITLE
KREST-4783 Increase slack in consumer timeout test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -31,7 +31,10 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
   // This is pretty large since there is sometimes significant overhead to doing a read (e.g.
   // checking topic existence in ZK)
   private static final Integer instanceTimeout = 1000;
-  private static final Integer slackTime = 1100;
+  //there is a 1s sleep in the KafkaConsumerManager cleanup thread, which means that if the instance
+  // timeout takes 1s to expire, it could be 2s before the consumer is cleaned up (if we just missed
+  // the timer) + we need to allow for slack on top of this
+  private static final Integer slackTime = 2000;
 
   @Before
   @Override


### PR DESCRIPTION
This test sets a consumer instance timeout of 1000ms, creates a consumer instance with that timeout, does some consuming, and then waits 2100ms before doing the next consume.

It expects that the consume will fail because the consume instance has timed out - it should expire after 1s and the test waits for 2.1s which should be plenty even allowing for slowness.

However, if you look in the consumer instance timeout code, there is a 1000ms wait between cleanup cycles.

So, it’s conceivable that we could wait up to 2000ms for the consumer instance to be cleared.

The current wait in the test is 2100ms (instanceTimeout + slackTime) before checking if the consumer has expired, which doesn’t account for any slowness in the machine.

I've increased the slack time