### PR TITLE
KREST-5637 Add count based byte metrics and move tracking earlier

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -140,6 +140,8 @@ public final class ProduceAction {
       throw new StacklessCompletionException(e);
     }
 
+    recordRequestMetrics(request.getOriginalSize());
+
     Instant requestInstant = Instant.now();
     Optional<RegisteredSchema> keySchema =
         request.getKey().flatMap(key -> getSchema(topicName, /* isKey= */ true, key));
@@ -158,8 +160,6 @@ public final class ProduceAction {
             .orElse(request.getValue().flatMap(ProduceRequestData::getFormat));
     Optional<ByteString> serializedValue =
         serialize(topicName, valueFormat, valueSchema, request.getValue(), /* isKey= */ false);
-
-    recordRequestMetrics(request.getOriginalSize());
 
     CompletableFuture<ProduceResult> produceResult =
         controller.produce(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -140,6 +140,8 @@ public final class ProduceAction {
       throw new StacklessCompletionException(e);
     }
 
+    // Request metrics are recorded before we check the validity of the message body, but after
+    // rate limiting, as these metrics are used for billing.
     recordRequestMetrics(request.getOriginalSize());
 
     Instant requestInstant = Instant.now();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
@@ -70,7 +70,7 @@ final class ProducerMetrics {
 
   static final String REQUEST_SIZE_WINDOWED_SUM_METRIC_NAME = "request-size-windowed-sum";
   private static final String REQUEST_SIZE_WINDOWED_SUM_METRIC_DOC =
-      "The windowed sum of request sizes in bytes.";
+      "The summed size in bytes of requests sent within the given window";
 
   static final String REQUEST_COUNT_WINDOWED_METRIC_NAME = "request-count-windowed";
   private static final String REQUEST_COUNT_WINDOWED_METRIC_DOC =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.metrics.stats.Percentile;
 import org.apache.kafka.common.metrics.stats.Percentiles;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
+import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +67,10 @@ final class ProducerMetrics {
 
   static final String REQUEST_SIZE_AVG_METRIC_NAME = "request-size-avg";
   private static final String REQUEST_SIZE_AVG_METRIC_DOC = "The average request size in bytes.";
+
+  static final String REQUEST_SIZE_WINDOWED_SUM_METRIC_NAME = "request-size-windowed-sum";
+  private static final String REQUEST_SIZE_WINDOWED_SUM_METRIC_DOC =
+      "The windowed sum of request sizes in bytes.";
 
   static final String REQUEST_COUNT_WINDOWED_METRIC_NAME = "request-count-windowed";
   private static final String REQUEST_COUNT_WINDOWED_METRIC_DOC =
@@ -155,6 +160,10 @@ final class ProducerMetrics {
   private void setupRequestSizeSensor() {
     Sensor requestSizeSensor = createSensor(REQUEST_SIZE_SENSOR_NAME);
     addAvg(requestSizeSensor, REQUEST_SIZE_AVG_METRIC_NAME, REQUEST_SIZE_AVG_METRIC_DOC);
+    addWindowedSum(
+        requestSizeSensor,
+        REQUEST_SIZE_WINDOWED_SUM_METRIC_NAME,
+        REQUEST_SIZE_WINDOWED_SUM_METRIC_DOC);
   }
 
   private void setupResponseSensor() {
@@ -205,6 +214,10 @@ final class ProducerMetrics {
 
   private void addWindowedCount(Sensor sensor, String name, String doc) {
     sensor.add(getMetricName(name, doc), new WindowedCount());
+  }
+
+  private void addWindowedSum(Sensor sensor, String name, String doc) {
+    sensor.add(getMetricName(name, doc), new WindowedSum());
   }
 
   private void addPercentiles(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
@@ -152,4 +152,23 @@ public class ProducerMetricsTest {
       assertEquals(10.0, mBeanServer.getAttribute(beanNames.iterator().next(), metric));
     }
   }
+
+  @Test
+  public void testWindowedSumMetrics() throws Exception {
+    String[] maxMetrics = new String[] {ProducerMetrics.REQUEST_SIZE_WINDOWED_SUM_METRIC_NAME};
+
+    IntStream.range(0, 10)
+        .forEach(
+            n -> {
+              metrics.recordRequestSize(123);
+            });
+
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
+    assertEquals(1, beanNames.size());
+
+    for (String metric : maxMetrics) {
+      assertEquals(1230.0, mBeanServer.getAttribute(beanNames.iterator().next(), metric));
+    }
+  }
 }


### PR DESCRIPTION
In our billing one pager, we have agreement that we will count billing metrics after rate limiting, but before validation of the produce request body.

This PR moves the produce metrics collection point slightly earlier to match that decision.

Currently the bytes metric is an Avg() - so if you send 10 messages of 67, the metric records 67.

I've added a summed count metric to the produce bytes sensor, which is what ce-kafka uses to record bytes as described here https://confluentinc.atlassian.net/wiki/spaces/KREST/pages/2777684595/Billing+metrics#Counting-the-bytes

Waiting on confirmation that this is correct, but I'm fairly sure it is, so raising the PR now.  It's simple to revisit later to swap to eg a Windowed Count or something else if needed.