### PR TITLE
APIF-2768: Workaround for "Failed to bind to 0.0.0.0/0.0.0.0:9998" error.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/PartitionsResourceTest.java
@@ -39,16 +39,11 @@ import org.easymock.EasyMockExtension;
 import org.easymock.Mock;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(EasyMockExtension.class)
-@TestInstance(Lifecycle.PER_CLASS)
 public class PartitionsResourceTest extends JerseyTest {
 
   private static final String CLUSTER_ID = "cluster-1";
@@ -93,16 +88,6 @@ public class PartitionsResourceTest extends JerseyTest {
     application.register(new PartitionsResource(() -> partitionManager));
     application.register(new JacksonMessageBodyProvider());
     return application;
-  }
-
-  @BeforeAll
-  public void before() throws Exception {
-    super.setUp();
-  }
-
-  @AfterAll
-  public void after() throws Exception {
-    super.tearDown();
   }
 
   @BeforeEach

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     </modules>
 
     <properties>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.kafka-rest.version>7.2.1-0</io.confluent.kafka-rest.version>
@@ -153,6 +154,26 @@
                                 <version>1.0-rc6</version>
                             </path>
                         </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <jersey.config.test.container.port>0</jersey.config.test.container.port>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <jersey.config.test.container.port>0</jersey.config.test.container.port>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     </modules>
 
     <properties>
-        <jetty.version>9.4.48.v20220622</jetty.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.kafka-rest.version>7.2.1-0</io.confluent.kafka-rest.version>


### PR DESCRIPTION
This change will cause `JerseyTest` to run on a random port instead of the default 9998. This should work around the fact the ports are possibly leaking between tests.