### PR TITLE
Log Describe log Dirs and log the topic name causing a 404 anyway

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/common/KafkaFutures.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/common/KafkaFutures.java
@@ -44,7 +44,7 @@ public final class KafkaFutures {
           if (exception == null) {
             completableFuture.complete(value);
           } else {
-            log.error("Caught Exception when Complete KafkaFuture", exception);
+            log.error("Caught Exception on completion of KafkaFuture", exception);
             completableFuture.completeExceptionally(exception);
           }
         });

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/common/KafkaFutures.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/common/KafkaFutures.java
@@ -44,7 +44,7 @@ public final class KafkaFutures {
           if (exception == null) {
             completableFuture.complete(value);
           } else {
-            log.error("Caught Exception on completion of KafkaFuture", exception);
+            log.debug("Caught Exception on completion of KafkaFuture", exception);
             completableFuture.completeExceptionally(exception);
           }
         });

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/common/KafkaFutures.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/common/KafkaFutures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2020 - 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -18,8 +18,12 @@ package io.confluent.kafkarest.common;
 import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class KafkaFutures {
+
+  private static final Logger log = LoggerFactory.getLogger(KafkaFutures.class);
 
   private KafkaFutures() {}
 
@@ -40,6 +44,7 @@ public final class KafkaFutures {
           if (exception == null) {
             completableFuture.complete(value);
           } else {
+            log.error("Caught Exception when Complete KafkaFuture", exception);
             completableFuture.completeExceptionally(exception);
           }
         });

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -100,6 +100,9 @@ final class PartitionManagerImpl implements PartitionManager {
               } else if (exception instanceof NotFoundException
                   || exception.getCause() instanceof NotFoundException) {
                 throw new NotFoundException(exception.getCause());
+              } else if (exception instanceof RuntimeException
+                  || exception.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) exception;
               }
               throw new CompletionException(exception.getCause());
             });

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -31,8 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsOptions;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
@@ -88,8 +88,10 @@ final class PartitionManagerImpl implements PartitionManager {
                       String.format(
                           "This server does not host this topic-partition for topic %s", topicName);
                   throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
+                } else if (exception.getCause() instanceof NotFoundException) {
+                  throw new NotFoundException(exception);
                 }
-                throw new CompletionException(exception);
+                throw new RuntimeException(exception);
               }
               return checkEntityExists(value, "Topic %s cannot be found.", value);
             })

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -89,14 +89,12 @@ final class PartitionManagerImpl implements PartitionManager {
         .thenApply(partitions -> partitions.stream().findAny())
         .exceptionally(
             exception -> {
-              if (exception != null) {
-                if (exception.getCause() instanceof UnknownTopicOrPartitionException) {
-                  String exceptionMessage =
-                      String.format(
-                          "This server does not host topic-partition %d for topic %s",
-                          partitionId, topicName);
-                  throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
-                }
+              if (exception.getCause() instanceof UnknownTopicOrPartitionException) {
+                String exceptionMessage =
+                    String.format(
+                        "This server does not host topic-partition %d for topic %s",
+                        partitionId, topicName);
+                throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
               } else if (exception instanceof NotFoundException
                   || exception.getCause() instanceof NotFoundException) {
                 throw new NotFoundException(exception.getCause());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsOptions;
@@ -88,11 +89,7 @@ final class PartitionManagerImpl implements PartitionManager {
                           "This server does not host this topic-partition for topic %s", topicName);
                   throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
                 }
-                try {
-                  throw exception;
-                } catch (Throwable throwable) {
-                  log.error("Caught another exception while re-throw exception", throwable);
-                }
+                throw new CompletionException(exception);
               }
               return checkEntityExists(value, "Topic %s cannot be found.", value);
             })

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -88,7 +88,7 @@ final class PartitionManagerImpl implements PartitionManager {
                       String.format(
                           "This server does not host this topic-partition for topic %s", topicName);
                   throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
-                } else if (exception.getCause() instanceof NotFoundException) {
+                } else if (exception instanceof NotFoundException) {
                   throw new NotFoundException(exception);
                 }
                 throw new RuntimeException(exception);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -93,7 +93,8 @@ final class PartitionManagerImpl implements PartitionManager {
                 if (exception.getCause() instanceof UnknownTopicOrPartitionException) {
                   String exceptionMessage =
                       String.format(
-                          "This server does not host this topic-partition for topic %s", topicName);
+                          "This server does not host topic-partition %d for topic %s",
+                          partitionId, topicName);
                   throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
                 }
               } else if (exception instanceof NotFoundException

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -88,7 +88,8 @@ final class PartitionManagerImpl implements PartitionManager {
                       String.format(
                           "This server does not host this topic-partition for topic %s", topicName);
                   throw new UnknownTopicOrPartitionException(exceptionMessage, exception);
-                } else if (exception instanceof NotFoundException) {
+                } else if (exception instanceof NotFoundException
+                    || exception.getCause() instanceof NotFoundException) {
                   throw new NotFoundException(exception);
                 }
                 throw new RuntimeException(exception);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2020 - 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -32,12 +32,16 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeLogDirsOptions;
 import org.apache.kafka.clients.admin.DescribeLogDirsResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class ReplicaManagerImpl implements ReplicaManager {
 
   private final Admin adminClient;
   private final BrokerManager brokerManager;
   private final PartitionManager partitionManager;
+
+  private static final Logger log = LoggerFactory.getLogger(ReplicaManagerImpl.class);
 
   @Inject
   ReplicaManagerImpl(
@@ -84,15 +88,22 @@ final class ReplicaManagerImpl implements ReplicaManager {
               return KafkaFutures.toCompletableFuture(result.values().get(brokerId));
             })
         .thenCompose(
-            logDirs ->
-                CompletableFutures.allAsList(
-                    logDirs.values().stream()
-                        .flatMap(logDir -> logDir.replicaInfos.keySet().stream())
-                        .map(
-                            partition ->
-                                getReplica(
-                                    clusterId, partition.topic(), partition.partition(), brokerId))
-                        .collect(Collectors.toList())))
+            logDirs -> {
+              logDirs.forEach((key, value) -> log.debug("Describe log Dirs" + key + value));
+              CompletableFuture<List<Optional<PartitionReplica>>> res =
+                  CompletableFutures.allAsList(
+                      logDirs.values().stream()
+                          .flatMap(logDir -> logDir.replicaInfos.keySet().stream())
+                          .map(
+                              partition ->
+                                  getReplica(
+                                      clusterId,
+                                      partition.topic(),
+                                      partition.partition(),
+                                      brokerId))
+                          .collect(Collectors.toList()));
+              return res;
+            })
         .thenApply(
             replicas ->
                 replicas.stream()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
@@ -89,7 +89,7 @@ final class ReplicaManagerImpl implements ReplicaManager {
             })
         .thenCompose(
             logDirs -> {
-              logDirs.forEach((key, value) -> log.debug("Describe log Dirs" + key + value));
+              log.debug("Describe log dirs {} ", logDirs);
               return CompletableFutures.allAsList(
                   logDirs.values().stream()
                       .flatMap(logDir -> logDir.replicaInfos.keySet().stream())

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ReplicaManagerImpl.java
@@ -90,19 +90,14 @@ final class ReplicaManagerImpl implements ReplicaManager {
         .thenCompose(
             logDirs -> {
               logDirs.forEach((key, value) -> log.debug("Describe log Dirs" + key + value));
-              CompletableFuture<List<Optional<PartitionReplica>>> res =
-                  CompletableFutures.allAsList(
-                      logDirs.values().stream()
-                          .flatMap(logDir -> logDir.replicaInfos.keySet().stream())
-                          .map(
-                              partition ->
-                                  getReplica(
-                                      clusterId,
-                                      partition.topic(),
-                                      partition.partition(),
-                                      brokerId))
-                          .collect(Collectors.toList()));
-              return res;
+              return CompletableFutures.allAsList(
+                  logDirs.values().stream()
+                      .flatMap(logDir -> logDir.replicaInfos.keySet().stream())
+                      .map(
+                          partition ->
+                              getReplica(
+                                  clusterId, partition.topic(), partition.partition(), brokerId))
+                      .collect(Collectors.toList()));
             })
         .thenApply(
             replicas ->

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
@@ -377,9 +377,7 @@ public class PartitionManagerImplTest {
         .andReturn(
             failedFuture(
                 new UnknownTopicOrPartitionException(
-                    String.format(
-                        "This server does not host topic-partition %d for topic %s",
-                        0, TOPIC_NAME))));
+                    "This server does not host this topic-partition.")));
     replay(topicManager);
 
     try {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/PartitionManagerImplTest.java
@@ -378,8 +378,8 @@ public class PartitionManagerImplTest {
             failedFuture(
                 new UnknownTopicOrPartitionException(
                     String.format(
-                        "This server does not host this topic-partition for topic %s",
-                        TOPIC_NAME))));
+                        "This server does not host topic-partition %d for topic %s",
+                        0, TOPIC_NAME))));
     replay(topicManager);
 
     try {
@@ -388,7 +388,7 @@ public class PartitionManagerImplTest {
     } catch (ExecutionException e) {
       assertEquals(UnknownTopicOrPartitionException.class, e.getCause().getClass());
       assertEquals(
-          String.format("This server does not host this topic-partition for topic %s", TOPIC_NAME),
+          String.format("This server does not host topic-partition %d for topic %s", 0, TOPIC_NAME),
           e.getCause().getMessage());
     }
   }


### PR DESCRIPTION
If there are stray partition of topic, the user will see 404, but the user can't see which topic has stray partition. We added the following information related to this:

1. add a debug line that logs the response from getLogDirs ```[2022-09-07 12:16:44,626] DEBUG Describe log Dirs/tmp/kafka-logs/server0(error=NONE, replicas={tst-53=(size=0, offsetLag=-1, isFuture=false), tst-86=(size=0, offsetLag=-1, isFuture=false), tst-20=(size=0, offsetLag=-1, isFuture=false), test-32=(size=0, offsetLag=0, isFuture=false), tst-111=(size=0, offsetLag=-1, isFuture=false), test-98=(size=0, offsetLag=0, isFuture=false), tst-45=(size=0, offsetLag=-1, isFuture=false), tst-78=(size=0, offsetLag=-1, isFuture=false), tst-12=(size=0, offsetLag=-1, isFuture=false), test-24=(size=0, offsetLag=0, isFuture=false), tst-103=(size=0, offsetLag=-1, isFuture=false), test-90=(size=0, offsetLag=0, isFuture=false), tst-37=(size=0, offsetLag=-1, isFuture=false), tst-70=(size=0, offsetLag=-1, isFuture=false), tst-4=(size=0, offsetLag=-1, isFuture=false), test-48=(size=0, offsetLag=0, isFuture=false), tst-95=(size=0, offsetLag=-1, isFuture=false), test-114=(size=0, offsetLag=0, isFuture=false), tst-29=(size=0, offsetLag=-1, isFuture=false), tst-62=(size=0, offsetLag=-1, isFuture=false), test-40=(size=0, offsetLag=0, isFuture=false), tst-87=(size=0, offsetLag=-1, isFuture=false), test-106=(size=0, offsetLag=0, isFuture=false), tst-120=(size=0, offsetLag=-1, isFuture=false), tst-21=(size=0, offsetLag=-1, isFuture=false), tst-54=(size=0, offsetLag=-1, isFuture=false), test-64=(size=0, offsetLag=0, isFuture=false), tst-79=(size=0, offsetLag=-1, isFuture=false), tst-112=(size=0, offsetLag=-1, isFuture=false), tst-13=(size=0, offsetLag=-1, isFuture=false), tst-46=(size=0, offsetLag=-1, isFuture=false), test-56=(size=0, offsetLag=0, isFuture=false), tst-71=(size=0, offsetLag=-1, isFuture=false), test-122=(size=0, offsetLag=0, isFuture=false), tst-104=(size=0, offsetLag=-1, isFuture=false), tst-5=(size=0, offsetLag=-1, isFuture=false), tst-38=(size=0, offsetLag=-1, isFuture=false), test-14=(size=0, offsetLag=0, isFuture=false), test-80=(size=0, offsetLag=0, isFuture=false), tst-63=(size=0, offsetLag=-1, isFuture=false), tst-96=(size=0, offsetLag=-1, isFuture=false), tst-30=(size=0, offsetLag=-1, isFuture=false), test-6=(size=0, offsetLag=0, isFuture=false), tst-121=(size=0, offsetLag=-1, isFuture=false), test-72=(size=0, offsetLag=0, isFuture=false), tst-55=(size=0, offsetLag=-1, isFuture=false), tst-88=(size=0, offsetLag=-1, isFuture=false), test-92=(size=0, offsetLag=0, isFuture=false), tst-22=(size=0, offsetLag=-1, isFuture=false), tst-113=(size=0, offsetLag=-1, isFuture=false), tst-47=(size=0, offsetLag=-1, isFuture=false), test-34=(size=0, offsetLag=0, isFuture=false), tst-80=(size=0, offsetLag=-1, isFuture=false), test-84=(size=0, offsetLag=0, isFuture=false), tst-14=(size=0, offsetLag=-1, isFuture=false), tst-105=(size=0, offsetLag=-1, isFuture=false), tst-39=(size=0, offsetLag=-1, isFuture=false), test-26=(size=0, offsetLag=0, isFuture=false), tst-72=(size=0, offsetLag=-1, isFuture=false), test-108=(size=0, offsetLag=0, isFuture=false), tst-6=(size=0, offsetLag=-1, isFuture=false), tst-97=(size=0, offsetLag=-1, isFuture=false), tst-31=(size=0, offsetLag=-1, isFuture=false), test-50=(size=0, offsetLag=0, isFuture=false), tst-64=(size=0, offsetLag=-1, isFuture=false), test-100=(size=0, offsetLag=0, isFuture=false), tst-89=(size=0, offsetLag=-1, isFuture=false), tst-122=(size=0, offsetLag=-1, isFuture=false), tst-23=(size=0, offsetLag=-1, isFuture=false), test-42=(size=0, offsetLag=0, isFuture=false), tst-56=(size=0, offsetLag=-1, isFuture=false), test-124=(size=0, offsetLag=0, isFuture=false), tst-81=(size=0, offsetLag=-1, isFuture=false), test-0=(size=0, offsetLag=0, isFuture=false), tst-114=(size=0, offsetLag=-1, isFuture=false), tst-15=(size=0, offsetLag=-1, isFuture=false), test-66=(size=0, offsetLag=0, isFuture=false), tst-48=(size=0, offsetLag=-1, isFuture=false), test-116=(size=0, offsetLag=0, isFuture=false), tst-73=(size=0, offsetLag=-1, isFuture=false), tst-106=(size=0, offsetLag=-1, isFuture=false), tst-7=(size=0, offsetLag=-1, isFuture=false), test-58=(size=0, offsetLag=0, isFuture=false), tst-40=(size=0, offsetLag=-1, isFuture=false), tst-65=(size=0, offsetLag=-1, isFuture=false), test-16=(size=0, offsetLag=0, isFuture=false), tst-98=(size=0, offsetLag=-1, isFuture=false), test-82=(size=0, offsetLag=0, isFuture=false), tst-32=(size=0, offsetLag=-1, isFuture=false), tst-123=(size=0, offsetLag=-1, isFuture=false), tst-57=(size=0, offsetLag=-1, isFuture=false), test-8=(size=0, offsetLag=0, isFuture=false), tst-90=(size=0, offsetLag=-1, isFuture=false), test-74=(size=0, offsetLag=0, isFuture=false), tst-24=(size=0, offsetLag=-1, isFuture=false), test-28=(size=0, offsetLag=0, isFuture=false), tst-115=(size=0, offsetLag=-1, isFuture=false), test-94=(size=0, offsetLag=0, isFuture=false), tst-49=(size=0, offsetLag=-1, isFuture=false), tst-82=(size=0, offsetLag=-1, isFuture=false), tst-16=(size=0, offsetLag=-1, isFuture=false), test-20=(size=0, offsetLag=0, isFuture=false), tst-107=(size=0, offsetLag=-1, isFuture=false), test-86=(size=0, offsetLag=0, isFuture=false), tst-41=(size=0, offsetLag=-1, isFuture=false), tst-74=(size=0, offsetLag=-1, isFuture=false), tst-8=(size=0, offsetLag=-1, isFuture=false), test-44=(size=0, offsetLag=0, isFuture=false), tst-99=(size=0, offsetLag=-1, isFuture=false), test-110=(size=0, offsetLag=0, isFuture=false), tst-33=(size=0, offsetLag=-1, isFuture=false), tst-66=(size=0, offsetLag=-1, isFuture=false), tst-0=(size=0, offsetLag=-1, isFuture=false), test-36=(size=0, offsetLag=0, isFuture=false), tst-91=(size=0, offsetLag=-1, isFuture=false), test-102=(size=0, offsetLag=0, isFuture=false), tst-124=(size=0, offsetLag=-1, isFuture=false), tst-25=(size=0, offsetLag=-1, isFuture=false), tst-58=(size=0, offsetLag=-1, isFuture=false), test-60=(size=0, offsetLag=0, isFuture=false), tst-83=(size=0, offsetLag=-1, isFuture=false), test-126=(size=0, offsetLag=0, isFuture=false), tst-116=(size=0, offsetLag=-1, isFuture=false), tst-17=(size=0, offsetLag=-1, isFuture=false), tst-50=(size=0, offsetLag=-1, isFuture=false), test-2=(size=0, offsetLag=0, isFuture=false), test-52=(size=0, offsetLag=0, isFuture=false), tst-75=(size=0, offsetLag=-1, isFuture=false), test-118=(size=0, offsetLag=0, isFuture=false), tst-108=(size=0, offsetLag=-1, isFuture=false), tst-9=(size=0, offsetLag=-1, isFuture=false), tst-42=(size=0, offsetLag=-1, isFuture=false), test-76=(size=0, offsetLag=0, isFuture=false), tst-67=(size=0, offsetLag=-1, isFuture=false), tst-100=(size=0, offsetLag=-1, isFuture=false), tst-1=(size=0, offsetLag=-1, isFuture=false), tst-34=(size=0, offsetLag=-1, isFuture=false), test-18=(size=0, offsetLag=0, isFuture=false), tst-125=(size=0, offsetLag=-1, isFuture=false), test-68=(size=0, offsetLag=0, isFuture=false), tst-59=(size=0, offsetLag=-1, isFuture=false), tst-92=(size=0, offsetLag=-1, isFuture=false), tst-26=(size=0, offsetLag=-1, isFuture=false), test-10=(size=0, offsetLag=0, isFuture=false), tst-117=(size=0, offsetLag=-1, isFuture=false), tst-51=(size=0, offsetLag=-1, isFuture=false), test-30=(size=0, offsetLag=0, isFuture=false), tst-84=(size=0, offsetLag=-1, isFuture=false), test-96=(size=0, offsetLag=0, isFuture=false), tst-18=(size=0, offsetLag=-1, isFuture=false), tst-109=(size=0, offsetLag=-1, isFuture=false), tst-43=(size=0, offsetLag=-1, isFuture=false), test-22=(size=0, offsetLag=0, isFuture=false), tst-76=(size=0, offsetLag=-1, isFuture=false), test-88=(size=0, offsetLag=0, isFuture=false), tst-10=(size=0, offsetLag=-1, isFuture=false), tst-101=(size=0, offsetLag=-1, isFuture=false), tst-35=(size=0, offsetLag=-1, isFuture=false), test-46=(size=0, offsetLag=0, isFuture=false), tst-68=(size=0, offsetLag=-1, isFuture=false), test-112=(size=0, offsetLag=0, isFuture=false), tst-2=(size=0, offsetLag=-1, isFuture=false), tst-93=(size=0, offsetLag=-1, isFuture=false), tst-126=(size=0, offsetLag=-1, isFuture=false), tst-27=(size=0, offsetLag=-1, isFuture=false), test-38=(size=0, offsetLag=0, isFuture=false), tst-60=(size=0, offsetLag=-1, isFuture=false), test-104=(size=0, offsetLag=0, isFuture=false), tst-85=(size=0, offsetLag=-1, isFuture=false), tst-118=(size=0, offsetLag=-1, isFuture=false), tst-19=(size=0, offsetLag=-1, isFuture=false), test-62=(size=0, offsetLag=0, isFuture=false), tst-52=(size=0, offsetLag=-1, isFuture=false), tst-77=(size=0, offsetLag=-1, isFuture=false), tst-110=(size=0, offsetLag=-1, isFuture=false), tst-11=(size=0, offsetLag=-1, isFuture=false), test-54=(size=0, offsetLag=0, isFuture=false), tst-44=(size=0, offsetLag=-1, isFuture=false), test-120=(size=0, offsetLag=0, isFuture=false), tst-69=(size=0, offsetLag=-1, isFuture=false), test-12=(size=0, offsetLag=0, isFuture=false), tst-102=(size=0, offsetLag=-1, isFuture=false), tst-3=(size=0, offsetLag=-1, isFuture=false), test-78=(size=0, offsetLag=0, isFuture=false), tst-36=(size=0, offsetLag=-1, isFuture=false), tst-127=(size=0, offsetLag=-1, isFuture=false), tst-61=(size=0, offsetLag=-1, isFuture=false), test-4=(size=0, offsetLag=0, isFuture=false), tst-94=(size=0, offsetLag=-1, isFuture=false), test-70=(size=0, offsetLag=0, isFuture=false), tst-28=(size=0, offsetLag=-1, isFuture=false), tst-119=(size=0, offsetLag=-1, isFuture=false)}) (io.confluent.kafkarest.controllers.ReplicaManagerImpl:92)```
2. log the topic causing a 404 anyway: ```curl http://localhost:8082/v3/clusters/eWEhwPqSSD6HrqZSjtXyYQ/brokers/0/partition-replicas
{"error_code":40403,"message":"This server does not host this topic-partition for topic tst"}% ```

3. logged exception information:
```
[2022-09-08 22:11:25,656] ERROR Caught Exception on completion of KafkaFuture (io.confluent.kafkarest.common.KafkaFutures:47)
java.util.concurrent.CompletionException: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:636)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)
	at org.apache.kafka.common.internals.KafkaCompletableFuture.kafkaCompleteExceptionally(KafkaCompletableFuture.java:49)
	at org.apache.kafka.common.internals.KafkaFutureImpl.completeExceptionally(KafkaFutureImpl.java:130)
	at org.apache.kafka.common.KafkaFuture.lambda$allOf$2(KafkaFuture.java:93)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)
	at org.apache.kafka.common.internals.KafkaCompletableFuture.kafkaCompleteExceptionally(KafkaCompletableFuture.java:49)
	at org.apache.kafka.common.internals.KafkaFutureImpl.completeExceptionally(KafkaFutureImpl.java:130)
	at org.apache.kafka.clients.admin.KafkaAdminClient$5.handleResponse(KafkaAdminClient.java:1980)
	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.handleResponses(KafkaAdminClient.java:1268)
	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.processRequests(KafkaAdminClient.java:1421)
	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.run(KafkaAdminClient.java:1344)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.
```