### PR TITLE
Backport consumer deadlock fix to 5.4.x

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -66,6 +66,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
   private Queue<ConsumerRecord<KafkaKeyT, KafkaValueT>> consumerRecords = new ArrayDeque<>();
 
   volatile long expiration;
+  private final Object expirationLock = new Object();
 
   KafkaConsumerState(
       KafkaRestConfig config,
@@ -335,13 +336,17 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
         .map(OffsetAndTimestamp::offset);
   }
 
-  public synchronized boolean expired(long nowMs) {
-    return expiration <= nowMs;
+  public boolean expired(long nowMs) {
+    synchronized (this.expirationLock) {
+      return expiration <= nowMs;
+    }
   }
 
-  public synchronized void updateExpiration() {
-    this.expiration = config.getTime().milliseconds()
-                      + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
+  public void updateExpiration() {
+    synchronized (this.expirationLock) {
+      this.expiration = config.getTime().milliseconds()
+                        + config.getInt(KafkaRestConfig.CONSUMER_INSTANCE_TIMEOUT_MS_CONFIG);
+    }
   }
 
   public synchronized KafkaRestConfig getConfig() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -499,7 +499,7 @@ public class KafkaConsumerManagerTest {
     public void testConsumerExpirationIsUpdated() throws Exception {
         bootstrapConsumer(consumer);
         KafkaConsumerState state = consumerManager.getConsumerInstance(groupName, consumer.cid());
-        long initialExpiration = state.expiration;
+        long lastExpiration = state.expiration;
         consumerManager.readRecords(groupName, consumer.cid(), BinaryKafkaConsumerState.class, -1, Long.MAX_VALUE,
                 new ConsumerReadCallback<byte[], byte[]>() {
                     @Override
@@ -510,12 +510,12 @@ public class KafkaConsumerManagerTest {
                     }
                 });
         Thread.sleep(100);
-        assertTrue(state.expiration > initialExpiration);
-        initialExpiration = state.expiration;
+        assertFalse(state.expired(lastExpiration));
+        lastExpiration = state.expiration;
         awaitRead();
         assertTrue("Callback failed to fire", sawCallback);
-        assertTrue(state.expiration > initialExpiration);
-        initialExpiration = state.expiration;
+        assertFalse(state.expired(lastExpiration));
+        lastExpiration = state.expiration;
 
         consumerManager.commitOffsets(groupName, consumer.cid(), null, null, new KafkaConsumerManager.CommitCallback() {
             @Override
@@ -526,7 +526,7 @@ public class KafkaConsumerManagerTest {
                 actualOffsets = offsets;
             }
         }).get();
-        assertTrue(state.expiration > initialExpiration);
+        assertFalse(state.expired(lastExpiration));
     }
 
     private void awaitRead() throws InterruptedException {


### PR DESCRIPTION
This backports @merrygoround-of-life's fix from #942 in `5.4.x` as although the deadlocking synchronization changes were originally introduced in `6.0.x` (where #942 has landed), they were also backported to `5.2.x` (with #777) and `5.4.x` (with #778).