### PR TITLE
KREST-5830: Create a lazy wrapper around MappingIterator for Produce Action.

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -33,6 +33,7 @@ import io.confluent.kafkarest.extension.ResourceAccesslistFeature;
 import io.confluent.kafkarest.extension.RestResourceExtension;
 import io.confluent.kafkarest.ratelimit.RateLimitFeature;
 import io.confluent.kafkarest.resources.ResourcesFeature;
+import io.confluent.kafkarest.response.JsonStreamMessageBodyReader;
 import io.confluent.kafkarest.response.ResponseModule;
 import io.confluent.rest.Application;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
@@ -95,6 +96,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     }
 
     config.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
+    config.register(new JsonStreamMessageBodyReader(getJsonMapper()));
     config.register(new BackendsModule());
     config.register(new ConfigModule(appConfig));
     config.register(new ControllersModule());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -17,7 +17,6 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.protobuf.ByteString;
@@ -39,6 +38,7 @@ import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
 import io.confluent.kafkarest.ratelimit.DoNotRateLimit;
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException;
 import io.confluent.kafkarest.resources.v3.V3ResourcesModule.ProduceResponseThreadPool;
+import io.confluent.kafkarest.response.JsonStream;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
 import java.time.Duration;
@@ -60,15 +60,11 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import org.apache.kafka.common.errors.SerializationException;
 import org.eclipse.jetty.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @DoNotRateLimit
 @Path("/v3/clusters/{clusterId}/topics/{topicName}/records")
 @ResourceName("api.v3.produce.*")
 public final class ProduceAction {
-
-  private static final Logger log = LoggerFactory.getLogger(ProduceAction.class);
 
   private static final Collector<
           ProduceRequestHeader,
@@ -116,7 +112,7 @@ public final class ProduceAction {
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
       @PathParam("topicName") String topicName,
-      MappingIterator<ProduceRequest> requests)
+      JsonStream<ProduceRequest> requests)
       throws Exception {
 
     if (requests == null) {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStream.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStream.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.response;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.google.common.base.Suppliers;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+/**
+ * A lazy wrapper over {@link MappingIterator} to delay {@link
+ * com.fasterxml.jackson.core.JsonParser} until the first read.
+ */
+public final class JsonStream<T> implements Closeable {
+  private final Supplier<MappingIterator<T>> delegate;
+
+  public JsonStream(Supplier<MappingIterator<T>> delegate) {
+    this.delegate = Suppliers.memoize(delegate::get);
+  }
+
+  public boolean hasNext() {
+    if (delegate.get() == null) {
+      return false;
+    }
+    return delegate.get().hasNext();
+  }
+
+  public T nextValue() throws IOException {
+    if (delegate.get() == null) {
+      throw new NoSuchElementException();
+    }
+    return delegate.get().nextValue();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (delegate.get() != null) {
+      delegate.get().close();
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStreamMessageBodyReader.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStreamMessageBodyReader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.response;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+
+/** A {@link MessageBodyReader} for {@link JsonStream}. */
+public final class JsonStreamMessageBodyReader implements MessageBodyReader<JsonStream<?>> {
+  private final ObjectMapper objectMapper;
+
+  public JsonStreamMessageBodyReader(ObjectMapper objectMapper) {
+    this.objectMapper = requireNonNull(objectMapper);
+  }
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return JsonStream.class.equals(type) && MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+  }
+
+  @Override
+  public JsonStream<?> readFrom(
+      Class<JsonStream<?>> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws WebApplicationException {
+    JavaType wrappedType = objectMapper.constructType(genericType).containedType(0);
+    return new JsonStream<>(
+        () -> {
+          try {
+            // JsonParser needs to be instantiated lazily because it eagerly reads in a few bytes
+            // from the entityStream. If this initial bootstrapping doesn't work, and this is not
+            // done lazily, it can create problems with releasing request scoped resources. See
+            // KREST-5830 for context.
+            JsonParser parser = objectMapper.createParser(entityStream);
+            return objectMapper.readValues(parser, wrappedType);
+          } catch (IOException e) {
+            throw new BadRequestException("Unexpected error while starting JSON stream: ", e);
+          }
+        });
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseFactory.java
@@ -17,7 +17,6 @@ package io.confluent.kafkarest.response;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.databind.MappingIterator;
 import javax.inject.Inject;
 
 public final class StreamingResponseFactory {
@@ -29,7 +28,7 @@ public final class StreamingResponseFactory {
     this.chunkedOutputFactory = requireNonNull(chunkedOutputFactory);
   }
 
-  public <T> StreamingResponse<T> from(MappingIterator<T> input) {
-    return StreamingResponse.from(input, chunkedOutputFactory);
+  public <T> StreamingResponse<T> from(JsonStream<T> inputStream) {
+    return StreamingResponse.from(inputStream, chunkedOutputFactory);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ProducerLeakTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ProducerLeakTest.java
@@ -65,8 +65,7 @@ public class ProducerLeakTest {
   private final KafkaRestFixture kafkaRest =
       KafkaRestFixture.builder()
           .setConfig("producer.max.block.ms", "5000")
-          .setConfig(
-              "kafka.rest.resource.extension.class", LeakyContextExtension.class.getName())
+          .setConfig("kafka.rest.resource.extension.class", LeakyContextExtension.class.getName())
           .setKafkaCluster(kafkaCluster)
           .build();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ProducerLeakTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ProducerLeakTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.extension.RestResourceExtension;
+import io.confluent.kafkarest.testing.KafkaClusterFixture;
+import io.confluent.kafkarest.testing.KafkaRestFixture;
+import io.confluent.kafkarest.testing.ZookeeperFixture;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Tag("IntegrationTest")
+public class ProducerLeakTest {
+  private static final String TOPIC_NAME = "topic-1";
+
+  @Order(1)
+  @RegisterExtension
+  private final ZookeeperFixture zookeeper = ZookeeperFixture.create();
+
+  @Order(2)
+  @RegisterExtension
+  private final KafkaClusterFixture kafkaCluster =
+      KafkaClusterFixture.builder().setNumBrokers(3).setZookeeper(zookeeper).build();
+
+  @Order(3)
+  @RegisterExtension
+  private final KafkaRestFixture kafkaRest =
+      KafkaRestFixture.builder()
+          .setConfig("producer.max.block.ms", "5000")
+          .setConfig(
+              "kafka.rest.resource.extension.class", TeapotRestContextExtension.class.getName())
+          .setKafkaCluster(kafkaCluster)
+          .build();
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    kafkaCluster.createTopic(TOPIC_NAME, 3, (short) 1);
+  }
+
+  @Test
+  public void producerDoesNotLeak() throws Exception {
+    String clusterId = kafkaCluster.getClusterId();
+
+    Response response =
+        kafkaRest
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .request()
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.json(new byte[1]));
+
+    // Should give enough time for the client to close.
+    response.readEntity(String.class);
+
+    List<String> aliveClients =
+        Thread.getAllStackTraces().keySet().stream()
+            .map(Thread::getName)
+            .filter(name -> name.contains("proxy"))
+            .collect(Collectors.toList());
+    assertEquals(
+        0,
+        aliveClients.size(),
+        "Expected no live Kafka client threads, but some got left behind instead: " + aliveClients);
+  }
+
+  public static final class TeapotRestContextExtension implements RestResourceExtension {
+
+    @Override
+    public void register(Configurable<?> configurable, KafkaRestConfig config) {
+      configurable.register(TeapotContainerRequestFilter.class);
+      configurable.register(TeapotModule.class);
+    }
+
+    @Override
+    public void clean() {}
+  }
+
+  private static final class TeapotContainerRequestFilter implements ContainerRequestFilter {
+    private final Provider<Producer<byte[], byte[]>> producer;
+
+    @Inject
+    public TeapotContainerRequestFilter(Provider<Producer<byte[], byte[]>> producer) {
+      this.producer = requireNonNull(producer);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+      producer.get();
+    }
+  }
+
+  private static final class TeapotModule extends AbstractBinder {
+
+    @Override
+    protected void configure() {
+      bindFactory(TeapotProducerFactory.class)
+          .to(new TypeLiteral<Producer<byte[], byte[]>>() {})
+          .in(RequestScoped.class)
+          .ranked(1);
+    }
+  }
+
+  private static final class TeapotProducerFactory implements Factory<Producer<byte[], byte[]>> {
+    private final KafkaRestConfig config;
+
+    @Inject
+    private TeapotProducerFactory(KafkaRestConfig config) {
+      this.config = requireNonNull(config);
+    }
+
+    @Override
+    public Producer<byte[], byte[]> provide() {
+      Map<String, Object> producerConfigs = config.getProducerConfigs();
+      producerConfigs.put("client.id", "proxy");
+      return new KafkaProducer<>(
+          producerConfigs, new ByteArraySerializer(), new ByteArraySerializer());
+    }
+
+    @Override
+    public void dispose(Producer<byte[], byte[]> producer) {
+      producer.close();
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -34,6 +34,7 @@ import io.confluent.kafkarest.ratelimit.RateLimitExceededException;
 import io.confluent.kafkarest.ratelimit.RequestRateLimiter;
 import io.confluent.kafkarest.response.ChunkedOutputFactory;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.kafkarest.response.JsonStream;
 import io.confluent.kafkarest.response.StreamingResponse.ResultOrError;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
@@ -123,7 +124,8 @@ public class ProduceActionTest {
 
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     EasyMock.verify(requests);
@@ -229,7 +231,8 @@ public class ProduceActionTest {
 
     // run test
     FakeAsyncResponse fakeAsyncResponse1 = new FakeAsyncResponse();
-    produceAction1.produce(fakeAsyncResponse1, "clusterId", "topicName", requests);
+    produceAction1.produce(
+        fakeAsyncResponse1, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     EasyMock.verify(requests);
@@ -320,9 +323,11 @@ public class ProduceActionTest {
 
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
     FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse2, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     // check results
@@ -420,9 +425,11 @@ public class ProduceActionTest {
 
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
     FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse2, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     verify(
@@ -501,9 +508,11 @@ public class ProduceActionTest {
 
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
     FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
-    produceAction.produce(fakeAsyncResponse2, "clusterId", "topicName", requests);
+    produceAction.produce(
+        fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     verify(
@@ -556,14 +565,13 @@ public class ProduceActionTest {
             bytesLimitProvider,
             countLimiterGlobalProvider,
             bytesLimiterGlobalProvider);
-    MappingIterator<ProduceRequest> requests = null;
 
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
 
     RestConstraintViolationException e =
         assertThrows(
             RestConstraintViolationException.class,
-            () -> produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", requests));
+            () -> produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", null));
     assertEquals("Payload error. Null input provided. Data is required.", e.getMessage());
     assertEquals(42206, e.getErrorCode());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
@@ -73,7 +73,8 @@ public class StreamingResponseTest {
 
     StreamingResponseFactory streamingResponseFactory =
         new StreamingResponseFactory(mockedChunkedOutputFactory);
-    StreamingResponse<ProduceRequest> streamingResponse = streamingResponseFactory.from(requests);
+    StreamingResponse<ProduceRequest> streamingResponse =
+        streamingResponseFactory.from(new JsonStream<>(() -> requests));
 
     CompletableFuture<ProduceResponse> produceResponseFuture = new CompletableFuture<>();
 
@@ -138,7 +139,7 @@ public class StreamingResponseTest {
         new StreamingResponseFactory(mockedChunkedOutputFactory);
 
     StreamingResponse<ProduceRequest> streamingResponse =
-        streamingResponseFactory.from(requestsMappingIterator);
+        streamingResponseFactory.from(new JsonStream<>(() -> requestsMappingIterator));
 
     CompletableFuture<ProduceResponse> produceResponseFuture = new CompletableFuture<>();
     produceResponseFuture.complete(produceResponse);
@@ -180,7 +181,8 @@ public class StreamingResponseTest {
 
     StreamingResponseFactory streamingResponseFactory =
         new StreamingResponseFactory(mockedChunkedOutputFactory);
-    StreamingResponse<ProduceRequest> streamingResponse = streamingResponseFactory.from(requests);
+    StreamingResponse<ProduceRequest> streamingResponse =
+        streamingResponseFactory.from(new JsonStream<>(() -> requests));
 
     FakeAsyncResponse response = new FakeAsyncResponse();
 
@@ -217,7 +219,8 @@ public class StreamingResponseTest {
 
     StreamingResponseFactory streamingResponseFactory =
         new StreamingResponseFactory(mockedChunkedOutputFactory);
-    StreamingResponse<ProduceRequest> streamingResponse = streamingResponseFactory.from(requests);
+    StreamingResponse<ProduceRequest> streamingResponse =
+        streamingResponseFactory.from(new JsonStream<>(() -> requests));
 
     FakeAsyncResponse response = new FakeAsyncResponse();
 


### PR DESCRIPTION
JsonParser instantiation, which happens during MappingIterator deserialization, can throw on bad request. This can cause the request scope to not be disposed properly if a `@RequestScoped` resource is injected into a filter before an async resource method is executed. For Kafka REST, this only happens for the Produce Action.

This PR wraps the MappingIterator, so that the JsonParser is only instantiated during the first hasNext/nextValue call.

The PR also adds a test that shows the aforementioned resource leak.