### PR TITLE
KREST-4979 reverse order of produce global rate limiters

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
@@ -66,7 +66,8 @@ public class ProduceRateLimiters {
     if (!rateLimitingEnabled) {
       return;
     }
-    // global rate limit first to reduce CPU usage under load
+    // Global rate limit first to reduce CPU usage under load
+    // https://confluentinc.atlassian.net/browse/KREST-4979
     countLimiterGlobal.get().rateLimit(1);
     bytesLimiterGlobal.get().rateLimit(toIntExact(requestSize));
     RequestRateLimiter countRateLimiter = countCache.getUnchecked(clusterId);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceRateLimiters.java
@@ -66,14 +66,13 @@ public class ProduceRateLimiters {
     if (!rateLimitingEnabled) {
       return;
     }
-
+    // global rate limit first to reduce CPU usage under load
+    countLimiterGlobal.get().rateLimit(1);
+    bytesLimiterGlobal.get().rateLimit(toIntExact(requestSize));
     RequestRateLimiter countRateLimiter = countCache.getUnchecked(clusterId);
     RequestRateLimiter byteRateLimiter = bytesCache.getUnchecked(clusterId);
     countRateLimiter.rateLimit(1);
     byteRateLimiter.rateLimit(toIntExact(requestSize));
-
-    countLimiterGlobal.get().rateLimit(1);
-    bytesLimiterGlobal.get().rateLimit(toIntExact(requestSize));
   }
 
   public void clear() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -167,6 +167,10 @@ public class ProduceRateLimitersTest {
     bytesLimiterGlobal.rateLimit(anyInt());
     countLimiterGlobal.rateLimit(anyInt());
 
+    expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
+    expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     expectLastCall().andThrow(new RateLimitExceededException());
 
@@ -234,6 +238,10 @@ public class ProduceRateLimitersTest {
     bytesLimiterGlobal.rateLimit(anyInt());
     countLimiterGlobal.rateLimit(anyInt());
 
+    expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
+    expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
     expectLastCall().andThrow(new RateLimitExceededException());
@@ -363,12 +371,8 @@ public class ProduceRateLimitersTest {
     RequestRateLimiter rateLimiterForCount1 = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes1 = mock(RequestRateLimiter.class);
 
-    expect(countLimitProvider.get()).andReturn(rateLimiterForCount1);
-    expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes1);
     expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
     expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
-    rateLimiterForCount1.rateLimit(anyInt());
-    rateLimiterForBytes1.rateLimit(anyInt());
 
     countLimiterGlobal.rateLimit(anyInt());
     expectLastCall().andThrow(new RateLimitExceededException());
@@ -424,13 +428,8 @@ public class ProduceRateLimitersTest {
     RequestRateLimiter rateLimiterForCount1 = mock(RequestRateLimiter.class);
     RequestRateLimiter rateLimiterForBytes1 = mock(RequestRateLimiter.class);
 
-    expect(countLimitProvider.get()).andReturn(rateLimiterForCount1);
-    expect(bytesLimitProvider.get()).andReturn(rateLimiterForBytes1);
     expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
     expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
-    rateLimiterForCount1.rateLimit(anyInt());
-    rateLimiterForBytes1.rateLimit(anyInt());
-
     countLimiterGlobal.rateLimit(anyInt());
     bytesLimiterGlobal.rateLimit(anyInt());
     expectLastCall().andThrow(new RateLimitExceededException());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -269,6 +269,10 @@ public class ProduceActionTest {
     bytesLimiterGlobal.rateLimit(anyInt());
     countLimiterGlobal.rateLimit(anyInt());
 
+    expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
+    expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     rateLimiterForBytes.rateLimit(anyInt());
     EasyMock.expectLastCall().andThrow(new RateLimitExceededException());
@@ -366,6 +370,10 @@ public class ProduceActionTest {
     bytesLimiterGlobal.rateLimit(anyInt());
     countLimiterGlobal.rateLimit(anyInt());
 
+    expect(countLimiterGlobalProvider.get()).andReturn(countLimiterGlobal);
+    expect(bytesLimiterGlobalProvider.get()).andReturn(bytesLimiterGlobal);
+    bytesLimiterGlobal.rateLimit(anyInt());
+    countLimiterGlobal.rateLimit(anyInt());
     rateLimiterForCount.rateLimit(anyInt());
     EasyMock.expectLastCall().andThrow(new RateLimitExceededException());
 


### PR DESCRIPTION
Testing showed that putting the global rate limiter first results in reduced CPU load.