### PR TITLE
Remove all compiler warnings from kafka-rest.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -82,7 +82,7 @@ public class KafkaRestConfig extends RestConfig {
   // ensures poll is frequently needed and called
   public static final String MAX_POLL_RECORDS_VALUE = "30";
 
-  @Deprecated public static final String HOST_NAME_CONFIG = "host.name";
+  public static final String HOST_NAME_CONFIG = "host.name";
   private static final String HOST_NAME_DOC =
       "The host name used to generate absolute URLs in responses. If empty, the default canonical"
           + " hostname is used";
@@ -269,9 +269,7 @@ public class KafkaRestConfig extends RestConfig {
           + " Use 0 for no timeout";
   public static final String SIMPLE_CONSUMER_POOL_TIMEOUT_MS_DEFAULT = "1000";
 
-  // TODO: change this to "http://0.0.0.0:8082" when PORT_CONFIG is deleted.
-  private static final String KAFKAREST_LISTENERS_DEFAULT = "";
-  @Deprecated private static final int KAFKAREST_PORT_DEFAULT = 8082;
+  private static final String KAFKAREST_LISTENERS_DEFAULT = "http://0.0.0.0:8082";
 
   public static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.rest";
 
@@ -461,7 +459,7 @@ public class KafkaRestConfig extends RestConfig {
 
   protected static ConfigDef baseKafkaRestConfigDef() {
     return baseConfigDef(
-            KAFKAREST_PORT_DEFAULT,
+            0 /* port */,
             KAFKAREST_LISTENERS_DEFAULT,
             String.join(",", Versions.PREFERRED_RESPONSE_TYPES),
             MediaType.APPLICATION_JSON,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/UriUtils.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/UriUtils.java
@@ -26,14 +26,9 @@ public class UriUtils {
 
   public static String absoluteUri(KafkaRestConfig config, UriInfo uriInfo, String... components) {
     List<URI> advertisedListeners;
-    List<URI> listeners;
     try {
       advertisedListeners =
           config.getList(KafkaRestConfig.ADVERTISED_LISTENERS_CONFIG).stream()
-              .map(URI::create)
-              .collect(Collectors.toList());
-      listeners =
-          config.getList(KafkaRestConfig.LISTENERS_CONFIG).stream()
               .map(URI::create)
               .collect(Collectors.toList());
     } catch (IllegalArgumentException e) {
@@ -41,11 +36,7 @@ public class UriUtils {
     }
 
     return new UrlFactoryImpl(
-            config.getString(KafkaRestConfig.HOST_NAME_CONFIG),
-            config.getInt(KafkaRestConfig.PORT_CONFIG),
-            advertisedListeners,
-            listeners,
-            uriInfo)
+            advertisedListeners, config.getString(KafkaRestConfig.HOST_NAME_CONFIG), uriInfo)
         .create(components);
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -101,8 +101,6 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new MaxSchemasPerSubjectConfigImpl())
         .to(Integer.class);
 
-    bind(config.getInt(RestConfig.PORT_CONFIG)).qualifiedBy(new PortConfigImpl()).to(Integer.class);
-
     bind(config.getInt(KafkaRestConfig.PRODUCE_MAX_BYTES_PER_SECOND))
         .qualifiedBy(new ProduceRateLimitBytesConfigImpl())
         .to(Integer.class);
@@ -223,7 +221,6 @@ public final class ConfigModule extends AbstractBinder {
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
-  @Deprecated
   public @interface HostNameConfig {}
 
   private static final class HostNameConfigImpl extends AnnotationLiteral<HostNameConfig>
@@ -261,15 +258,6 @@ public final class ConfigModule extends AbstractBinder {
 
   private static final class MaxSchemasPerSubjectConfigImpl
       extends AnnotationLiteral<MaxSchemasPerSubjectConfig> implements MaxSchemasPerSubjectConfig {}
-
-  @Qualifier
-  @Retention(RetentionPolicy.RUNTIME)
-  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
-  @Deprecated
-  public @interface PortConfig {}
-
-  private static final class PortConfigImpl extends AnnotationLiteral<PortConfig>
-      implements PortConfig {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
@@ -81,13 +81,13 @@ final class ReplicaManagerImpl implements ReplicaManager {
               DescribeLogDirsResult result =
                   adminClient.describeLogDirs(
                       singletonList(brokerId), new DescribeLogDirsOptions());
-              return KafkaFutures.toCompletableFuture(result.values().get(brokerId));
+              return KafkaFutures.toCompletableFuture(result.descriptions().get(brokerId));
             })
         .thenCompose(
             logDirs ->
                 CompletableFutures.allAsList(
                     logDirs.values().stream()
-                        .flatMap(logDir -> logDir.replicaInfos.keySet().stream())
+                        .flatMap(logDir -> logDir.replicaInfos().keySet().stream())
                         .map(
                             partition ->
                                 getReplica(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -151,7 +151,7 @@ final class TopicManagerImpl implements TopicManager {
                     topicNames,
                     new DescribeTopicsOptions()
                         .includeAuthorizedOperations(includeAuthorizedOperations))
-                .all())
+                .allTopicNames())
         .thenApply(
             topics ->
                 topics.values().stream()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/UrlFactoryImpl.java
@@ -17,12 +17,8 @@ package io.confluent.kafkarest.response;
 
 import io.confluent.kafkarest.config.ConfigModule.AdvertisedListenersConfig;
 import io.confluent.kafkarest.config.ConfigModule.HostNameConfig;
-import io.confluent.kafkarest.config.ConfigModule.ListenersConfig;
-import io.confluent.kafkarest.config.ConfigModule.PortConfig;
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
@@ -35,14 +31,10 @@ public final class UrlFactoryImpl implements UrlFactory {
 
   @Inject
   public UrlFactoryImpl(
-      @HostNameConfig String hostNameConfig,
-      @PortConfig Integer portConfig,
       @AdvertisedListenersConfig List<URI> advertisedListenersConfig,
-      @ListenersConfig List<URI> listenersConfig,
+      @HostNameConfig String hostNameConfig,
       @Context UriInfo requestUriInfo) {
-    baseUrl =
-        computeBaseUrl(
-            hostNameConfig, portConfig, advertisedListenersConfig, listenersConfig, requestUriInfo);
+    baseUrl = computeBaseUrl(advertisedListenersConfig, hostNameConfig, requestUriInfo);
   }
 
   @Override
@@ -63,15 +55,9 @@ public final class UrlFactoryImpl implements UrlFactory {
   }
 
   private static String computeBaseUrl(
-      String hostNameConfig,
-      Integer portConfig,
-      List<URI> advertisedListenersConfig,
-      List<URI> listenersConfig,
-      UriInfo requestUriInfo) {
+      List<URI> advertisedListenersConfig, String hostNameConfig, UriInfo requestUriInfo) {
     String scheme = computeScheme(requestUriInfo);
-    String authority =
-        computeAuthority(
-            hostNameConfig, portConfig, advertisedListenersConfig, listenersConfig, requestUriInfo);
+    String authority = computeAuthority(advertisedListenersConfig, hostNameConfig, requestUriInfo);
     String basePath = computeBasePath(requestUriInfo);
 
     StringBuilder baseUrl = new StringBuilder(scheme).append("://").append(authority);
@@ -87,53 +73,21 @@ public final class UrlFactoryImpl implements UrlFactory {
   }
 
   private static String computeAuthority(
-      String hostNameConfig,
-      Integer portConfig,
-      List<URI> advertisedListenersConfig,
-      List<URI> listenersConfig,
-      UriInfo requestUriInfo) {
-    return Stream.of(
-            computeAuthorityFromAdvertisedListeners(advertisedListenersConfig, requestUriInfo),
-            computeAuthorityFromHostNameAndPort(
-                hostNameConfig, portConfig, listenersConfig, requestUriInfo))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .findFirst()
-        .orElse(requestUriInfo.getAbsolutePath().getAuthority());
-  }
-
-  private static Optional<String> computeAuthorityFromAdvertisedListeners(
-      List<URI> advertisedListenersConfig, UriInfo requestUriInfo) {
+      List<URI> advertisedListenersConfig, String hostNameConfig, UriInfo requestUriInfo) {
     String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
+
     for (URI listener : advertisedListenersConfig) {
       if (requestScheme.equals(listener.getScheme())) {
-        return Optional.of(listener.getAuthority());
-      }
-    }
-    return Optional.empty();
-  }
-
-  private static Optional<String> computeAuthorityFromHostNameAndPort(
-      String hostNameConfig,
-      Integer portConfig,
-      List<URI> listenersConfig,
-      UriInfo requestUriInfo) {
-    String requestScheme = requestUriInfo.getAbsolutePath().getScheme();
-    if (hostNameConfig == null || hostNameConfig.isEmpty()) {
-      return Optional.empty();
-    }
-
-    int port = -1;
-    if (requestUriInfo.getAbsolutePath().getPort() != -1) {
-      port = portConfig;
-      for (URI listener : listenersConfig) {
-        if (requestScheme.equals(listener.getScheme())) {
-          port = listener.getPort();
-        }
+        return listener.getAuthority();
       }
     }
 
-    return Optional.of(String.format("%s%s", hostNameConfig, port != -1 ? ":" + port : ""));
+    if (hostNameConfig != null && !hostNameConfig.isEmpty()) {
+      int port = requestUriInfo.getBaseUri().getPort();
+      return hostNameConfig + (port > 0 ? (":" + port) : "");
+    }
+
+    return requestUriInfo.getBaseUri().getAuthority();
   }
 
   private static String computeBasePath(UriInfo requestUriInfo) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/BinaryKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/BinaryKafkaConsumerState.java
@@ -34,7 +34,7 @@ public class BinaryKafkaConsumerState
       KafkaRestConfig config,
       ConsumerInstanceConfig consumerInstanceConfig,
       ConsumerInstanceId instanceId,
-      Consumer consumer) {
+      Consumer<byte[], byte[]> consumer) {
     super(config, consumerInstanceConfig, instanceId, consumer);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/JsonKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/JsonKafkaConsumerState.java
@@ -32,7 +32,7 @@ public class JsonKafkaConsumerState extends KafkaConsumerState<byte[], byte[], O
       KafkaRestConfig config,
       ConsumerInstanceConfig consumerInstanceConfig,
       ConsumerInstanceId instanceId,
-      Consumer consumer) {
+      Consumer<byte[], byte[]> consumer) {
     super(config, consumerInstanceConfig, instanceId, consumer);
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/SchemaKafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/SchemaKafkaConsumerState.java
@@ -37,7 +37,7 @@ public final class SchemaKafkaConsumerState
       KafkaRestConfig config,
       ConsumerInstanceConfig consumerInstanceConfig,
       ConsumerInstanceId instanceId,
-      Consumer consumer,
+      Consumer<Object, Object> consumer,
       SchemaConverter schemaConverter) {
     super(config, consumerInstanceConfig, instanceId, consumer);
     this.schemaConverter = schemaConverter;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ReplicaManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ReplicaManagerImplTest.java
@@ -39,10 +39,10 @@ import java.util.concurrent.ExecutionException;
 import javax.ws.rs.NotFoundException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo;
-import org.apache.kafka.common.requests.DescribeLogDirsResponse.ReplicaInfo;
 import org.easymock.EasyMockExtension;
 import org.easymock.Mock;
 import org.junit.jupiter.api.BeforeEach;
@@ -236,12 +236,12 @@ public class ReplicaManagerImplTest {
         .andReturn(completedFuture(Optional.of(BROKER_1)));
     expect(adminClient.describeLogDirs(eq(singletonList(BROKER_ID_1)), anyObject()))
         .andReturn(describeLogDirsResult);
-    expect(describeLogDirsResult.values())
+    expect(describeLogDirsResult.descriptions())
         .andReturn(
             singletonMap(
                 BROKER_ID_1,
                 KafkaFuture.completedFuture(
-                    singletonMap(TOPIC_NAME, new LogDirInfo(null, partitions)))));
+                    singletonMap(TOPIC_NAME, new LogDirDescription(null, partitions)))));
     expect(partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_ID_1))
         .andReturn(completedFuture(Optional.of(PARTITION_1)));
     expect(partitionManager.getPartition(CLUSTER_ID, TOPIC_NAME, PARTITION_ID_2))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceAvroProduceTest.java
@@ -94,8 +94,8 @@ public class TopicsResourceAvroProduceTest
   private static final TopicPartition PARTITION = new TopicPartition(TOPIC_NAME, 0);
   private final List<RecordMetadata> PRODUCE_RESULTS =
       Arrays.asList(
-          new RecordMetadata(PARTITION, 0L, 0L, 0L, 0L, 1, 1),
-          new RecordMetadata(PARTITION, 0L, 1L, 0L, 0L, 1, 1));
+          new RecordMetadata(PARTITION, 0L, 0, 0L, 1, 1),
+          new RecordMetadata(PARTITION, 0L, 1, 0L, 1, 1));
   private static final List<PartitionOffset> OFFSETS =
       Arrays.asList(new PartitionOffset(0, 0L, null, null), new PartitionOffset(0, 1L, null, null));
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
@@ -97,8 +97,8 @@ public class TopicsResourceBinaryProduceTest
   private static final TopicPartition PARTITION = new TopicPartition(TOPIC_NAME, 0);
   private static final List<CompletableFuture<RecordMetadata>> PRODUCE_RESULTS =
       Arrays.asList(
-          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 0L, 0L, 0L, 1, 1)),
-          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 1L, 0L, 0L, 1, 1)));
+          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 0, 0L, 1, 1)),
+          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 1, 0L, 1, 1)));
   private static final List<PartitionOffset> OFFSETS =
       Arrays.asList(new PartitionOffset(0, 0L, null, null), new PartitionOffset(0, 1L, null, null));
   private static final List<ProduceRecord> PRODUCE_EXCEPTION_DATA =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/UrlFactoryImplTest.java
@@ -34,136 +34,32 @@ public class UrlFactoryImplTest {
   @Mock private UriInfo requestUriInfo;
 
   @Test
-  public void create_withHostNameAndPortConfig_returnsUrlRelativeToHostNameAndPortConfig() {
+  public void create_withoutAdvertisedListenersAndHostNameConfigs_returnsUrlRelativeToRequestUri() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    expect(requestUriInfo.getBaseUri()).andStubReturn(URI.create("http://1.2.3.4:1000/"));
     replay(requestUriInfo);
 
     UrlFactory urlFactory =
-        new UrlFactoryImpl("hostname", 2000, emptyList(), emptyList(), requestUriInfo);
+        new UrlFactoryImpl(
+            /* advertisedListenersConfig= */ emptyList(), /* hostNameConfig= */ "", requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
 
-    assertEquals("http://hostname:2000/foo/bar", url);
+    assertEquals("http://1.2.3.4:1000/foo/bar", url);
   }
 
   @Test
   public void
-      create_withAdvertisedListenerSameScheme_returnsUrlRelativeToAdvertisedListenerSameScheme() {
+      create_withoutAdvertisedListenersAndHostNameConfigs_returnsUrlRelativeToRequestUriAndBasePath() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    expect(requestUriInfo.getBaseUri()).andStubReturn(URI.create("http://1.2.3.4:1000/xxx/"));
     replay(requestUriInfo);
 
     UrlFactory urlFactory =
         new UrlFactoryImpl(
-            /* hostNameConfig= */ "",
-            /* portConfig= */ 0,
-            singletonList(URI.create("http://advertised.listener:2000")),
-            singletonList(URI.create("http://listener:3000")),
-            requestUriInfo);
-
-    String url = urlFactory.create("foo", "bar");
-
-    assertEquals("http://advertised.listener:2000/foo/bar", url);
-  }
-
-  @Test
-  public void
-      create_withAdvertisedListenerDifferentSchemeAndListenerSameScheme_returnsUrlRelativeToRequestUri() {
-    expect(requestUriInfo.getAbsolutePath())
-        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
-    replay(requestUriInfo);
-
-    UrlFactory urlFactory =
-        new UrlFactoryImpl(
-            /* hostNameConfig= */ "",
-            /* portConfig= */ 0,
-            singletonList(URI.create("https://advertised.listener:2000")),
-            singletonList(URI.create("http://listener:3000")),
-            requestUriInfo);
-
-    String url = urlFactory.create("foo", "bar");
-
-    assertEquals("http://1.2.3.4:1000/foo/bar", url);
-  }
-
-  @Test
-  public void create_withListenerSameScheme_returnsUrlRelativeToRequestUri() {
-    expect(requestUriInfo.getAbsolutePath())
-        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
-    replay(requestUriInfo);
-
-    UrlFactory urlFactory =
-        new UrlFactoryImpl(
-            /* hostNameConfig= */ "",
-            /* portConfig= */ 0,
-            /* advertisedListeners= */ emptyList(),
-            singletonList(URI.create("http://listener:2000")),
-            requestUriInfo);
-
-    String url = urlFactory.create("foo", "bar");
-
-    assertEquals("http://1.2.3.4:1000/foo/bar", url);
-  }
-
-  @Test
-  public void create_withListenerDifferentScheme_returnsUrlRelativeToRequestUri() {
-    expect(requestUriInfo.getAbsolutePath())
-        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
-    replay(requestUriInfo);
-
-    UrlFactory urlFactory =
-        new UrlFactoryImpl(
-            /* hostNameConfig= */ "",
-            /* portConfig= */ 0,
-            /* advertisedListeners= */ emptyList(),
-            singletonList(URI.create("https://listener:2000")),
-            requestUriInfo);
-
-    String url = urlFactory.create("foo", "bar");
-
-    assertEquals("http://1.2.3.4:1000/foo/bar", url);
-  }
-
-  @Test
-  public void create_withoutListeners_returnsUrlRelativeToRequestUri() {
-    expect(requestUriInfo.getAbsolutePath())
-        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
-    replay(requestUriInfo);
-
-    UrlFactory urlFactory =
-        new UrlFactoryImpl(
-            /* hostNameConfig= */ "",
-            /* portConfig= */ 0,
-            /* advertisedListeners= */ emptyList(),
-            /* listeners= */ emptyList(),
-            requestUriInfo);
-
-    String url = urlFactory.create("foo", "bar");
-
-    assertEquals("http://1.2.3.4:1000/foo/bar", url);
-  }
-
-  @Test
-  public void create_withoutListenersAndWithBasePath_returnsUrlRelativeToRequestUriAndBasePath() {
-    expect(requestUriInfo.getAbsolutePath())
-        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/xxx/"));
-    replay(requestUriInfo);
-
-    UrlFactory urlFactory =
-        new UrlFactoryImpl(
-            /* hostNameConfig= */ "",
-            /* portConfig= */ 0,
-            /* advertisedListeners= */ emptyList(),
-            /* listeners= */ emptyList(),
-            requestUriInfo);
+            /* advertisedListenersConfig= */ emptyList(), /* hostNameConfig= */ "", requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
 
@@ -171,7 +67,24 @@ public class UrlFactoryImplTest {
   }
 
   @Test
-  public void testCreateHostAndAdvertisedListenerReturnsRelativeToAdvertisedListener() {
+  public void create_withHostNameConfig_returnsUrlRelativeToHostNameConfig() {
+    expect(requestUriInfo.getAbsolutePath())
+        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
+    expect(requestUriInfo.getBaseUri()).andStubReturn(URI.create("http://1.2.3.4:1000/"));
+    replay(requestUriInfo);
+
+    UrlFactory urlFactory =
+        new UrlFactoryImpl(
+            /* advertisedListenersConfig= */ emptyList(), "hostname", requestUriInfo);
+
+    String url = urlFactory.create("foo", "bar");
+
+    assertEquals("http://hostname:1000/foo/bar", url);
+  }
+
+  @Test
+  public void
+      create_withAdvertisedListenersConfigSameScheme_returnsUrlRelativeToAdvertisedListenerSameScheme() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
     expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
@@ -179,10 +92,8 @@ public class UrlFactoryImplTest {
 
     UrlFactory urlFactory =
         new UrlFactoryImpl(
-            "hostname",
-            2000,
             singletonList(URI.create("http://advertised.listener:2000")),
-            emptyList(),
+            /* hostNameConfig= */ "",
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -191,58 +102,35 @@ public class UrlFactoryImplTest {
   }
 
   @Test
-  public void testCreateHostAndListenerReturnsRelativeToListener() {
+  public void create_withAdvertisedListenersConfigDifferentScheme_returnsUrlRelativeToRequestUri() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    expect(requestUriInfo.getBaseUri()).andStubReturn(URI.create("http://1.2.3.4:1000/"));
     replay(requestUriInfo);
 
     UrlFactory urlFactory =
         new UrlFactoryImpl(
-            "hostname",
-            2000,
-            emptyList(),
-            singletonList(URI.create("http://listener:2000")),
+            singletonList(URI.create("https://advertised.listener:2000")),
+            /* hostNameConfig= */ "",
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
 
-    assertEquals("http://hostname:2000/foo/bar", url);
+    assertEquals("http://1.2.3.4:1000/foo/bar", url);
   }
 
   @Test
-  public void testCreateAdvertisedListenerAndListenerReturnsRelativeToAdvertisedListener() {
+  public void
+      create_withHostNameAndAdvertisedListenerConfigs_returnsRelativeToAdvertisedListener() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    expect(requestUriInfo.getBaseUri()).andStubReturn(URI.create("http://1.2.3.4:1000/"));
     replay(requestUriInfo);
 
     UrlFactory urlFactory =
         new UrlFactoryImpl(
-            "",
-            0,
             singletonList(URI.create("http://advertised.listener:2000")),
-            singletonList(URI.create("http://listener:2000")),
-            requestUriInfo);
-
-    String url = urlFactory.create("foo", "bar");
-
-    assertEquals("http://advertised.listener:2000/foo/bar", url);
-  }
-
-  @Test
-  public void testCreateHostAdvertisedListenerAndListenerReturnsRelativeToAdvertisedListener() {
-    expect(requestUriInfo.getAbsolutePath())
-        .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
-    replay(requestUriInfo);
-
-    UrlFactory urlFactory =
-        new UrlFactoryImpl(
             "hostname",
-            2000,
-            singletonList(URI.create("http://advertised.listener:2000")),
-            singletonList(URI.create("http://listener:2000")),
             requestUriInfo);
 
     String url = urlFactory.create("foo", "bar");
@@ -254,11 +142,12 @@ public class UrlFactoryImplTest {
   public void urlBuilder_urlEncodesQueryParamValues() {
     expect(requestUriInfo.getAbsolutePath())
         .andStubReturn(URI.create("http://1.2.3.4:1000/xxx/yyy"));
-    expect(requestUriInfo.getBaseUri()).andReturn(URI.create("http://1.2.3.4:1000/"));
+    expect(requestUriInfo.getBaseUri()).andStubReturn(URI.create("http://1.2.3.4:1000/"));
     replay(requestUriInfo);
 
     UrlFactory urlFactory =
-        new UrlFactoryImpl("hostname", 2000, emptyList(), emptyList(), requestUriInfo);
+        new UrlFactoryImpl(
+            /* advertisedListenersConfig= */ emptyList(), "hostname", requestUriInfo);
     UrlBuilder urlBuilder = urlFactory.newUrlBuilder();
 
     String url =
@@ -268,6 +157,6 @@ public class UrlFactoryImplTest {
             .putQueryParameter("foz", "b!a@z")
             .build();
 
-    assertEquals("http://hostname:2000/foobar?foo=b+a+r&foz=b%21a%40z", url);
+    assertEquals("http://hostname:1000/foobar?foo=b+a+r&foz=b%21a%40z", url);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AvroConverterTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/AvroConverterTest.java
@@ -162,7 +162,7 @@ public class AvroConverterTest {
   @Test
   public void testArrayToJson() {
     GenericData.Array<String> data =
-        new GenericData.Array(arraySchema, Arrays.asList("one", "two", "three"));
+        new GenericData.Array<>(arraySchema, Arrays.asList("one", "two", "three"));
     AvroConverter.JsonNodeAndSize result = new AvroConverter().toJson(data);
     assertTrue(result.getSize() > 0);
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/unit/UriUtilsTest.java
@@ -41,7 +41,7 @@ public class UriUtilsTest {
   public void testAbsoluteURIBuilderDefaultHost() {
     KafkaRestConfig config = new KafkaRestConfig();
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("http://foo.com"));
     EasyMock.replay(uriInfo);
     assertEquals("http://foo.com", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
@@ -53,33 +53,20 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
     KafkaRestConfig config = new KafkaRestConfig(props);
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("http://foo.com"));
     EasyMock.replay(uriInfo);
     assertEquals("http://bar.net", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
   }
 
   @Test
-  public void testAbsoluteURIBuilderWithPort() {
+  public void testAbsoluteURIBuilderWithInvalidAdvertisedListeners() {
     Properties props = new Properties();
     props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
-    props.put(KafkaRestConfig.PORT_CONFIG, 5000);
-    KafkaRestConfig config = new KafkaRestConfig(props);
-    EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:5000"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:5000"));
-    EasyMock.replay(uriInfo);
-    assertEquals("http://bar.net:5000", UriUtils.absoluteUri(config, uriInfo));
-    EasyMock.verify(uriInfo);
-  }
-
-  @Test
-  public void testAbsoluteURIBuilderWithInvalidListener() {
-    Properties props = new Properties();
-    props.put(KafkaRestConfig.HOST_NAME_CONFIG, "bar.net");
-    props.put(KafkaRestConfig.LISTENERS_CONFIG, "http:||0.0.0.0:9091");
+    props.put(KafkaRestConfig.ADVERTISED_LISTENERS_CONFIG, "http:||0.0.0.0:9091");
     KafkaRestConfig config = new KafkaRestConfig(props);
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9091"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9091"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("http://foo.com:9091"));
     EasyMock.replay(uriInfo);
 
     assertThrows(ConfigException.class, () -> UriUtils.absoluteUri(config, uriInfo));
@@ -92,7 +79,7 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:9091,https://0.0.0.0:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9091"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9091"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("http://foo.com:9091"));
     EasyMock.replay(uriInfo);
     assertEquals("http://bar.net:9091", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
@@ -105,7 +92,7 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:9091,https://0.0.0.0:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("https://foo.com:9092"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("https://foo.com:9092"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("https://foo.com:9092"));
     EasyMock.replay(uriInfo);
     assertEquals("https://bar.net:9092", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
@@ -118,7 +105,7 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://[fe80:0:1:2:3:4:5:6]:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9092"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9092"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("http://foo.com:9092"));
     EasyMock.replay(uriInfo);
     assertEquals("http://bar.net:9092", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);
@@ -131,7 +118,7 @@ public class UriUtilsTest {
     props.put(KafkaRestConfig.LISTENERS_CONFIG, "http://[fe80::1]:9092");
     KafkaRestConfig config = new KafkaRestConfig(props);
     EasyMock.expect(uriInfo.getAbsolutePath()).andStubReturn(URI.create("http://foo.com:9092"));
-    EasyMock.expect(uriInfo.getBaseUri()).andReturn(URI.create("http://foo.com:9092"));
+    EasyMock.expect(uriInfo.getBaseUri()).andStubReturn(URI.create("http://foo.com:9092"));
     EasyMock.replay(uriInfo);
     assertEquals("http://bar.net:9092", UriUtils.absoluteUri(config, uriInfo));
     EasyMock.verify(uriInfo);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/LoadTest.java
@@ -67,30 +67,31 @@ public class LoadTest {
   private Random random = new Random();
 
   class ConsumerTestRun {
-    private final MockConsumer consumer;
+    private final MockConsumer<byte[], byte[]> consumer;
     private final Time time;
     private ReentrantLock lock = new ReentrantLock();
     private Condition cond = lock.newCondition();
     private volatile boolean sawCallback = false;
-    private volatile List<ConsumerRecord<byte[], byte[]>> actualRecords = null;
+    private volatile List<ConsumerRecord<ByteString, ByteString>> actualRecords = null;
     private volatile Exception actualException;
-    private ConsumerReadCallback callback;
+    private ConsumerReadCallback<ByteString, ByteString> callback;
     private int latestOffset = 0;
     private long readStartMs;
 
-    ConsumerTestRun(MockConsumer consumer) {
+    ConsumerTestRun(MockConsumer<byte[], byte[]> consumer) {
       this(consumer, new SystemTime());
     }
 
-    ConsumerTestRun(MockConsumer consumer, Time time) {
+    ConsumerTestRun(MockConsumer<byte[], byte[]> consumer, Time time) {
       this.consumer = consumer;
       this.time = time;
       this.readStartMs = Integer.MAX_VALUE;
       sawCallback = false;
       callback =
-          new ConsumerReadCallback<byte[], byte[]>() {
+          new ConsumerReadCallback<ByteString, ByteString>() {
             @Override
-            public void onCompletion(List<ConsumerRecord<byte[], byte[]>> records, Exception e) {
+            public void onCompletion(
+                List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
               lock.lock();
               try {
                 sawCallback = true;
@@ -212,7 +213,8 @@ public class LoadTest {
     }
     capturedConsumerConfig = Capture.newInstance();
     Properties properties = EasyMock.capture(capturedConsumerConfig);
-    IExpectationSetters<Consumer> a = EasyMock.expect(consumerFactory.createConsumer(properties));
+    IExpectationSetters<Consumer<byte[], byte[]>> a =
+        EasyMock.expect(consumerFactory.createConsumer(properties));
     Method andReturnInstance = a.getClass().getMethod("andReturn", Object.class);
     for (ConsumerTestRun run : consumers) {
       andReturnInstance.invoke(a, run.consumer);


### PR DESCRIPTION
All the compiler warnings are due to either raw generic type usage or deprecated methods.

There are two changes in behaviour in kafka-rest:

 * `port` config is gone. That changes a bit how we create URLs to return back on responses (Consumer V2 API and V3 APIs). The preference now is 1) `advertised.listeners` (if same scheme as `<request scheme>`), 2) `host.name`:`<request port>` and 3) `<request host>`:`<request port>`. `port` has been deprecated since forever, so the change in behaviour is fine.
 * It used to be that we didn't block on consumer poll calls to Kafka. This behaviour is now deprecated in the consumer, so we now block at most for the remaining time of the timeout. I don't expect this to have any changes in external behaviour, but you never know.