### PR TITLE
DOCS-16947, DOCS-14660 Produce v3 API from EA to Open Preview (platform, api repo, kafka-rest)

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1266,7 +1266,7 @@ paths:
     post:
       summary: 'Produce records to the given topic.'
       description: |-
-        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+        [![Open Preview](https://img.shields.io/badge/Lifecycle%20Stage-Open%20Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
 
         Produce records to the given topic, returning delivery reports for each
                     record produced. This API can be used in streaming mode by setting "Transfer-Encoding:


### PR DESCRIPTION
#### Description:
This PR targets 7.2.0-post for the change on the platform docs to be visible (just targeting `master` won't work on platform)

- https://confluentinc.atlassian.net/browse/DOCS-16947
- https://confluentinc.atlassian.net/browse/DOCS-14660

Related PR for platform: https://github.com/confluentinc/ce-kafka-rest/pull/347

Related PRs for the same change on Cloud API docs:
- https://github.com/confluentinc/ce-kafka-rest/pull/342
- https://github.com/confluentinc/api/pull/730


Signed-off-by: Victoria Bialas <vicky@confluent.io>