### PR TITLE
NPE when post to topics endpoint without payload

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -116,7 +116,7 @@ public final class ProduceAction {
       throws Exception {
 
     if (requests == null) {
-      throw Errors.invalidPayloadException("Null input provided. Data is required.");
+      throw Errors.invalidPayloadException("Request body is empty. Data is required.");
     }
 
     ProduceController controller = produceControllerProvider.get();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -143,7 +143,7 @@ public final class TopicsResource {
       @Valid CreateTopicRequest request) {
 
     if (request == null) {
-      throw Errors.invalidPayloadException("Null input provided. Data is required.");
+      throw Errors.invalidPayloadException("Request body is empty. Data is required.");
     }
 
     String topicName = request.getTopicName();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -19,6 +19,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.TopicManager;
 import io.confluent.kafkarest.entities.Topic;
 import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
@@ -140,6 +141,11 @@ public final class TopicsResource {
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
       @Valid CreateTopicRequest request) {
+
+    if (request == null) {
+      throw Errors.invalidPayloadException("Null input provided. Data is required.");
+    }
+
     String topicName = request.getTopicName();
     Optional<Integer> partitionsCount = request.getPartitionsCount();
     Optional<Short> replicationFactor = request.getReplicationFactor();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -470,6 +470,16 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
+  public void createTopic_withoutRequestBody_returnsInvalidPayload() {
+    String clusterId = getClusterId();
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(null, MediaType.APPLICATION_JSON));
+    assertEquals(422, response.getStatus());
+  }
+
+  @Test
   public void deleteTopic_existingTopic_deletesTopic() {
     String clusterId = getClusterId();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -613,7 +613,7 @@ public class ProduceActionTest {
         assertThrows(
             RestConstraintViolationException.class,
             () -> produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", null));
-    assertEquals("Payload error. Null input provided. Data is required.", e.getMessage());
+    assertEquals("Payload error. Request body is empty. Data is required.", e.getMessage());
     assertEquals(42206, e.getErrorCode());
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -43,6 +44,7 @@ import io.confluent.kafkarest.entities.v3.TopicDataList;
 import io.confluent.kafkarest.response.CrnFactoryImpl;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
 import io.confluent.kafkarest.response.FakeUrlFactory;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -638,6 +640,18 @@ public class TopicsResourceTest {
             .build());
 
     assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void createTopic_nonData_throwsInvalidPayload() {
+    FakeAsyncResponse response = new FakeAsyncResponse();
+
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () -> topicsResource.createTopic(response, TOPIC_1.getClusterId(), null));
+    assertEquals("Payload error. Null input provided. Data is required.", e.getMessage());
+    assertEquals(42206, e.getErrorCode());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -650,7 +650,7 @@ public class TopicsResourceTest {
         assertThrows(
             RestConstraintViolationException.class,
             () -> topicsResource.createTopic(response, TOPIC_1.getClusterId(), null));
-    assertEquals("Payload error. Null input provided. Data is required.", e.getMessage());
+    assertEquals("Payload error. Request body is empty. Data is required.", e.getMessage());
     assertEquals(42206, e.getErrorCode());
   }
 


### PR DESCRIPTION
When create topics without payload, a general server errors will return currently: 
```
curl -X POST http://localhost:9391/v3/clusters/kZ7pDeiQSS-9eRtOXlWSMQ/topics -H "Authorization: Basic ABC"

returns a {"error_code":500,"message":"Internal Server Error"}%
```

But this should be a user error, after the user adds payload, it should be resolved. The return message and error code should be clear to mention that.

Result for local manual test.
```
curl -X POST http://localhost:8082/v3/clusters/vD3GG4PqT0-C1UcpR1j-Ag/topics -H "Authorization: Basic ABC" -H "Content-Type:application/json"
{"error_code":42206,"message":"Payload error. Null input provided. Data is required."}% 
``` 

Result of unit test:
```
mvn -Dtest=TopicsResourceTest test
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.708 s - in io.confluent.kafkarest.resources.v2.TopicsResourceTest
[INFO] Running io.confluent.kafkarest.resources.v3.TopicsResourceTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.059 s - in io.confluent.kafkarest.resources.v3.TopicsResourceTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16.044 s
[INFO] Finished at: 2022-07-26T17:11:33-07:00
[INFO] ------------------------------------------------------------------------
jliu@C02DM32YMD6T kafka-rest % 
```

