### PR TITLE
KREST-6139 Deflake produce rate limiter test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -152,15 +152,15 @@ public class ProduceRateLimitersTest {
     Clock clock = mock(Clock.class);
     expect(clock.millis()).andReturn(0L);
     expect(clock.millis()).andReturn(1L);
-    expect(clock.millis()).andReturn(8L);
+    expect(clock.millis()).andReturn(700L);
     replay(clock);
 
     Properties properties = new Properties();
     properties.put(PRODUCE_MAX_REQUESTS_PER_SECOND, Integer.toString(1));
     properties.put(PRODUCE_MAX_BYTES_PER_SECOND, Integer.toString(100));
-    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(100));
+    properties.put(PRODUCE_GRACE_PERIOD_MS, Integer.toString(10000));
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
-    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(5));
+    properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(200));
 
     ProduceRateLimiters produceRateLimiters =
         new ProduceRateLimiters(
@@ -177,7 +177,7 @@ public class ProduceRateLimitersTest {
     waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId", 10);
     assertTrue(waitTime.isPresent());
     assertEquals(waitTime.get().toMillis(), 1000);
-    Thread.sleep(6);
+    Thread.sleep(400);
     waitTime = produceRateLimiters.calculateGracePeriodExceeded("clusterId", 10);
     assertFalse(waitTime.isPresent());
   }


### PR DESCRIPTION
There was a timing window in the test that checks the rate limiter cache expires.

The test is supposed to
 - send 1 message (OK)
 - send 2nd message (429)
 - expire rate limit cache
 - send 3rd message within 1 second : would get a 429 if using the same rate limiter instance, instead should get OK because the rate limiter has been reset

However what we see sometimes is

 - send 1st message (OK)
 - expire cache
 - send second message - get OK, not 429

There is an overridden time on the rate limiter, but this can't be overridden on the cache as that's outside our scope of control. That cache expiration is managed by a thread.sleep :(

And it looks like the send of the second message, despite having an overridden time of only 1ms delay, was actually taking longer than the thread.sleep to really happen. Slow jenkins :( 

I managed to reproduce this quite regularly locally by adding in a pile of log.trace statements.

Ideally we would mock up the rate limiter cache somehow, but for now I've just made all the gaps bigger.  Hopefully this is enough for jenkins, if not we'll have to revisit and mock up the cache.