### PR TITLE
APPSEC-1156: Patch gson to be 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.jupiter.version}</version>


### PR DESCRIPTION
This is needed to enforce gson version. Otherewise, it inherits from com.google.protobuf:protobuf-java-util which is 2.8.6.