### PR TITLE
KREST-3323 add global rate limiter for produce

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -169,14 +169,37 @@ public class KafkaRestConfig extends RestConfig {
   public static final ConfigDef.Range PRODUCE_MAX_REQUESTS_PER_SECOND_VALIDATOR =
       ConfigDef.Range.between(1, Integer.MAX_VALUE);
 
+  public static final String PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND =
+      "api.v3.produce.rate.limit.max.requests.global.per.sec";
+  private static final String PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND_DOC =
+      "Maximum number of requests per second before rate limiting is enforced, across all "
+          + "clusterIds. "
+          + "Messages produced that exceed the rate limit are discarded and a 429 is returned "
+          + "to the client.";
+  public static final String PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND_DEFAULT = "10000";
+  public static final ConfigDef.Range PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND_VALIDATOR =
+      ConfigDef.Range.between(1, Integer.MAX_VALUE);
+
   public static final String PRODUCE_MAX_BYTES_PER_SECOND =
       "api.v3.produce.rate.limit.max.bytes.per.sec";
   private static final String PRODUCE_MAX_BYTES_PER_SECOND_DOC =
       "Maximum number of bytes per second before rate limiting is enforced. "
+          + "The limit is enforced per clusterId, so the total rate limit will be "
+          + "number of clusters * api.v3.produce.rate.limit.max.bytes.per.sec. "
           + "Messages produced that exceed the rate limit are discarded and a 429 is returned "
           + "to the client.";
   public static final String PRODUCE_MAX_BYTES_PER_SECOND_DEFAULT = "10000000";
   public static final ConfigDef.Range PRODUCE_MAX_BYTES_PER_SECOND_VALIDATOR =
+      ConfigDef.Range.between(1, Integer.MAX_VALUE);
+
+  public static final String PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND =
+      "api.v3.produce.rate.limit.max.bytes.global.per.sec";
+  private static final String PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND_DOC =
+      "Maximum number of bytes per second before rate limiting is enforced, across all clusterIds. "
+          + "Messages produced that exceed the rate limit are discarded and a 429 is returned "
+          + "to the client.";
+  public static final String PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND_DEFAULT = "10000000";
+  public static final ConfigDef.Range PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND_VALIDATOR =
       ConfigDef.Range.between(1, Integer.MAX_VALUE);
 
   public static final String PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS =
@@ -501,12 +524,26 @@ public class KafkaRestConfig extends RestConfig {
             Importance.LOW,
             PRODUCE_MAX_REQUESTS_PER_SECOND_DOC)
         .define(
+            PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND,
+            Type.INT,
+            PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND_DEFAULT,
+            PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND_VALIDATOR,
+            Importance.LOW,
+            PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND_DOC)
+        .define(
             PRODUCE_MAX_BYTES_PER_SECOND,
             Type.INT,
             PRODUCE_MAX_BYTES_PER_SECOND_DEFAULT,
             PRODUCE_MAX_BYTES_PER_SECOND_VALIDATOR,
             Importance.LOW,
             PRODUCE_MAX_BYTES_PER_SECOND_DOC)
+        .define(
+            PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND,
+            Type.INT,
+            PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND_DEFAULT,
+            PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND_VALIDATOR,
+            Importance.LOW,
+            PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND_DOC)
         .define(
             PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS,
             Type.INT,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -111,6 +111,14 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new ProduceRateLimitCountConfigImpl())
         .to(Integer.class);
 
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitCountGlobalConfigImpl())
+        .to(Integer.class);
+
+    bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND))
+        .qualifiedBy(new ProduceRateLimitBytesGlobalConfigImpl())
+        .to(Integer.class);
+
     bind(Duration.ofMillis(config.getInt(KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))
         .qualifiedBy(new ProduceRateLimitCacheExpiryConfigImpl())
         .to(Duration.class);
@@ -289,6 +297,24 @@ public final class ConfigModule extends AbstractBinder {
   private static final class ProduceRateLimitBytesConfigImpl
       extends AnnotationLiteral<ProduceRateLimitBytesConfig>
       implements ProduceRateLimitBytesConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceRateLimitBytesGlobalConfig {}
+
+  private static final class ProduceRateLimitBytesGlobalConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitBytesGlobalConfig>
+      implements ProduceRateLimitBytesGlobalConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceRateLimitCountGlobalConfig {}
+
+  private static final class ProduceRateLimitCountGlobalConfigImpl
+      extends AnnotationLiteral<ProduceRateLimitCountGlobalConfig>
+      implements ProduceRateLimitCountGlobalConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RateLimitModule.java
@@ -46,6 +46,16 @@ public final class RateLimitModule extends AbstractBinder {
         .qualifiedBy(new ProduceRateLimiterBytesImpl())
         .to(RequestRateLimiter.class)
         .in(PerLookup.class);
+
+    bindFactory(RequestRateLimiterProduceCountGlobalFactory.class)
+        .qualifiedBy(new ProduceRateLimiterCountGlobalImpl())
+        .to(RequestRateLimiter.class)
+        .in(Singleton.class);
+
+    bindFactory(RequestRateLimiterProduceBytesGlobalFactory.class)
+        .qualifiedBy(new ProduceRateLimiterBytesGlobalImpl())
+        .to(RequestRateLimiter.class)
+        .in(Singleton.class);
   }
 
   @Qualifier
@@ -63,6 +73,24 @@ public final class RateLimitModule extends AbstractBinder {
 
   private static final class ProduceRateLimiterBytesImpl
       extends AnnotationLiteral<ProduceRateLimiterBytes> implements ProduceRateLimiterBytes {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceRateLimiterCountGlobal {}
+
+  private static final class ProduceRateLimiterCountGlobalImpl
+      extends AnnotationLiteral<ProduceRateLimiterCountGlobal>
+      implements ProduceRateLimiterCountGlobal {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface ProduceRateLimiterBytesGlobal {}
+
+  private static final class ProduceRateLimiterBytesGlobalImpl
+      extends AnnotationLiteral<ProduceRateLimiterBytesGlobal>
+      implements ProduceRateLimiterBytesGlobal {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiterProduceBytesGlobalFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiterProduceBytesGlobalFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitBytesGlobalConfig;
+import io.confluent.kafkarest.config.ConfigModule.RateLimitTimeoutConfig;
+import java.time.Duration;
+import javax.inject.Inject;
+
+public class RequestRateLimiterProduceBytesGlobalFactory extends RequestRateLimiterFactory {
+
+  @Inject
+  public RequestRateLimiterProduceBytesGlobalFactory(
+      RateLimitBackend backend,
+      @ProduceRateLimitBytesGlobalConfig Integer permitsPerSecond,
+      @RateLimitTimeoutConfig Duration timeout) {
+    super(backend, permitsPerSecond, timeout);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiterProduceCountGlobalFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/ratelimit/RequestRateLimiterProduceCountGlobalFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.ratelimit;
+
+import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitCountGlobalConfig;
+import io.confluent.kafkarest.config.ConfigModule.RateLimitTimeoutConfig;
+import java.time.Duration;
+import javax.inject.Inject;
+
+public class RequestRateLimiterProduceCountGlobalFactory extends RequestRateLimiterFactory {
+
+  @Inject
+  public RequestRateLimiterProduceCountGlobalFactory(
+      RateLimitBackend backend,
+      @ProduceRateLimitCountGlobalConfig Integer permitsPerSecond,
+      @RateLimitTimeoutConfig Duration timeout) {
+    super(backend, permitsPerSecond, timeout);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
@@ -24,7 +24,9 @@ import com.google.common.cache.LoadingCache;
 import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitCacheExpiryConfig;
 import io.confluent.kafkarest.config.ConfigModule.ProduceRateLimitEnabledConfig;
 import io.confluent.kafkarest.ratelimit.RateLimitModule.ProduceRateLimiterBytes;
+import io.confluent.kafkarest.ratelimit.RateLimitModule.ProduceRateLimiterBytesGlobal;
 import io.confluent.kafkarest.ratelimit.RateLimitModule.ProduceRateLimiterCount;
+import io.confluent.kafkarest.ratelimit.RateLimitModule.ProduceRateLimiterCountGlobal;
 import io.confluent.kafkarest.ratelimit.RequestRateLimiter;
 import java.time.Duration;
 import javax.inject.Inject;
@@ -35,14 +37,21 @@ public class ProduceRateLimiters {
   private final boolean rateLimitingEnabled;
   private final LoadingCache<String, RequestRateLimiter> countCache;
   private final LoadingCache<String, RequestRateLimiter> bytesCache;
+  private final RequestRateLimiter bytesLimiterGlobal;
+  private final RequestRateLimiter countLimiterGlobal;
 
   @Inject
   public ProduceRateLimiters(
       @ProduceRateLimiterCount Provider<RequestRateLimiter> countLimiterProvider,
       @ProduceRateLimiterBytes Provider<RequestRateLimiter> bytesLimiterProvider,
+      @ProduceRateLimiterCountGlobal RequestRateLimiter countLimiterGlobal,
+      @ProduceRateLimiterBytesGlobal RequestRateLimiter bytesLimiterGlobal,
       @ProduceRateLimitEnabledConfig Boolean produceRateLimitEnabledConfig,
       @ProduceRateLimitCacheExpiryConfig Duration produceRateLimitCacheExpiryConfig) {
     this.rateLimitingEnabled = requireNonNull(produceRateLimitEnabledConfig);
+    this.countLimiterGlobal = requireNonNull(countLimiterGlobal);
+    this.bytesLimiterGlobal = requireNonNull(bytesLimiterGlobal);
+
     countCache =
         CacheBuilder.newBuilder()
             .expireAfterAccess(produceRateLimitCacheExpiryConfig)
@@ -62,6 +71,9 @@ public class ProduceRateLimiters {
     RequestRateLimiter byteRateLimiter = bytesCache.getUnchecked(clusterId);
     countRateLimiter.rateLimit(1);
     byteRateLimiter.rateLimit(toIntExact(requestSize));
+
+    countLimiterGlobal.rateLimit(1);
+    bytesLimiterGlobal.rateLimit(toIntExact(requestSize));
   }
 
   public void clear() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -4,6 +4,7 @@ import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_CACHE_EX
 import static io.confluent.kafkarest.KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED;
 import static org.easymock.EasyMock.anyInt;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
@@ -17,7 +18,6 @@ import java.time.Duration;
 import java.util.Properties;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
 public class ProduceRateLimitersTest {
@@ -32,21 +32,37 @@ public class ProduceRateLimitersTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             countLimitProvider,
             bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
     produceRateLimiters.rateLimit("clusterId", 10L);
 
-    verify(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    verify(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -59,6 +75,10 @@ public class ProduceRateLimitersTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
+    Provider<RequestRateLimiter> countLimiterGlobalProvider = mock(Provider.class);
+    Provider<RequestRateLimiter> bytesLimiterGlobalProvider = mock(Provider.class);
     RequestRateLimiter rateLimiterForCount1 = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes1 = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount2 = mock(RequestRateLimiter.class);
@@ -66,13 +86,19 @@ public class ProduceRateLimitersTest {
 
     expect(countLimitProvider.get()).andReturn(rateLimiterForCount1);
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes1);
+    expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
+    expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
     rateLimiterForCount1.rateLimit(anyInt());
     rateLimiterForBytes1.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
     expect(countLimitProvider.get()).andReturn(rateLimiterForCount2);
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes2);
     rateLimiterForCount2.rateLimit(anyInt());
     rateLimiterForBytes2.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
     replay(
         countLimitProvider,
@@ -80,12 +106,16 @@ public class ProduceRateLimitersTest {
         rateLimiterForCount1,
         rateLimiterForBytes1,
         rateLimiterForCount2,
-        rateLimiterForBytes2);
+        rateLimiterForBytes2,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             countLimitProvider,
             bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
@@ -100,7 +130,9 @@ public class ProduceRateLimitersTest {
         rateLimiterForCount1,
         rateLimiterForBytes1,
         rateLimiterForCount2,
-        rateLimiterForBytes2);
+        rateLimiterForBytes2,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -113,6 +145,8 @@ public class ProduceRateLimitersTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -120,15 +154,26 @@ public class ProduceRateLimitersTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
-    rateLimiterForCount.rateLimit(anyInt());
-    EasyMock.expectLastCall().andThrow(new RateLimitExceededException());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    rateLimiterForCount.rateLimit(anyInt());
+    expectLastCall().andThrow(new RateLimitExceededException());
+
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             countLimitProvider,
             bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
@@ -142,7 +187,13 @@ public class ProduceRateLimitersTest {
 
     assertEquals("The rate limit of requests per second has been exceeded.", e.getMessage());
 
-    verify(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    verify(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -155,6 +206,8 @@ public class ProduceRateLimitersTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -162,16 +215,27 @@ public class ProduceRateLimitersTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
+
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
-    EasyMock.expectLastCall().andThrow(new RateLimitExceededException());
+    expectLastCall().andThrow(new RateLimitExceededException());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             countLimitProvider,
             bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
@@ -185,7 +249,13 @@ public class ProduceRateLimitersTest {
 
     assertEquals("The rate limit of requests per second has been exceeded.", e.getMessage());
 
-    verify(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    verify(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -197,6 +267,8 @@ public class ProduceRateLimitersTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -204,6 +276,8 @@ public class ProduceRateLimitersTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
     // these are called after the delay that will reset the cache
     expect(countLimitProvider.get()).andReturn(rateLimiterForCount);
@@ -211,13 +285,23 @@ public class ProduceRateLimitersTest {
 
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
             countLimitProvider,
             bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
@@ -227,6 +311,123 @@ public class ProduceRateLimitersTest {
     Thread.sleep(50);
     produceRateLimiters.rateLimit("clusterId", 10L);
 
-    verify(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    verify(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
+  }
+
+  @Test
+  @Inject
+  public void globalCountLimitHit() {
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
+    Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter rateLimiterForCount1 = mock(RequestRateLimiter.class);
+    RequestRateLimiter rateLimiterForBytes1 = mock(RequestRateLimiter.class);
+
+    expect(countLimitProvider.get()).andReturn(rateLimiterForCount1);
+    expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes1);
+    rateLimiterForCount1.rateLimit(anyInt());
+    rateLimiterForBytes1.rateLimit(anyInt());
+
+    countLimiterGlobal.rateLimit(anyInt());
+    expectLastCall().andThrow(new RateLimitExceededException());
+
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount1,
+        rateLimiterForBytes1,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
+
+    RateLimitExceededException e =
+        assertThrows(
+            RateLimitExceededException.class,
+            () -> produceRateLimiters.rateLimit("clusterId1", 10L));
+
+    verify(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount1,
+        rateLimiterForBytes1,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
+  }
+
+  @Test
+  @Inject
+  public void globalBytesLimitHit() {
+
+    Properties properties = new Properties();
+    properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
+
+    Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
+    Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter rateLimiterForCount1 = mock(RequestRateLimiter.class);
+    RequestRateLimiter rateLimiterForBytes1 = mock(RequestRateLimiter.class);
+
+    expect(countLimitProvider.get()).andReturn(rateLimiterForCount1);
+    expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes1);
+    rateLimiterForCount1.rateLimit(anyInt());
+    rateLimiterForBytes1.rateLimit(anyInt());
+
+    countLimiterGlobal.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    expectLastCall().andThrow(new RateLimitExceededException());
+
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount1,
+        rateLimiterForBytes1,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
+
+    ProduceRateLimiters produceRateLimiters =
+        new ProduceRateLimiters(
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
+            Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
+            Duration.ofMillis(
+                Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
+
+    RateLimitExceededException e =
+        assertThrows(
+            RateLimitExceededException.class,
+            () -> produceRateLimiters.rateLimit("clusterId1", 10L));
+
+    verify(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount1,
+        rateLimiterForBytes1,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -68,6 +68,8 @@ public class ProduceActionTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -75,12 +77,27 @@ public class ProduceActionTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceAction produceAction =
         getProduceAction(
-            properties, chunkedOutputFactory, 1, countLimitProvider, bytesLimitProvider, true);
+            properties,
+            chunkedOutputFactory,
+            1,
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
+            true);
     MappingIterator<ProduceRequest> requests = getProduceRequestsMappingIteratorWithSchemaNeeded();
 
     // expected results
@@ -123,6 +140,8 @@ public class ProduceActionTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -130,14 +149,28 @@ public class ProduceActionTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceAction produceAction1 =
         getProduceAction(
@@ -145,7 +178,9 @@ public class ProduceActionTest {
             chunkedOutputFactory,
             TOTAL_NUMBER_OF_STREAMING_CALLS,
             countLimitProvider,
-            bytesLimitProvider);
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal);
     MappingIterator<ProduceRequest> requests = getStreamingProduceRequestsMappingIterator(4);
 
     // expected results
@@ -199,6 +234,8 @@ public class ProduceActionTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -206,16 +243,30 @@ public class ProduceActionTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
     EasyMock.expectLastCall().andThrow(new RateLimitExceededException());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceAction produceAction =
         getProduceAction(
-            properties, chunkedOutputFactory, 1, countLimitProvider, bytesLimitProvider);
+            properties,
+            chunkedOutputFactory,
+            1,
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal);
     MappingIterator<ProduceRequest> requests =
         getProduceRequestsMappingIterator(TOTAL_NUMBER_OF_PRODUCE_CALLS);
 
@@ -251,7 +302,9 @@ public class ProduceActionTest {
         countLimitProvider,
         bytesLimitProvider,
         rateLimiterForCount,
-        rateLimiterForBytes);
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -272,6 +325,8 @@ public class ProduceActionTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -279,15 +334,29 @@ public class ProduceActionTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
     rateLimiterForCount.rateLimit(anyInt());
     EasyMock.expectLastCall().andThrow(new RateLimitExceededException());
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceAction produceAction =
         getProduceAction(
-            properties, chunkedOutputFactory, 1, countLimitProvider, bytesLimitProvider);
+            properties,
+            chunkedOutputFactory,
+            1,
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal);
     MappingIterator<ProduceRequest> requests =
         getProduceRequestsMappingIterator(TOTAL_NUMBER_OF_PRODUCE_CALLS);
 
@@ -322,7 +391,9 @@ public class ProduceActionTest {
         countLimitProvider,
         bytesLimitProvider,
         rateLimiterForCount,
-        rateLimiterForBytes);
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -343,14 +414,28 @@ public class ProduceActionTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
-    replay(countLimitProvider, bytesLimitProvider, rateLimiterForCount, rateLimiterForBytes);
+    replay(
+        countLimitProvider,
+        bytesLimitProvider,
+        rateLimiterForCount,
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
 
     ProduceAction produceAction =
         getProduceAction(
-            properties, chunkedOutputFactory, 2, countLimitProvider, bytesLimitProvider);
+            properties,
+            chunkedOutputFactory,
+            2,
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal);
     MappingIterator<ProduceRequest> requests =
         getProduceRequestsMappingIterator(TOTAL_NUMBER_OF_PRODUCE_CALLS);
 
@@ -383,7 +468,9 @@ public class ProduceActionTest {
         countLimitProvider,
         bytesLimitProvider,
         rateLimiterForCount,
-        rateLimiterForBytes);
+        rateLimiterForBytes,
+        countLimiterGlobal,
+        bytesLimiterGlobal);
   }
 
   @Test
@@ -400,6 +487,8 @@ public class ProduceActionTest {
 
     Provider<RequestRateLimiter> countLimitProvider = mock(Provider.class);
     Provider<RequestRateLimiter> bytesLimitProvider = mock(Provider.class);
+    RequestRateLimiter countLimiterGlobal = mock(RequestRateLimiter.class);
+    RequestRateLimiter bytesLimiterGlobal = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForCount = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes = mock(RequestRateLimiter.class);
 
@@ -407,10 +496,18 @@ public class ProduceActionTest {
     expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes);
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
 
     ProduceAction produceAction =
         getProduceAction(
-            properties, chunkedOutputFactory, 1, countLimitProvider, bytesLimitProvider);
+            properties,
+            chunkedOutputFactory,
+            1,
+            countLimitProvider,
+            bytesLimitProvider,
+            countLimiterGlobal,
+            bytesLimiterGlobal);
     MappingIterator<ProduceRequest> requests = null;
 
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
@@ -607,9 +704,18 @@ public class ProduceActionTest {
       ChunkedOutputFactory chunkedOutputFactory,
       int times,
       Provider<RequestRateLimiter> countLimiter,
-      Provider<RequestRateLimiter> bytesLimiter) {
+      Provider<RequestRateLimiter> bytesLimiter,
+      RequestRateLimiter countLimiterGlobal,
+      RequestRateLimiter bytesLimiterGlobal) {
     return getProduceAction(
-        properties, chunkedOutputFactory, times, countLimiter, bytesLimiter, false);
+        properties,
+        chunkedOutputFactory,
+        times,
+        countLimiter,
+        bytesLimiter,
+        countLimiterGlobal,
+        bytesLimiterGlobal,
+        false);
   }
 
   private static ProduceAction getProduceAction(
@@ -618,11 +724,15 @@ public class ProduceActionTest {
       int times,
       Provider<RequestRateLimiter> countLimiter,
       Provider<RequestRateLimiter> bytesLimiter,
+      RequestRateLimiter countLimiterGlobal,
+      RequestRateLimiter bytesLimiterGlobal,
       boolean errorSchemaRegistry) {
     return getProduceAction(
         new ProduceRateLimiters(
             countLimiter,
             bytesLimiter,
+            countLimiterGlobal,
+            bytesLimiterGlobal,
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS)))),


### PR DESCRIPTION
At the moment produce rate limiting is done per clusterId.  This means that if there are lots of clusterIds (as there would be in  MT cluster) then we could swamp the jvm.

This PR adds in a global count and byte rate limiter that will prevent this

The config is set to the same as the per clusterID limiters, so there is no change in behaviour for existing deployments.

I've put the new rate limiters after the existing per clusterId limiters because I think the per cluster ones are more likely to be triggered.