### PR TITLE
Revert replacement of poll(Duration) with poll(long)

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -381,7 +381,7 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
    * be invoked with the lock held, i.e. after startRead().
    */
   private synchronized void getOrCreateConsumerRecords() {
-    ConsumerRecords<KafkaKeyT, KafkaValueT> polledRecords = consumer.poll(Duration.ZERO);
+    ConsumerRecords<KafkaKeyT, KafkaValueT> polledRecords = consumer.poll(0);
     // drain the iterator and buffer to list
     for (ConsumerRecord<KafkaKeyT, KafkaValueT> consumerRecord : polledRecords) {
       consumerRecords.add(consumerRecord);


### PR DESCRIPTION
#1035 replaced a usage of the deprecated [KafkaConsumer#poll(long)](https://github.com/apache/kafka/blob/0507597597e1d2d9adaa33b87e5ea509e12fd2f0/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L1167) API with the [KafkaConsumer#poll(Duration)](https://github.com/apache/kafka/blob/0507597597e1d2d9adaa33b87e5ea509e12fd2f0/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L1214) API in the internals of Kafka REST's Consume v2 API. There is a slight difference in behavior between the two KafkaConsumer APIs related to blocking during consumer rebalancing.
- See [this wiki](https://cwiki.apache.org/confluence/display/KAFKA/KIP-266%3A+Fix+consumer+indefinite+blocking+behavior#KIP266:Fixconsumerindefiniteblockingbehavior-Consumer#poll) for more details.

Unfortunately although this seemed fairly reasonable, we are seeing change in behavior which breaks some tests and can affect users of the Kafka REST Consume v2 API.
Because of that we will be reverting back to the old poll(long) API until we find a better alternative.

CC @dennisgermany 