### PR TITLE
KREST-4825 Huge timeout in consume test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -30,10 +30,11 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
   private static final Integer requestTimeout = 500;
   // This is pretty large since there is sometimes significant overhead to doing a read (e.g.
   // checking topic existence in ZK)
-  private static final Integer instanceTimeout = 1000;
-  //there is a 1s sleep in the KafkaConsumerManager cleanup thread, which means that if the instance
-  // timeout takes 1s to expire, it could be 2s before the consumer is cleaned up (if we just missed
-  // the timer) + we need to allow for slack on top of this
+  // Tests have seen > 2s delays between registering the consumer and the consume
+  private static final Integer instanceTimeout = 3500;
+  // There is a 1s sleep in the KafkaConsumerManager cleanup thread, which means that if the
+  // instance timeout takes 1s to expire, it could be 2s before the consumer is cleaned up
+  // (if we just missed the timer) + we need to allow for slack on top of this
   private static final Integer slackTime = 2000;
 
   @Before

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerTimeoutTest.java
@@ -27,21 +27,21 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
   private static final String topicName = "test";
   private static final String groupName = "testconsumergroup";
 
-  private static final Integer requestTimeout = 500;
+  private static final Integer REQUEST_TIMEOUT_MS = 500;
   // This is pretty large since there is sometimes significant overhead to doing a read (e.g.
   // checking topic existence in ZK)
   // Tests have seen > 2s delays between registering the consumer and the consume
-  private static final Integer instanceTimeout = 3500;
+  private static final Integer INSTANCE_TIMEOUT_MS = 3500;
   // There is a 1s sleep in the KafkaConsumerManager cleanup thread, which means that if the
   // instance timeout takes 1s to expire, it could be 2s before the consumer is cleaned up
   // (if we just missed the timer) + we need to allow for slack on top of this
-  private static final Integer slackTime = 2000;
+  private static final Integer SLACK_TIME_MS = 2000;
 
   @Before
   @Override
   public void setUp() throws Exception {
-    restProperties.setProperty("consumer.request.timeout.ms", requestTimeout.toString());
-    restProperties.setProperty("consumer.instance.timeout.ms", instanceTimeout.toString());
+    restProperties.setProperty("consumer.request.timeout.ms", REQUEST_TIMEOUT_MS.toString());
+    restProperties.setProperty("consumer.instance.timeout.ms", INSTANCE_TIMEOUT_MS.toString());
     super.setUp();
     final int numPartitions = 3;
     final int replicationFactor = 1;
@@ -63,7 +63,7 @@ public class ConsumerTimeoutTest extends AbstractConsumerTest {
                       new GenericType<List<BinaryConsumerRecord>>() {
                       });
     // Then sleep long enough for it to expire
-    Thread.sleep(instanceTimeout + slackTime);
+    Thread.sleep(INSTANCE_TIMEOUT_MS + SLACK_TIME_MS);
 
     consumeForNotFoundError(instanceUri);
   }


### PR DESCRIPTION
The consumeTimeout test is failing in the 7.1 CP tests because of huge gaps between API calls.

There is 0.5s between the POST to create the consumer group and the subscription and then over 2 seconds between the subscription create and the GET that does the consume

Before this change the instance expiry (how long the consumer group is kept for) was set to 1s, and so the consumer group was timing out before the GET happened, resulting in a 404.

This PR increases the instance timeout to 3.5 s, which unfortutately adds 2.5s to the consumeTimeout test run time, but won't impact the run time of any other tests.