### PR TITLE
Cherry-pick "KREST-4356 Optimize CompletionExceptions when rate-limiting (#973)" into v0.2816.x

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/StacklessCompletionException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/StacklessCompletionException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.exceptions;
+
+import java.util.concurrent.CompletionException;
+
+/**
+ * A {@link CompletionException} which doesn't fill its stack trace. Can be explicitly used instead
+ * of the regular one in performance-sensitive code paths where we throw during async processing
+ * with {@link java.util.concurrent.CompletableFuture}s.
+ *
+ * <ul>
+ *   <li>One good example of that is Produce v3 rate-limiting.
+ * </ul>
+ */
+public final class StacklessCompletionException extends CompletionException {
+
+  public StacklessCompletionException(Throwable cause) {
+    super(cause);
+  }
+
+  @SuppressWarnings("unused")
+  public StacklessCompletionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
+}


### PR DESCRIPTION
This cherry-picks the changes of https://github.com/confluentinc/kafka-rest/pull/973 into the latest `ce-kafka-images` release branch.

These changes remove a significant Produce v3 rate-limiting overhead (well over 10% of the CPU profiler in specific cases) and are very important for Kafka REST's upcoming Produce v3 EA release to Multi-tenant clusters.
- They also depend on https://github.com/confluentinc/kafka-rest/pull/990 which has already been merged to the 2816 branch.

The changes are fairly simple, isolated, and have been tested fairly well in [the original JIRA](https://confluentinc.atlassian.net/browse/KREST-4356).