### PR TITLE
Fix Checkstyle empty catch block error.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -577,6 +577,7 @@ public abstract class ClusterTestHarness {
     try {
       Thread.sleep(HALF_SECOND_MILLIS);
     } catch (InterruptedException ie3) {
+      // Noop
     }
   }
 


### PR DESCRIPTION
As #978 got merged roughly together with #1022, an empty catch block validation error that it introduced managed to sneak in.
This change addresses that.

I'll be merging this change immediately to fix the build.