### PR TITLE
KREST-6005 Use HTTPS for public Maven repo URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Tested via @javabrett's Dockerfile from #832.

One thing I've noted though - apparently `6.1.1-post` got clobbered, and the #832 changes are again unavailable there (and the aforementioned Dockerfile can again be used to reproduce the problem Brett originally fixed).
I'm not sure how or why did that happen (my guess would be some sort of an automated update process) - I will focus specifically on the HTTP/HTTPS issue here.

@javabrett feel free to file an internal JIRA for looking into the clobbering and eventually reapplying your fix to `6.1.1-post`.