### PR TITLE
KREST-5385: Add error_code to produce responses.

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -2061,11 +2061,15 @@ components:
     ProduceResponse:
       type: object
       required:
+        - error_code
         - cluster_id
         - topic_name
         - partition_id
         - offset
       properties:
+        error_code:
+          type: integer
+          format: int32
         cluster_id:
           type: string
         topic_name:
@@ -3623,6 +3627,7 @@ components:
           schema:
             $ref: '#/components/schemas/ProduceResponse'
           example:
+            error_code: 200
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
             partition_id: 1

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1271,10 +1271,10 @@ paths:
         Produce records to the given topic, returning delivery reports for each
                     record produced. This API can be used in streaming mode by setting "Transfer-Encoding:
                     chunked" header. For as long as the connection is kept open, the server will
-                    keep accepting records. For each record sent to the server, the server will
-                    asynchronously send back a delivery report, in the same order. The delivery reports 
-                    each have their own error_code. An error_code of 200 indicates success. Records are
-                    streamed to and from the server as Concatenated JSON. The HTTP status code will be HTTP 
+                    keep accepting records. Records are streamed to and from the server as Concatenated 
+                    JSON. For each record sent to the server, the server will
+                    asynchronously send back a delivery report, in the same order, each with its own
+                    error_code. An error_code of 200 indicates success. The HTTP status code will be HTTP 
                     200 OK as long as the connection is successfully established. To identify records
                     that have encountered an error, check the error_code of each delivery report.
       tags:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1272,9 +1272,11 @@ paths:
                     record produced. This API can be used in streaming mode by setting "Transfer-Encoding:
                     chunked" header. For as long as the connection is kept open, the server will
                     keep accepting records. For each record sent to the server, the server will
-                    asynchronously send back a delivery report, in the same order. Records are
-                    streamed to and from the server as Concatenated JSON. Errors are reported per
-                    record. The HTTP status code will be HTTP 200 OK as long as the connection is successfully established.
+                    asynchronously send back a delivery report, in the same order. The delivery reports 
+                    each have their own error_code. An error_code of 200 indicates success. Records are
+                    streamed to and from the server as Concatenated JSON. The HTTP status code will be HTTP 
+                    200 OK as long as the connection is successfully established. To identify records
+                    that have encountered an error, check the error_code of each delivery report.
       tags:
         - Records
       requestBody:

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ProduceResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ProduceResponse.java
@@ -30,6 +30,9 @@ public abstract class ProduceResponse {
 
   ProduceResponse() {}
 
+  @JsonProperty("error_code")
+  public abstract int getErrorCode();
+
   @JsonProperty("cluster_id")
   public abstract String getClusterId();
 
@@ -56,6 +59,7 @@ public abstract class ProduceResponse {
 
   @JsonCreator
   static ProduceResponse fromJson(
+      @JsonProperty("error_code") int errorCode,
       @JsonProperty("cluster_id") String clusterId,
       @JsonProperty("topic_name") String topicName,
       @JsonProperty("partition_id") int partitionId,
@@ -64,6 +68,7 @@ public abstract class ProduceResponse {
       @JsonProperty("key") @Nullable ProduceResponseData key,
       @JsonProperty("value") @Nullable ProduceResponseData value) {
     return builder()
+        .setErrorCode(errorCode)
         .setClusterId(clusterId)
         .setTopicName(topicName)
         .setPartitionId(partitionId)
@@ -82,6 +87,8 @@ public abstract class ProduceResponse {
   public abstract static class Builder {
 
     Builder() {}
+
+    public abstract Builder setErrorCode(int errorCode);
 
     public abstract Builder setClusterId(String clusterId);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -59,6 +59,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import org.apache.kafka.common.errors.SerializationException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -270,6 +271,7 @@ public final class ProduceAction {
                         .setSchemaVersion(valueSchema.map(RegisteredSchema::getSchemaVersion))
                         .setSize(result.getSerializedValueSize())
                         .build()))
+        .setErrorCode(HttpStatus.OK_200)
         .build();
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import javax.inject.Provider;
 import org.easymock.EasyMock;
+import org.eclipse.jetty.http.HttpStatus;
 import org.glassfish.jersey.server.ChunkedOutput;
 import org.junit.jupiter.api.Test;
 
@@ -707,6 +708,7 @@ public class ProduceActionTest {
         .setPartitionId(partitionId)
         .setOffset(offset)
         .setTimestamp(Instant.ofEpochMilli(0))
+        .setErrorCode(HttpStatus.OK_200)
         .build();
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
@@ -16,6 +16,7 @@ import io.confluent.kafkarest.response.StreamingResponse.ResultOrError;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.easymock.EasyMock;
+import org.eclipse.jetty.http.HttpStatus;
 import org.glassfish.jersey.server.ChunkedOutput;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +59,7 @@ public class StreamingResponseTest {
             .setTopicName("topicName")
             .setPartitionId(1)
             .setOffset(1L)
+            .setErrorCode(HttpStatus.OK_200)
             .build();
 
     ResultOrError resultOrError = ResultOrError.result(produceResponse);
@@ -122,6 +124,7 @@ public class StreamingResponseTest {
             .setTopicName("topicName")
             .setPartitionId(1)
             .setOffset(1L)
+            .setErrorCode(HttpStatus.ACCEPTED_202)
             .build();
     ResultOrError resultOrError = ResultOrError.result(produceResponse);
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
@@ -124,7 +124,7 @@ public class StreamingResponseTest {
             .setTopicName("topicName")
             .setPartitionId(1)
             .setOffset(1L)
-            .setErrorCode(HttpStatus.ACCEPTED_202)
+            .setErrorCode(HttpStatus.OK_200)
             .build();
     ResultOrError resultOrError = ResultOrError.result(produceResponse);
 


### PR DESCRIPTION
Before this change, produce responses did not include an http status code if they were successful, only for error responses

This meant that code generated to match the openapi spec can't easily differentiate between a success and a failure response.

Ideally we'd have added in a status_code for success and failure cases, but there is an existing ErrorResponse that is used by all existing endpoints, and it seems overkill (and probably not the right thing to do for consistency) to put in place custom error handling for produce only, with a different structure

Also, using status_code implies real http statuses, whereas error_code gives us the freedom to use the more detailed 5 digit responses.

The response for a successful produce now looks like

{"error_code":200,"cluster_id":"nHQfD6V7Q_K29guDHiLdpw","topic_name":"summit","partition_id":0,"offset":6,"timestamp":"2022-04-22T14:48:47.650Z","value":{"type":"JSON","size":30}}

The error code is at the beginning to match what we do for the error response.

I thought about having a null error code response, but I think an explicit value is clearer.