### PR TITLE
KREST-5096 Fix NPE in Topics Resource when no key, or no value specified

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AvroProduceRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AvroProduceRecord.java
@@ -70,4 +70,12 @@ public class AvroProduceRecord extends ProduceRecordBase<JsonNode, JsonNode> {
     result = 31 * result + (value != null ? value.hashCode() : 0);
     return result;
   }
+
+  public boolean hasKey() {
+    return this.getJsonKey() != null && !this.getJsonKey().isNull();
+  }
+
+  public boolean hasValue() {
+    return this.getJsonValue() != null && !this.getJsonValue().isNull();
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AvroProduceRecord.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/AvroProduceRecord.java
@@ -72,10 +72,10 @@ public class AvroProduceRecord extends ProduceRecordBase<JsonNode, JsonNode> {
   }
 
   public boolean hasKey() {
-    return this.getJsonKey() != null && !this.getJsonKey().isNull();
+    return key != null && !key.isNull();
   }
 
   public boolean hasValue() {
-    return this.getJsonValue() != null && !this.getJsonValue().isNull();
+    return value != null && !value.isNull();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/PartitionsResource.java
@@ -213,8 +213,8 @@ public class PartitionsResource {
     boolean hasKeys = false;
     boolean hasValues = false;
     for (AvroProduceRecord rec : request.getRecords()) {
-      hasKeys = hasKeys || !rec.getJsonKey().isNull();
-      hasValues = hasValues || !rec.getJsonValue().isNull();
+      hasKeys = hasKeys || rec.hasKey();
+      hasValues = hasValues || rec.hasValue();
     }
     if (hasKeys && request.getKeySchema() == null && request.getKeySchemaId() == null) {
       throw Errors.keySchemaMissingException();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/TopicsResource.java
@@ -122,9 +122,10 @@ public class TopicsResource {
     // be available if there are any non-null entries
     boolean hasKeys = false;
     boolean hasValues = false;
+
     for (AvroTopicProduceRecord rec : request.getRecords()) {
-      hasKeys = hasKeys || !rec.getJsonKey().isNull();
-      hasValues = hasValues || !rec.getJsonValue().isNull();
+      hasKeys = hasKeys || rec.hasKey();
+      hasValues = hasValues || rec.hasValue();
     }
     if (hasKeys && request.getKeySchema() == null && request.getKeySchemaId() == null) {
       throw Errors.keySchemaMissingException();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v2/PartitionsResource.java
@@ -125,8 +125,8 @@ public final class PartitionsResource {
     boolean hasKeys = false;
     boolean hasValues = false;
     for (AvroProduceRecord rec : request.getRecords()) {
-      hasKeys = hasKeys || !rec.getJsonKey().isNull();
-      hasValues = hasValues || !rec.getJsonValue().isNull();
+      hasKeys = hasKeys || rec.hasKey();
+      hasValues = hasValues || rec.hasValue();
     }
     if (hasKeys && request.getKeySchema() == null && request.getKeySchemaId() == null) {
       throw Errors.keySchemaMissingException();


### PR DESCRIPTION
We need to null check the record.getJsonKey() call before calling any methods on it.

5.3.x still passes, the jackson version there is 2.10.5, and the jackson version at 5.4.x is 2.13.2.

I can only assume something has changed between these Jackson versions that has altered how null objects are dealt with (ie really null, rather than returning a json literal null object), possibly as part of  RFC 7159.  However I've not managed to track down the change.

I also had a look to see if there was an annotation I could set on the fields in the AvroProducerRecord to change how it behaves with nulls, but no joy.

Have fixed for all the cases I could find of .isNull being called without a null check.

