### PR TITLE
KREST-2655 Simple version of disconnect

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -458,14 +458,15 @@ public class KafkaRestConfig extends RestConfig {
       "streaming.connection.max.duration.ms";
   private static final String STREAMING_CONNECTION_MAX_DURATION_MS_DOC =
       "The maximum duration of a streaming connection. Once this time has elapsed, the connection "
-          + "is closed.";
+          + "will stop processing new requests and will be closed once there are no "
+          + "outstanding requests.";
   private static final String STREAMING_CONNECTION_MAX_DURATION_MS_DEFAULT = "86400000";
 
   public static final String STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS =
       "streaming.connection.max.duration.grace.period.ms";
   private static final String STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS_DOC =
-      "How long after a streaming connection reaches its maximum duration that outstanding "
-          + "requests can be processed for before the connection is closed.";
+      "How long after a streaming connection reaches its maximum duration outstanding "
+          + "requests will be processed for before the connection is closed.";
   private static final String STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS_DEFAULT = "500";
 
   private static final ConfigDef config;

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -454,18 +454,19 @@ public class KafkaRestConfig extends RestConfig {
           + "\"api.v3.clusters.*=1,api.v3.brokers.list=2\". A cost of zero means no rate-limit.";
   private static final String RATE_LIMIT_COSTS_DEFAULT = "";
 
-  public static final String STREAMING_CONNECTION_TIMEOUT_MS = "streaming.connection.timeout.ms";
-  private static final String STREAMING_CONNECTION_TIMEOUT_MS_DOC =
+  public static final String STREAMING_CONNECTION_MAX_DURATION_MS =
+      "streaming.connection.max.duration.ms";
+  private static final String STREAMING_CONNECTION_MAX_DURATION_MS_DOC =
       "The maximum duration of a streaming connection. Once this time has elapsed, the connection "
           + "is closed.";
-  private static final String STREAMING_CONNECTION_TIMEOUT_MS_DEFAULT = "86400000";
+  private static final String STREAMING_CONNECTION_MAX_DURATION_MS_DEFAULT = "86400000";
 
-  public static final String STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS =
-      "streaming.connection.timeout.grace.period.ms";
-  private static final String STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DOC =
+  public static final String STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS =
+      "streaming.connection.max.duration.grace.period.ms";
+  private static final String STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS_DOC =
       "How long after a streaming connection reaches its maximum duration that outstanding "
           + "requests can be processed for before the connection is closed.";
-  private static final String STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DEFAULT = "500";
+  private static final String STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS_DEFAULT = "500";
 
   private static final ConfigDef config;
   private volatile Metrics metrics;
@@ -835,17 +836,17 @@ public class KafkaRestConfig extends RestConfig {
             Importance.LOW,
             RATE_LIMIT_COSTS_DOC)
         .define(
-            STREAMING_CONNECTION_TIMEOUT_MS,
+            STREAMING_CONNECTION_MAX_DURATION_MS,
             Type.LONG,
-            STREAMING_CONNECTION_TIMEOUT_MS_DEFAULT,
+            STREAMING_CONNECTION_MAX_DURATION_MS_DEFAULT,
             Importance.LOW,
-            STREAMING_CONNECTION_TIMEOUT_MS_DOC)
+            STREAMING_CONNECTION_MAX_DURATION_MS_DOC)
         .define(
-            STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS,
+            STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS,
             Type.LONG,
-            STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DEFAULT,
+            STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS_DEFAULT,
             Importance.LOW,
-            STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DOC);
+            STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS_DOC);
   }
 
   private static Properties getPropsFromFile(String propsFile) throws RestConfigException {
@@ -1078,12 +1079,12 @@ public class KafkaRestConfig extends RestConfig {
     return Duration.ofMillis(getLong(RATE_LIMIT_TIMEOUT_MS_CONFIG));
   }
 
-  public final Duration getStreamingConnectionTimeout() {
-    return Duration.ofMillis(getLong(STREAMING_CONNECTION_TIMEOUT_MS));
+  public final Duration getStreamingConnectionMaxDuration() {
+    return Duration.ofMillis(getLong(STREAMING_CONNECTION_MAX_DURATION_MS));
   }
 
-  public final Duration getStreamingConnectionTimeoutGracePeriod() {
-    return Duration.ofMillis(getLong(STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS));
+  public final Duration getStreamingConnectionMaxDurationGracePeriod() {
+    return Duration.ofMillis(getLong(STREAMING_CONNECTION_MAX_DURATION_GRACE_PERIOD_MS));
   }
 
   public final int getRateLimitDefaultCost() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -454,6 +454,19 @@ public class KafkaRestConfig extends RestConfig {
           + "\"api.v3.clusters.*=1,api.v3.brokers.list=2\". A cost of zero means no rate-limit.";
   private static final String RATE_LIMIT_COSTS_DEFAULT = "";
 
+  public static final String STREAMING_CONNECTION_TIMEOUT_MS = "streaming.connection.timeout.ms";
+  private static final String STREAMING_CONNECTION_TIMEOUT_MS_DOC =
+      "The maximum duration of a streaming connection. Once this time has elapsed, the connection "
+          + "is closed.";
+  private static final String STREAMING_CONNECTION_TIMEOUT_MS_DEFAULT = "86400000";
+
+  public static final String STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS =
+      "streaming.connection.timeout.grace.period.ms";
+  private static final String STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DOC =
+      "How long after a streaming connection reaches its maximum duration that outstanding "
+          + "requests can be processed for before the connection is closed.";
+  private static final String STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DEFAULT = "500";
+
   private static final ConfigDef config;
   private volatile Metrics metrics;
 
@@ -820,7 +833,19 @@ public class KafkaRestConfig extends RestConfig {
             Type.STRING,
             RATE_LIMIT_COSTS_DEFAULT,
             Importance.LOW,
-            RATE_LIMIT_COSTS_DOC);
+            RATE_LIMIT_COSTS_DOC)
+        .define(
+            STREAMING_CONNECTION_TIMEOUT_MS,
+            Type.LONG,
+            STREAMING_CONNECTION_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            STREAMING_CONNECTION_TIMEOUT_MS_DOC)
+        .define(
+            STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS,
+            Type.LONG,
+            STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DEFAULT,
+            Importance.LOW,
+            STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS_DOC);
   }
 
   private static Properties getPropsFromFile(String propsFile) throws RestConfigException {
@@ -1051,6 +1076,14 @@ public class KafkaRestConfig extends RestConfig {
 
   public final Duration getRateLimitTimeout() {
     return Duration.ofMillis(getLong(RATE_LIMIT_TIMEOUT_MS_CONFIG));
+  }
+
+  public final Duration getStreamingConnectionTimeout() {
+    return Duration.ofMillis(getLong(STREAMING_CONNECTION_TIMEOUT_MS));
+  }
+
+  public final Duration getStreamingConnectionTimeoutGracePeriod() {
+    return Duration.ofMillis(getLong(STREAMING_CONNECTION_TIMEOUT_GRACE_PERIOD_MS));
   }
 
   public final int getRateLimitDefaultCost() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -161,6 +161,14 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new RateLimitTimeoutConfigImpl())
         .to(Duration.class);
 
+    bind(config.getStreamingConnectionTimeout())
+        .qualifiedBy(new StreamingConnectionTimeoutConfigImpl())
+        .to(Duration.class);
+
+    bind(config.getStreamingConnectionTimeoutGracePeriod())
+        .qualifiedBy(new StreamingConnectionTimeoutGracePeriodImpl())
+        .to(Duration.class);
+
     bind(config.getSchemaRegistryConfigs())
         .qualifiedBy(new SchemaRegistryConfigsImpl())
         .to(new TypeLiteral<Map<String, Object>>() {});
@@ -415,5 +423,23 @@ public final class ConfigModule extends AbstractBinder {
 
   private static final class SchemaRegistryUrlsConfigImpl
       extends AnnotationLiteral<SchemaRegistryUrlsConfig> implements SchemaRegistryUrlsConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface StreamingMaxConnectionDurationConfig {}
+
+  private static final class StreamingConnectionTimeoutConfigImpl
+      extends AnnotationLiteral<StreamingMaxConnectionDurationConfig>
+      implements StreamingMaxConnectionDurationConfig {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+  public @interface StreamingMaxConnectionGracePeriod {}
+
+  private static final class StreamingConnectionTimeoutGracePeriodImpl
+      extends AnnotationLiteral<StreamingMaxConnectionGracePeriod>
+      implements StreamingMaxConnectionGracePeriod {}
 }
 // CHECKSTYLE:ON:ClassDataAbstractionCoupling

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -161,12 +161,12 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new RateLimitTimeoutConfigImpl())
         .to(Duration.class);
 
-    bind(config.getStreamingConnectionTimeout())
-        .qualifiedBy(new StreamingConnectionTimeoutConfigImpl())
+    bind(config.getStreamingConnectionMaxDuration())
+        .qualifiedBy(new StreamingConnectionMaxDurationConfigImpl())
         .to(Duration.class);
 
-    bind(config.getStreamingConnectionTimeoutGracePeriod())
-        .qualifiedBy(new StreamingConnectionTimeoutGracePeriodImpl())
+    bind(config.getStreamingConnectionMaxDurationGracePeriod())
+        .qualifiedBy(new StreamingConnectionMaxDurationGracePeriodImpl())
         .to(Duration.class);
 
     bind(config.getSchemaRegistryConfigs())
@@ -429,7 +429,7 @@ public final class ConfigModule extends AbstractBinder {
   @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
   public @interface StreamingMaxConnectionDurationConfig {}
 
-  private static final class StreamingConnectionTimeoutConfigImpl
+  private static final class StreamingConnectionMaxDurationConfigImpl
       extends AnnotationLiteral<StreamingMaxConnectionDurationConfig>
       implements StreamingMaxConnectionDurationConfig {}
 
@@ -438,7 +438,7 @@ public final class ConfigModule extends AbstractBinder {
   @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
   public @interface StreamingMaxConnectionGracePeriod {}
 
-  private static final class StreamingConnectionTimeoutGracePeriodImpl
+  private static final class StreamingConnectionMaxDurationGracePeriodImpl
       extends AnnotationLiteral<StreamingMaxConnectionGracePeriod>
       implements StreamingMaxConnectionGracePeriod {}
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -71,6 +71,7 @@ import org.slf4j.LoggerFactory;
 public abstract class StreamingResponse<T> {
 
   private static final Logger log = LoggerFactory.getLogger(StreamingResponse.class);
+  private static final int ONE_SECOND_MS = 1000;
 
   private static final CompositeErrorMapper EXCEPTION_MAPPER =
       new CompositeErrorMapper.Builder()
@@ -106,13 +107,12 @@ public abstract class StreamingResponse<T> {
           .build();
 
   private final ChunkedOutputFactory chunkedOutputFactory;
-
   private final Duration maxDuration;
   private final Duration gracePeriod;
-  volatile boolean closingStarted = false;
   private final Instant streamStartTime;
   private final Clock clock;
-  private static final int ONE_SECOND_MS = 1000;
+
+  volatile boolean closingStarted = false;
 
   StreamingResponse(
       ChunkedOutputFactory chunkedOutputFactory,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -110,15 +110,18 @@ public abstract class StreamingResponse<T> {
   private final Duration maxDuration;
   private final Duration gracePeriod;
   volatile boolean closingStarted = false;
-  private Instant streamStartTime;
-  private Clock clock;
+  private final Instant streamStartTime;
+  private final Clock clock;
   private static final int ONE_SECOND_MS = 1000;
 
   StreamingResponse(
-      ChunkedOutputFactory chunkedOutputFactory, Duration maxDuration, Duration gracePeriod) {
-    clock = Clock.systemUTC();
-    this.chunkedOutputFactory = requireNonNull(chunkedOutputFactory);
+      ChunkedOutputFactory chunkedOutputFactory,
+      Duration maxDuration,
+      Duration gracePeriod,
+      Clock clock) {
+    this.clock = clock;
     this.streamStartTime = clock.instant();
+    this.chunkedOutputFactory = requireNonNull(chunkedOutputFactory);
     this.maxDuration = maxDuration;
     this.gracePeriod = gracePeriod;
   }
@@ -129,7 +132,18 @@ public abstract class StreamingResponse<T> {
       Duration maxDuration,
       Duration gracePeriod) {
     return new InputStreamingResponse<>(
-        inputStream, chunkedOutputFactory, maxDuration, gracePeriod);
+        inputStream, chunkedOutputFactory, maxDuration, gracePeriod, Clock.systemUTC());
+  }
+
+  @VisibleForTesting
+  static <T> StreamingResponse<T> fromWithClock(
+      JsonStream<T> inputStream,
+      ChunkedOutputFactory chunkedOutputFactory,
+      Duration maxDuration,
+      Duration gracePeriod,
+      Clock clock) {
+    return new InputStreamingResponse<>(
+        inputStream, chunkedOutputFactory, maxDuration, gracePeriod, clock);
   }
 
   public final <O> StreamingResponse<O> compose(
@@ -226,8 +240,9 @@ public abstract class StreamingResponse<T> {
         JsonStream<T> inputStream,
         ChunkedOutputFactory chunkedOutputFactory,
         Duration maxDuration,
-        Duration gracePeriod) {
-      super(chunkedOutputFactory, maxDuration, gracePeriod);
+        Duration gracePeriod,
+        Clock clock) {
+      super(chunkedOutputFactory, maxDuration, gracePeriod, clock);
       this.inputStream = requireNonNull(inputStream);
     }
 
@@ -274,7 +289,7 @@ public abstract class StreamingResponse<T> {
         ChunkedOutputFactory chunkedOutputFactory,
         Duration maxDuration,
         Duration gracePeriod) {
-      super(chunkedOutputFactory, maxDuration, gracePeriod);
+      super(chunkedOutputFactory, maxDuration, gracePeriod, streamingResponseInput.clock);
       this.streamingResponseInput = requireNonNull(streamingResponseInput);
       this.transform = requireNonNull(transform);
     }
@@ -478,13 +493,6 @@ public abstract class StreamingResponse<T> {
         return new CompositeErrorMapper(mappers.build(), defaultMapper);
       }
     }
-  }
-
-  @VisibleForTesting
-  protected StreamingResponse<T> overrideClock(Clock clock) {
-    this.clock = clock;
-    streamStartTime = clock.instant();
-    return this;
   }
 }
 // CHECKSTYLE:ON:ClassDataAbstractionCoupling

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseFactory.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponseFactory.java
@@ -17,18 +17,28 @@ package io.confluent.kafkarest.response;
 
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.kafkarest.config.ConfigModule.StreamingMaxConnectionDurationConfig;
+import io.confluent.kafkarest.config.ConfigModule.StreamingMaxConnectionGracePeriod;
+import java.time.Duration;
 import javax.inject.Inject;
 
 public final class StreamingResponseFactory {
 
   private final ChunkedOutputFactory chunkedOutputFactory;
+  private final Duration maxDuration;
+  private final Duration gracePeriod;
 
   @Inject
-  public StreamingResponseFactory(ChunkedOutputFactory chunkedOutputFactory) {
+  public StreamingResponseFactory(
+      ChunkedOutputFactory chunkedOutputFactory,
+      @StreamingMaxConnectionDurationConfig Duration maxDuration,
+      @StreamingMaxConnectionGracePeriod Duration gracePeriod) {
     this.chunkedOutputFactory = requireNonNull(chunkedOutputFactory);
+    this.maxDuration = maxDuration;
+    this.gracePeriod = gracePeriod;
   }
 
   public <T> StreamingResponse<T> from(JsonStream<T> inputStream) {
-    return StreamingResponse.from(inputStream, chunkedOutputFactory);
+    return StreamingResponse.from(inputStream, chunkedOutputFactory, maxDuration, gracePeriod);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -76,6 +76,8 @@ import org.junit.jupiter.api.Test;
 
 public class ProduceActionTest {
 
+  private static final Duration DURATION = Duration.ofMillis(5000);
+
   @AfterAll
   public static void cleanUp() {
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -150,7 +152,8 @@ public class ProduceActionTest {
     ErrorResponse err =
         ErrorResponse.create(
             422,
-            "Error: 42206 : Payload error. Schema Registry must be configured when using schemas.");
+            "Error: 42206 : Payload error. Schema Registry must be configured when using"
+                + " schemas.");
     ResultOrError resultOrErrorFail = ResultOrError.error(err);
     expect(mockedChunkedOutput.isClosed()).andReturn(false);
     mockedChunkedOutput.write(resultOrErrorFail);
@@ -836,7 +839,7 @@ public class ProduceActionTest {
     replay(produceControllerProvider, produceController);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(chunkedOutputFactory);
+        new StreamingResponseFactory(chunkedOutputFactory, DURATION, DURATION);
 
     // get the current thread so that the call counts can be seen by easy mock
     ExecutorService executorService = MoreExecutors.newDirectExecutorService();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -76,7 +76,7 @@ import org.junit.jupiter.api.Test;
 
 public class ProduceActionTest {
 
-  private static final Duration DURATION = Duration.ofMillis(5000);
+  private static final Duration FIVE_SECONDS_MS = Duration.ofMillis(5000);
 
   @AfterAll
   public static void cleanUp() {
@@ -839,7 +839,7 @@ public class ProduceActionTest {
     replay(produceControllerProvider, produceController);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(chunkedOutputFactory, DURATION, DURATION);
+        new StreamingResponseFactory(chunkedOutputFactory, FIVE_SECONDS_MS, FIVE_SECONDS_MS);
 
     // get the current thread so that the call counts can be seen by easy mock
     ExecutorService executorService = MoreExecutors.newDirectExecutorService();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
@@ -340,8 +340,12 @@ public class StreamingResponseTest {
             mockedChunkedOutputFactory, Duration.ofMillis(timeout), Duration.ofMillis(50));
 
     StreamingResponse<ProduceRequest> streamingResponse =
-        streamingResponseFactory.from(new JsonStream<>(() -> requestsMappingIterator));
-    streamingResponse.overrideClock(clock);
+        StreamingResponse.fromWithClock(
+            new JsonStream<>(() -> requestsMappingIterator),
+            mockedChunkedOutputFactory,
+            Duration.ofMillis(timeout),
+            Duration.ofMillis(50),
+            clock);
 
     CompletableFuture<ProduceResponse> produceResponseFuture = new CompletableFuture<>();
     produceResponseFuture.complete(produceResponse);
@@ -352,7 +356,6 @@ public class StreamingResponseTest {
             result -> {
               return produceResponseFuture;
             })
-        .overrideClock(clock)
         .resume(response);
 
     EasyMock.verify(mockedChunkedOutput);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
@@ -29,6 +29,9 @@ import io.confluent.kafkarest.entities.v3.ProduceResponse;
 import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
 import io.confluent.kafkarest.response.StreamingResponse.ResultOrError;
 import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import org.easymock.EasyMock;
 import org.eclipse.jetty.http.HttpStatus;
@@ -36,6 +39,8 @@ import org.glassfish.jersey.server.ChunkedOutput;
 import org.junit.jupiter.api.Test;
 
 public class StreamingResponseTest {
+
+  private static final Duration DURATION = Duration.ofMillis(5000);
 
   @Test
   public void testGracePeriodExceededExceptionThrown() throws IOException {
@@ -87,7 +92,7 @@ public class StreamingResponseTest {
     replay(mockedChunkedOutput);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(mockedChunkedOutputFactory);
+        new StreamingResponseFactory(mockedChunkedOutputFactory, DURATION, DURATION);
     StreamingResponse<ProduceRequest> streamingResponse =
         streamingResponseFactory.from(new JsonStream<>(() -> requests));
 
@@ -151,7 +156,7 @@ public class StreamingResponseTest {
     replay(mockedChunkedOutput, mockedChunkedOutputFactory);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(mockedChunkedOutputFactory);
+        new StreamingResponseFactory(mockedChunkedOutputFactory, DURATION, DURATION);
 
     StreamingResponse<ProduceRequest> streamingResponse =
         streamingResponseFactory.from(new JsonStream<>(() -> requestsMappingIterator));
@@ -196,7 +201,7 @@ public class StreamingResponseTest {
     replay(mockedChunkedOutput);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(mockedChunkedOutputFactory);
+        new StreamingResponseFactory(mockedChunkedOutputFactory, DURATION, DURATION);
     StreamingResponse<ProduceRequest> streamingResponse =
         streamingResponseFactory.from(new JsonStream<>(() -> requests));
 
@@ -213,7 +218,8 @@ public class StreamingResponseTest {
   public void testHasNextRuntimeException() throws IOException {
     MappingIterator<ProduceRequest> requests = mock(MappingIterator.class);
     expect(requests.hasNext())
-        .andThrow(new RuntimeException("IO error thrown by mapping iterator describing problem."));
+        .andThrow(
+            new RuntimeException("IO error thrown by mapping iterator describing" + " problem."));
     requests.close();
     replay(requests);
 
@@ -235,7 +241,7 @@ public class StreamingResponseTest {
     replay(mockedChunkedOutput);
 
     StreamingResponseFactory streamingResponseFactory =
-        new StreamingResponseFactory(mockedChunkedOutputFactory);
+        new StreamingResponseFactory(mockedChunkedOutputFactory, DURATION, DURATION);
     StreamingResponse<ProduceRequest> streamingResponse =
         streamingResponseFactory.from(new JsonStream<>(() -> requests));
 
@@ -246,5 +252,112 @@ public class StreamingResponseTest {
     EasyMock.verify(mockedChunkedOutput);
     EasyMock.verify(mockedChunkedOutputFactory);
     EasyMock.verify(requests);
+  }
+
+  @Test
+  public void testWriteToChunkedOutputAfterTimeout() throws IOException, InterruptedException {
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.AVRO)
+                    .setRawSchema("{\"type\": \"string\"}")
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.AVRO)
+                    .setRawSchema("{\"type\": \"string\"}")
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .setOriginalSize(0L)
+            .build();
+
+    MappingIterator<ProduceRequest> requestsMappingIterator = mock(MappingIterator.class);
+
+    long timeout = 10;
+    Clock clock = mock(Clock.class);
+
+    ProduceResponse produceResponse =
+        ProduceResponse.builder()
+            .setClusterId("clusterId")
+            .setTopicName("topicName")
+            .setPartitionId(1)
+            .setOffset(1L)
+            .setErrorCode(HttpStatus.OK_200)
+            .build();
+    ResultOrError sucessResult = ResultOrError.result(produceResponse);
+
+    ResultOrError error =
+        ResultOrError.error(
+            ErrorResponse.create(
+                408,
+                "Streaming connection open for longer than allowed: Connection will be closed."));
+
+    ChunkedOutputFactory mockedChunkedOutputFactory = mock(ChunkedOutputFactory.class);
+    ChunkedOutput<ResultOrError> mockedChunkedOutput = mock(ChunkedOutput.class);
+
+    expect(clock.instant())
+        .andReturn(Instant.ofEpochMilli(0)); // stream start - input stream response (check)
+    expect(clock.instant())
+        .andReturn(Instant.ofEpochMilli(0)); // stream start - composing response (check)
+    expect(requestsMappingIterator.hasNext()).andReturn(true); // first message - OK
+    expect(requestsMappingIterator.nextValue()).andReturn(request);
+    expect(clock.instant())
+        .andReturn(Instant.ofEpochMilli(1)); // first comparison duration.  within timeout
+
+    expect(mockedChunkedOutputFactory.getChunkedOutput()).andReturn(mockedChunkedOutput);
+    mockedChunkedOutput.write(sucessResult);
+    expect(mockedChunkedOutput.isClosed()).andReturn(false);
+
+    expect(requestsMappingIterator.hasNext()).andReturn(true); // is another message
+    expect(requestsMappingIterator.nextValue()).andReturn(request); // second message - bad gateway
+    expect(clock.instant())
+        .andReturn(Instant.ofEpochMilli(timeout + 5)); // second message beyond timeout
+
+    mockedChunkedOutput.write(error);
+    expect(mockedChunkedOutput.isClosed()).andReturn(false);
+
+    expect(requestsMappingIterator.hasNext())
+        .andAnswer(
+            () -> { // return hasnext true AFTER the thread executor has timed out and closed the
+              // connections.  Then expect no other calls except the connection closing.
+              Thread.sleep(500);
+              return true;
+            });
+
+    requestsMappingIterator.close(); // this ensures the closes have been called
+    mockedChunkedOutput.close();
+    requestsMappingIterator.close(); // expect twice - one from the thread and one from the finally
+    mockedChunkedOutput.close();
+
+    replay(mockedChunkedOutput, mockedChunkedOutputFactory, requestsMappingIterator, clock);
+
+    StreamingResponseFactory streamingResponseFactory =
+        new StreamingResponseFactory(
+            mockedChunkedOutputFactory, Duration.ofMillis(timeout), Duration.ofMillis(50));
+
+    StreamingResponse<ProduceRequest> streamingResponse =
+        streamingResponseFactory.from(new JsonStream<>(() -> requestsMappingIterator));
+    streamingResponse.overrideClock(clock);
+
+    CompletableFuture<ProduceResponse> produceResponseFuture = new CompletableFuture<>();
+    produceResponseFuture.complete(produceResponse);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    streamingResponse
+        .compose(
+            result -> {
+              return produceResponseFuture;
+            })
+        .overrideClock(clock)
+        .resume(response);
+
+    EasyMock.verify(mockedChunkedOutput);
+    EasyMock.verify(mockedChunkedOutputFactory);
+    EasyMock.verify(requestsMappingIterator);
+    EasyMock.verify(clock);
   }
 }


### PR DESCRIPTION
During our release review last year, one of the requests was to ensure that any long running connections are disconnected periodically.

Kafka does this for non-rest clients in https://github.com/confluentinc/ce-kafka/pull/3252 (which wasn't merged but has some interesting comments) and https://github.com/confluentinc/ce-kafka/pull/3292

The intent of this PR is to disconnect all streaming produce connections 24 hours after they were first made.  Once the stream has reached this age, the next message to arrive will get a 408 request timeout with message "Streaming connection open for longer than allowed: Connection will be closed." 

Suggestions please for a better http status code, there is nothing that I could find that matches what we are doing.

We want to try and respond to any outstanding requests that we know about, rather than just losing them, so there is a grace period of 500ms, where any message already with us, or that arrive within this time period are also responded to with the 408.

Any messages that arrive after the grace period, but before the connection closing has finished up (a small timing window) are ignored. 

The disconnect code only triggers for arriving messages, because there is already an existing, shorter timeout of 30s, for unused streams : https://github.com/confluentinc/rest-utils/blob/111998c26588cfcb773ee7bf9a757e3f79c5f301/core/src/main/java/io/confluent/rest/RestConfig.java#L418 so there was no point complicating the code further here to account for this.

hasNext() on the MappingIterator hangs if there is nothing new on the MappingIterator (you'd hope it would just return false)

There is still a timing window around "closingStarted" but it doesn't matter (i think) because all it means is that the scheduledExecutor has triggered the close on the MappingIterator and the output stream.  If we try and write to the closed output stream it does't matter, nothing bad will happen.  I didn't want to add a lock.

The next() call at line 163 is to clear the message off the MappingIterator so we can process the next one (and return 408) if needed.

There is a horrible override of clock (where I could have just an Instant for the stream start time) so that I can actually unit test this reliably - you can't mock Instant easily.

FUP - Should we add disconnect jitter in a follow on PR?