### PR TITLE
KREST-7275 update openapi changes for batch acl

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -102,6 +102,33 @@ paths:
         '5XX':
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /clusters/{cluster_id}/acls:batch:
+    parameters:
+      - $ref: '#/components/parameters/ClusterId'
+
+    post:
+      summary: 'Batch Create ACLs'
+      operationId: batchCreateKafkaV3Acls
+      description: |-
+        Internal use only.
+
+        Creates ACLs.
+      tags:
+        - ACL (v3)
+      requestBody:
+        $ref: '#/components/requestBodies/BatchCreateAclRequest'
+      responses:
+        '201':
+          description: 'No Content'
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsErrorResponse'
+        '5XX':
+          $ref: '#/components/responses/ServerErrorResponse'
+
   /clusters/{cluster_id}/acls:
     parameters:
       - $ref: '#/components/parameters/ClusterId'
@@ -136,7 +163,7 @@ paths:
           $ref: '#/components/responses/ServerErrorResponse'
 
     post:
-      summary: 'Create ACLs'
+      summary: 'Create an ACL'
       operationId: createKafkaV3Acls
       description: |-
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
@@ -1723,6 +1750,17 @@ components:
         permission:
           $ref: '#/components/schemas/AclPermission'
 
+    CreateAclRequestDataList:
+      allOf:
+        - type: object
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateAclRequestData'
+
     CreateTopicRequestData:
       type: object
       required:
@@ -2440,6 +2478,30 @@ components:
             host: '*'
             operation: 'DESCRIBE'
             permission: 'DENY'
+
+    BatchCreateAclRequest:
+      description: 'The batch ACL creation request.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateAclRequestDataList'
+          example:
+            data:
+              - resource_type: 'CLUSTER'
+                resource_name: 'kafka-cluster'
+                pattern_type: 'LITERAL'
+                principal: 'principalType:principalName'
+                host: '*'
+                operation: 'DESCRIBE'
+                permission: 'DENY'
+              - resource_type: 'TOPIC'
+                resource_name: 'kafka-cluster'
+                pattern_type: 'LITERAL'
+                principal: 'principalType:principalName'
+                host: '*'
+                operation: 'READ'
+                permission: 'ALLOW'
+
 
     CreateTopicRequest:
       description: 'The topic creation request.'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -110,8 +110,6 @@ paths:
       summary: 'Batch Create ACLs'
       operationId: batchCreateKafkaV3Acls
       description: |-
-        Internal use only.
-
         Creates ACLs.
       tags:
         - ACL (v3)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AclManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AclManager.java
@@ -20,9 +20,11 @@ import io.confluent.kafkarest.entities.Acl.Operation;
 import io.confluent.kafkarest.entities.Acl.PatternType;
 import io.confluent.kafkarest.entities.Acl.Permission;
 import io.confluent.kafkarest.entities.Acl.ResourceType;
+import io.confluent.kafkarest.entities.v3.CreateAclRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
+import javax.ws.rs.BadRequestException;
 
 public interface AclManager {
 
@@ -67,4 +69,7 @@ public interface AclManager {
       @Nullable String host,
       Operation operation,
       Permission permission);
+
+  AclManager validateAclCreateParameters(List<CreateAclRequest> requests)
+      throws BadRequestException;
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateAclBatchRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateAclBatchRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class CreateAclBatchRequest {
+
+  CreateAclBatchRequest() {}
+
+  @JsonValue
+  public abstract CreateAclBatchRequestData getValue();
+
+  public static CreateAclBatchRequest create(CreateAclBatchRequestData value) {
+    return new AutoValue_CreateAclBatchRequest(value);
+  }
+
+  @JsonCreator
+  static CreateAclBatchRequest fromJson(CreateAclBatchRequestData value) {
+    return create(value);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateAclBatchRequestData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateAclBatchRequestData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+// import io.confluent.kafkarest.entities.Acl;
+
+@AutoValue
+public abstract class CreateAclBatchRequestData {
+
+  CreateAclBatchRequestData() {}
+
+  @JsonProperty("data")
+  public abstract ImmutableList<CreateAclRequest> getData();
+
+  public static CreateAclBatchRequestData create(List<CreateAclRequest> data) {
+    return new AutoValue_CreateAclBatchRequestData(ImmutableList.copyOf(data));
+  }
+
+  @JsonCreator
+  static CreateAclBatchRequestData fromJson(@JsonProperty("data") List<CreateAclRequest> data) {
+    return create(data);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateAclBatchRequestData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateAclBatchRequestData.java
@@ -19,9 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import io.confluent.kafkarest.Errors;
 import java.util.List;
-
-// import io.confluent.kafkarest.entities.Acl;
 
 @AutoValue
 public abstract class CreateAclBatchRequestData {
@@ -31,8 +30,14 @@ public abstract class CreateAclBatchRequestData {
   @JsonProperty("data")
   public abstract ImmutableList<CreateAclRequest> getData();
 
-  public static CreateAclBatchRequestData create(List<CreateAclRequest> data) {
-    return new AutoValue_CreateAclBatchRequestData(ImmutableList.copyOf(data));
+  public static CreateAclBatchRequestData create(List<CreateAclRequest> requests) {
+    CreateAclBatchRequestData request;
+    try {
+      request = new AutoValue_CreateAclBatchRequestData(ImmutableList.copyOf(requests));
+    } catch (NullPointerException e) {
+      throw Errors.invalidPayloadException("Empty input provided. Data is required.");
+    }
+    return request;
   }
 
   @JsonCreator

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/AsyncResponses.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/AsyncResponses.java
@@ -24,6 +24,8 @@ import javax.annotation.Nullable;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utilities to deal with {@link AsyncResponse}. */
 public final class AsyncResponses {
@@ -86,6 +88,8 @@ public final class AsyncResponses {
       return this;
     }
 
+    private static final Logger log = LoggerFactory.getLogger(AsyncResponse.class);
+
     /** Resumes this {@code AsyncResponseBuilder}. */
     public void asyncResume(AsyncResponse asyncResponse) {
       if (entityFuture == null) {
@@ -104,8 +108,10 @@ public final class AsyncResponses {
                 asyncResponse.resume(responseBuilder.entity(entity).build());
               }
             } else if (exception instanceof CompletionException) {
+              log.error("AsyncResponse CompletionException: {}", exception);
               asyncResponse.resume(exception.getCause());
             } else {
+              log.error("AsyncResponse generic exception: {}", exception);
               asyncResponse.resume(exception);
             }
           });

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/AsyncResponses.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/AsyncResponses.java
@@ -108,24 +108,18 @@ public final class AsyncResponses {
                 asyncResponse.resume(responseBuilder.entity(entity).build());
               }
             } else if (exception instanceof CompletionException) {
-              if (entity != null) {
-                log.error(
-                    "Erroring response entity: {}, {}, {} ",
-                    entity.getClass(),
-                    entity.hashCode(),
-                    entity);
-              }
-              log.error("AsyncResponse CompletionException: {}", exception);
+              log.error(
+                  "Async response CompletionException with error response entity of type {}: {}",
+                  entity != null ? entity.getClass() : "unknown",
+                  entity,
+                  exception);
               asyncResponse.resume(exception.getCause());
             } else {
-              if (entity != null) {
-                log.error(
-                    "Erroring response entity: {}, {}, {} ",
-                    entity.getClass(),
-                    entity.hashCode(),
-                    entity);
-              }
-              log.error("AsyncResponse generic exception: {}", exception);
+              log.error(
+                  "Async response exception with error response entity of type {}: {}",
+                  entity != null ? entity.getClass() : "unknown",
+                  entity,
+                  exception);
               asyncResponse.resume(exception);
             }
           });

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/AsyncResponses.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/AsyncResponses.java
@@ -108,9 +108,23 @@ public final class AsyncResponses {
                 asyncResponse.resume(responseBuilder.entity(entity).build());
               }
             } else if (exception instanceof CompletionException) {
+              if (entity != null) {
+                log.error(
+                    "Erroring response entity: {}, {}, {} ",
+                    entity.getClass(),
+                    entity.hashCode(),
+                    entity);
+              }
               log.error("AsyncResponse CompletionException: {}", exception);
               asyncResponse.resume(exception.getCause());
             } else {
+              if (entity != null) {
+                log.error(
+                    "Erroring response entity: {}, {}, {} ",
+                    entity.getClass(),
+                    entity.hashCode(),
+                    entity);
+              }
               log.error("AsyncResponse generic exception: {}", exception);
               asyncResponse.resume(exception);
             }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.AclManager;
 import io.confluent.kafkarest.entities.Acl;
 import io.confluent.kafkarest.entities.Acl.Operation;
@@ -158,24 +159,12 @@ public final class AclsResource {
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
       @Valid CreateAclRequest request) {
-    if (request.getResourceType() == Acl.ResourceType.ANY
-        || request.getResourceType() == Acl.ResourceType.UNKNOWN) {
-      throw new BadRequestException("resource_type cannot be ANY");
+
+    if (request == null) {
+      throw Errors.invalidPayloadException("Null input provided. Data is required.");
     }
-    if (request.getPatternType() == Acl.PatternType.ANY
-        || request.getPatternType() == Acl.PatternType.MATCH
-        || request.getPatternType() == Acl.PatternType.UNKNOWN) {
-      throw new BadRequestException(
-          String.format("pattern_type cannot be %s", request.getPatternType()));
-    }
-    if (request.getOperation() == Acl.Operation.ANY
-        || request.getOperation() == Acl.Operation.UNKNOWN) {
-      throw new BadRequestException("operation cannot be ANY");
-    }
-    if (request.getPermission() == Acl.Permission.ANY
-        || request.getPermission() == Acl.Permission.UNKNOWN) {
-      throw new BadRequestException("permission cannot be ANY");
-    }
+
+    validateParameters(request);
 
     CompletableFuture<Void> response =
         aclManager
@@ -210,6 +199,28 @@ public final class AclsResource {
                             .build())))
         .entity(response)
         .asyncResume(asyncResponse);
+  }
+
+  private void validateParameters(CreateAclRequest request) {
+
+    if (request.getResourceType() == Acl.ResourceType.ANY
+        || request.getResourceType() == Acl.ResourceType.UNKNOWN) {
+      throw new BadRequestException("resource_type cannot be ANY");
+    }
+    if (request.getPatternType() == Acl.PatternType.ANY
+        || request.getPatternType() == Acl.PatternType.MATCH
+        || request.getPatternType() == Acl.PatternType.UNKNOWN) {
+      throw new BadRequestException(
+          String.format("pattern_type cannot be %s", request.getPatternType()));
+    }
+    if (request.getOperation() == Acl.Operation.ANY
+        || request.getOperation() == Acl.Operation.UNKNOWN) {
+      throw new BadRequestException("operation cannot be ANY");
+    }
+    if (request.getPermission() == Acl.Permission.ANY
+        || request.getPermission() == Acl.Permission.UNKNOWN) {
+      throw new BadRequestException("permission cannot be ANY");
+    }
   }
 
   @DELETE

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
@@ -37,6 +37,7 @@ import io.confluent.kafkarest.resources.AsyncResponses.AsyncResponseBuilder;
 import io.confluent.kafkarest.response.UrlFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -164,11 +165,10 @@ public final class AclsResource {
       throw Errors.invalidPayloadException("Null input provided. Data is required.");
     }
 
-    validateParameters(request);
-
     CompletableFuture<Void> response =
         aclManager
             .get()
+            .validateAclCreateParameters(Collections.singletonList(request))
             .createAcl(
                 clusterId,
                 request.getResourceType(),
@@ -199,28 +199,6 @@ public final class AclsResource {
                             .build())))
         .entity(response)
         .asyncResume(asyncResponse);
-  }
-
-  private void validateParameters(CreateAclRequest request) {
-
-    if (request.getResourceType() == Acl.ResourceType.ANY
-        || request.getResourceType() == Acl.ResourceType.UNKNOWN) {
-      throw new BadRequestException("resource_type cannot be ANY");
-    }
-    if (request.getPatternType() == Acl.PatternType.ANY
-        || request.getPatternType() == Acl.PatternType.MATCH
-        || request.getPatternType() == Acl.PatternType.UNKNOWN) {
-      throw new BadRequestException(
-          String.format("pattern_type cannot be %s", request.getPatternType()));
-    }
-    if (request.getOperation() == Acl.Operation.ANY
-        || request.getOperation() == Acl.Operation.UNKNOWN) {
-      throw new BadRequestException("operation cannot be ANY");
-    }
-    if (request.getPermission() == Acl.Permission.ANY
-        || request.getPermission() == Acl.Permission.UNKNOWN) {
-      throw new BadRequestException("permission cannot be ANY");
-    }
   }
 
   @DELETE

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/CreateAclBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/CreateAclBatchAction.java
@@ -53,8 +53,8 @@ public final class CreateAclBatchAction {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  @PerformanceMetric("v3.acls.create")
-  @ResourceName("api.v3.acls.create")
+  @PerformanceMetric("v3.acls.batch-create")
+  @ResourceName("api.v3.acls.batch-create")
   public void createAcls(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
@@ -67,6 +67,7 @@ public final class CreateAclBatchAction {
     CompletableFuture<Void> response =
         aclManager
             .get()
+            .validateAclCreateParameters(request.getValue().getData().asList())
             .createAcls(
                 clusterId,
                 request.getValue().getData().stream()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/CreateAclBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/CreateAclBatchAction.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafkarest.Errors;
+import io.confluent.kafkarest.controllers.AclManager;
+import io.confluent.kafkarest.entities.Acl;
+import io.confluent.kafkarest.entities.v3.CreateAclBatchRequest;
+import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
+import io.confluent.kafkarest.resources.AsyncResponses;
+import io.confluent.rest.annotations.PerformanceMetric;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/v3/clusters/{clusterId}/acls:batch")
+@ResourceName("api.v3.acls.*")
+public final class CreateAclBatchAction {
+
+  private final Provider<AclManager> aclManager;
+
+  @Inject
+  public CreateAclBatchAction(Provider<AclManager> aclManager) {
+    this.aclManager = requireNonNull(aclManager);
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @PerformanceMetric("v3.acls.create")
+  @ResourceName("api.v3.acls.create")
+  public void createAcls(
+      @Suspended AsyncResponse asyncResponse,
+      @PathParam("clusterId") String clusterId,
+      @Valid CreateAclBatchRequest request) {
+
+    if (request == null) {
+      throw Errors.invalidPayloadException("Null input provided. Data is required.");
+    }
+
+    CompletableFuture<Void> response =
+        aclManager
+            .get()
+            .createAcls(
+                clusterId,
+                request.getValue().getData().stream()
+                    .map(
+                        aclEntry ->
+                            Acl.builder()
+                                .setClusterId(clusterId)
+                                .setResourceType(aclEntry.getResourceType())
+                                .setResourceName(aclEntry.getResourceName())
+                                .setPatternType(aclEntry.getPatternType())
+                                .setPrincipal(aclEntry.getPrincipal())
+                                .setPermission(aclEntry.getPermission())
+                                .setHost(aclEntry.getHost())
+                                .setOperation(aclEntry.getOperation())
+                                .build())
+                    .collect(Collectors.toList()));
+
+    AsyncResponses.AsyncResponseBuilder.from(Response.status(Response.Status.NO_CONTENT))
+        .entity(response)
+        .asyncResume(asyncResponse);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/V3ResourcesFeature.java
@@ -24,6 +24,7 @@ public final class V3ResourcesFeature implements Feature {
   public boolean configure(FeatureContext configurable) {
     configurable.register(V3ResourcesModule.class);
     configurable.register(AclsResource.class);
+    configurable.register(CreateAclBatchAction.class);
     configurable.register(AlterBrokerConfigBatchAction.class);
     configurable.register(AlterClusterConfigBatchAction.class);
     configurable.register(AlterTopicConfigBatchAction.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafkarest.entities.Acl;
 import io.confluent.kafkarest.entities.v3.AclData;
 import io.confluent.kafkarest.entities.v3.AclDataList;
+import io.confluent.kafkarest.entities.v3.CreateAclBatchRequest;
+import io.confluent.kafkarest.entities.v3.CreateAclBatchRequestData;
 import io.confluent.kafkarest.entities.v3.CreateAclRequest;
 import io.confluent.kafkarest.entities.v3.DeleteAclsResponse;
 import io.confluent.kafkarest.entities.v3.Resource;
@@ -31,6 +33,7 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.entities.v3.SearchAclsResponse;
 import io.confluent.kafkarest.integration.ClusterTestHarness;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
@@ -65,6 +68,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
 
   private String clusterId;
   private String baseAclUrl;
+  private String batchAclUrl;
   private String expectedAliceUrl;
   private String expectedBobUrl;
   private String expectedSearchUrl;
@@ -113,6 +117,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
 
     clusterId = getClusterId();
     baseAclUrl = "/v3/clusters/" + clusterId + "/acls";
+    batchAclUrl = baseAclUrl + ":batch";
     expectedAliceUrl =
         restConnect
             + baseAclUrl
@@ -330,5 +335,97 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(
         expectedMultiDeleteResponse,
         multiDeleteResourceTypeAll.readEntity(DeleteAclsResponse.class));
+  }
+
+  @Test
+  public void testBatchAclCreate() {
+
+    SearchAclsResponse expectedPreCreateSearchResponse =
+        SearchAclsResponse.create(
+            AclDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder().setSelf(expectedSearchUrl).build())
+                .setData(emptyList())
+                .build());
+
+    Response actualPreCreateSearchResponse =
+        request(
+                baseAclUrl,
+                ImmutableMap.of(
+                    "resource_type", "topic",
+                    "resource_name", "topic-1",
+                    "pattern_type", "match"))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), actualPreCreateSearchResponse.getStatus());
+    assertEquals(
+        expectedPreCreateSearchResponse,
+        actualPreCreateSearchResponse.readEntity(SearchAclsResponse.class));
+
+    CreateAclRequest bob =
+        CreateAclRequest.builder()
+            .setResourceType(Acl.ResourceType.TOPIC)
+            .setResourceName("topic-")
+            .setPatternType(Acl.PatternType.PREFIXED)
+            .setPrincipal("User:bob")
+            .setHost("1.2.3.4")
+            .setOperation(Acl.Operation.WRITE)
+            .setPermission(Acl.Permission.ALLOW)
+            .build();
+
+    CreateAclRequest alice =
+        CreateAclRequest.builder()
+            .setResourceType(Acl.ResourceType.TOPIC)
+            .setResourceName("*")
+            .setPatternType(Acl.PatternType.LITERAL)
+            .setPrincipal("User:alice")
+            .setHost("*")
+            .setOperation(Acl.Operation.READ)
+            .setPermission(Acl.Permission.ALLOW)
+            .build();
+
+    List<CreateAclRequest> acls = Arrays.asList(bob, alice);
+
+    CreateAclBatchRequestData data = CreateAclBatchRequestData.create(acls);
+
+    CreateAclBatchRequest list = CreateAclBatchRequest.create(data);
+
+    Response actualCreateAliceAndBobResponse =
+        request(batchAclUrl).post(Entity.entity(list, MediaType.APPLICATION_JSON));
+
+    assertEquals(Status.NO_CONTENT.getStatusCode(), actualCreateAliceAndBobResponse.getStatus());
+
+    SearchAclsResponse expectedPostCreateSearchResponse =
+        SearchAclsResponse.create(
+            AclDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder().setSelf(expectedSearchUrl).build())
+                .setData(
+                    Arrays.asList(
+                        ALICE_ACL_DATA
+                            .setMetadata(
+                                Resource.Metadata.builder().setSelf(expectedAliceUrl).build())
+                            .setClusterId(clusterId)
+                            .build(),
+                        BOB_ACL_DATA
+                            .setMetadata(
+                                Resource.Metadata.builder().setSelf(expectedBobUrl).build())
+                            .setClusterId(clusterId)
+                            .build()))
+                .build());
+
+    Response actualPostCreateSearchResponse =
+        request(
+                baseAclUrl,
+                ImmutableMap.of(
+                    "resource_type", "topic",
+                    "resource_name", "topic-1",
+                    "pattern_type", "match"))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), actualPostCreateSearchResponse.getStatus());
+    assertEquals(
+        expectedPostCreateSearchResponse,
+        actualPostCreateSearchResponse.readEntity(SearchAclsResponse.class));
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
@@ -428,4 +428,158 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
         expectedPostCreateSearchResponse,
         actualPostCreateSearchResponse.readEntity(SearchAclsResponse.class));
   }
+
+  @Test
+  public void testBatchAclCreateWithNoRequestBody() {
+
+    Response nullRequestBodyResponse =
+        request(batchAclUrl).post(Entity.entity(null, MediaType.APPLICATION_JSON));
+
+    assertEquals(422, nullRequestBodyResponse.getStatus());
+
+    SearchAclsResponse expectedPostCreateSearchResponse =
+        SearchAclsResponse.create(
+            AclDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder().setSelf(expectedSearchUrl).build())
+                .setData(Arrays.asList())
+                .build());
+
+    Response actualPostCreateSearchResponse =
+        request(
+                baseAclUrl,
+                ImmutableMap.of(
+                    "resource_type", "topic",
+                    "resource_name", "topic-1",
+                    "pattern_type", "match"))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), actualPostCreateSearchResponse.getStatus());
+    assertEquals(
+        expectedPostCreateSearchResponse,
+        actualPostCreateSearchResponse.readEntity(SearchAclsResponse.class));
+  }
+
+  @Test
+  public void testBatchAclCreateRequestWithBodyAndNoContent() {
+
+    Response emptyRequestBodyResponse =
+        request(batchAclUrl).post(Entity.entity("{}}", MediaType.APPLICATION_JSON));
+
+    assertEquals(422, emptyRequestBodyResponse.getStatus());
+
+    SearchAclsResponse expectedPostCreateSearchResponse =
+        SearchAclsResponse.create(
+            AclDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder().setSelf(expectedSearchUrl).build())
+                .setData(Arrays.asList())
+                .build());
+
+    Response actualPostCreateSearchResponse =
+        request(
+                baseAclUrl,
+                ImmutableMap.of(
+                    "resource_type", "topic",
+                    "resource_name", "topic-1",
+                    "pattern_type", "match"))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), actualPostCreateSearchResponse.getStatus());
+    assertEquals(
+        expectedPostCreateSearchResponse,
+        actualPostCreateSearchResponse.readEntity(SearchAclsResponse.class));
+  }
+
+  @Test
+  public void testBatchAclCreateWithBodyAndEmptyData() {
+
+    List<CreateAclRequest> acls = Arrays.asList();
+
+    CreateAclBatchRequestData data = CreateAclBatchRequestData.create(acls);
+
+    CreateAclBatchRequest list = CreateAclBatchRequest.create(data);
+
+    Response actualCreateAliceAndBobResponse =
+        request(batchAclUrl).post(Entity.entity(list, MediaType.APPLICATION_JSON));
+
+    assertEquals(Status.NO_CONTENT.getStatusCode(), actualCreateAliceAndBobResponse.getStatus());
+
+    SearchAclsResponse expectedPostCreateSearchResponse =
+        SearchAclsResponse.create(
+            AclDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder().setSelf(expectedSearchUrl).build())
+                .setData(Arrays.asList())
+                .build());
+
+    Response actualPostCreateSearchResponse =
+        request(
+                baseAclUrl,
+                ImmutableMap.of(
+                    "resource_type", "topic",
+                    "resource_name", "topic-1",
+                    "pattern_type", "match"))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), actualPostCreateSearchResponse.getStatus());
+    assertEquals(
+        expectedPostCreateSearchResponse,
+        actualPostCreateSearchResponse.readEntity(SearchAclsResponse.class));
+  }
+
+  @Test
+  public void testBatchAclCreateInvalidEntry() {
+
+    CreateAclRequest bob =
+        CreateAclRequest.builder()
+            .setResourceType(Acl.ResourceType.TOPIC)
+            .setResourceName("topic-")
+            .setPatternType(Acl.PatternType.PREFIXED)
+            .setPrincipal("User:bill")
+            .setHost("1.2.3.4")
+            .setOperation(Acl.Operation.WRITE)
+            .setPermission(Acl.Permission.ALLOW)
+            .build();
+
+    CreateAclRequest alice =
+        CreateAclRequest.builder()
+            .setResourceType(Acl.ResourceType.TOPIC)
+            .setResourceName("*")
+            .setPatternType(Acl.PatternType.LITERAL)
+            .setPrincipal("User:alice")
+            .setHost("*")
+            .setOperation(Acl.Operation.READ)
+            .setPermission(Acl.Permission.ALLOW)
+            .build();
+
+    String payload = "{\"data\": [{\"resource_type\":\"TOPIC\"}]}";
+
+    Response actualCreateAliceAndBobResponse =
+        request(batchAclUrl).post(Entity.entity(payload, MediaType.APPLICATION_JSON));
+
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), actualCreateAliceAndBobResponse.getStatus());
+
+    SearchAclsResponse expectedPostCreateSearchResponse =
+        SearchAclsResponse.create(
+            AclDataList.builder()
+                .setMetadata(
+                    ResourceCollection.Metadata.builder().setSelf(expectedSearchUrl).build())
+                .setData(Arrays.asList())
+                .build());
+
+    Response actualPostCreateSearchResponse =
+        request(
+                baseAclUrl,
+                ImmutableMap.of(
+                    "resource_type", "topic",
+                    "resource_name", "topic-1",
+                    "pattern_type", "match"))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), actualPostCreateSearchResponse.getStatus());
+    assertEquals(
+        expectedPostCreateSearchResponse,
+        actualPostCreateSearchResponse.readEntity(SearchAclsResponse.class));
+  }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AclsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AclsResourceTest.java
@@ -16,6 +16,7 @@
 package io.confluent.kafkarest.resources.v3;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -181,6 +182,7 @@ public class AclsResourceTest {
                 Acl.Operation.READ,
                 Acl.Permission.ALLOW))
         .andReturn(completedFuture(/* value= */ null));
+    expect(aclManager.validateAclCreateParameters(anyObject())).andReturn(aclManager);
     replay(aclManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/CreateAclBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/CreateAclBatchActionTest.java
@@ -16,6 +16,7 @@
 package io.confluent.kafkarest.resources.v3;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -76,6 +77,7 @@ public class CreateAclBatchActionTest {
   @Test
   public void createAcls_createsAcls() {
     expect(aclManager.createAcls(CLUSTER_ID, ACLS)).andReturn(completedFuture(/* value= */ null));
+    expect(aclManager.validateAclCreateParameters(anyObject())).andReturn(aclManager);
     replay(aclManager);
 
     CreateAclBatchRequest createRequest =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/CreateAclBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/CreateAclBatchActionTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.confluent.kafkarest.controllers.AclManager;
+import io.confluent.kafkarest.entities.Acl;
+import io.confluent.kafkarest.entities.v3.CreateAclBatchRequest;
+import io.confluent.kafkarest.entities.v3.CreateAclBatchRequestData;
+import io.confluent.kafkarest.entities.v3.CreateAclRequest;
+import io.confluent.kafkarest.response.FakeAsyncResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.easymock.EasyMockExtension;
+import org.easymock.Mock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(EasyMockExtension.class)
+public class CreateAclBatchActionTest {
+
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final Acl ACL_1 =
+      Acl.builder()
+          .setClusterId(CLUSTER_ID)
+          .setResourceType(Acl.ResourceType.TOPIC)
+          .setResourceName("*")
+          .setPatternType(Acl.PatternType.LITERAL)
+          .setPrincipal("User:alice")
+          .setHost("*")
+          .setOperation(Acl.Operation.READ)
+          .setPermission(Acl.Permission.ALLOW)
+          .build();
+  private static final Acl ACL_2 =
+      Acl.builder()
+          .setClusterId(CLUSTER_ID)
+          .setResourceType(Acl.ResourceType.TOPIC)
+          .setResourceName("topic-")
+          .setPatternType(Acl.PatternType.PREFIXED)
+          .setPrincipal("User:bob")
+          .setHost("1.2.3.4")
+          .setOperation(Acl.Operation.WRITE)
+          .setPermission(Acl.Permission.ALLOW)
+          .build();
+
+  private static final List<Acl> ACLS = Arrays.asList(ACL_1, ACL_2);
+
+  @Mock public AclManager aclManager;
+
+  private CreateAclBatchAction aclsResource;
+
+  @BeforeEach
+  public void setUp() {
+    aclsResource = new CreateAclBatchAction(() -> aclManager);
+  }
+
+  @Test
+  public void createAcls_createsAcls() {
+    expect(aclManager.createAcls(CLUSTER_ID, ACLS)).andReturn(completedFuture(/* value= */ null));
+    replay(aclManager);
+
+    CreateAclBatchRequest createRequest =
+        CreateAclBatchRequest.create(
+            CreateAclBatchRequestData.create(
+                ACLS.stream()
+                    .map(
+                        acl ->
+                            CreateAclRequest.builder()
+                                .setPrincipal(acl.getPrincipal())
+                                .setPermission(acl.getPermission())
+                                .setOperation(acl.getOperation())
+                                .setHost(acl.getHost())
+                                .setPatternType(acl.getPatternType())
+                                .setResourceName(acl.getResourceName())
+                                .setResourceType(acl.getResourceType())
+                                .build())
+                    .collect(Collectors.toList())));
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+
+    aclsResource.createAcls(response, CLUSTER_ID, createRequest);
+
+    assertNull(response.getValue());
+    assertNull(response.getException());
+  }
+}


### PR DESCRIPTION
This commit
 - updates the kafka-rest openapi.yaml to include the changes for batch acl create which are required by the UI

 - It ports the code from Tom's ce-kafka-rest PR into kafka-rest, making this a new publically available API.  This feels like the right thing to do, because it's a simple API (just a wrapper around the individual create API comment), it was odd to split to very linked APIs across two repos (and this made our lives much harder wrt eg the integration test and the openapi doc).

 - Add a null check in the single create ACL to avoid a NPE and the subsequent 500 error being returned to the user.  Unfortunately this typed the cyclomatic complexity of all the valid payload checks in the createAcl class over the limit, so I had to pull them out into a separate method.

 - Add a log.error of any stack traces that are part of the failed async processing future.  Without these it's really hard to debug what goes wrong if any of our async calls fail.  Note that this change does not alter what the end user sees, just what comes out in our logs.

For batch ACL, if one of the structures within the data array is malformend  (eg an enum value doesn't match) then none of the  ACLs are created.  However, if one of the structures in the data array contains a value that the broker needs to determine is invalid, then the other structures are still applied.  For example if the user id specified in the first item in the array of ACLs does not actually exist, then that ACL is not created, but the second ACL in the array of ACLs is created (assuming it is valid)