### PR TITLE
KREST-7091 POC of request tracing with focus on Produce v3

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -35,6 +35,7 @@ import io.confluent.kafkarest.ratelimit.RateLimitFeature;
 import io.confluent.kafkarest.resources.ResourcesFeature;
 import io.confluent.kafkarest.response.JsonStreamMessageBodyReader;
 import io.confluent.kafkarest.response.ResponseModule;
+import io.confluent.kafkarest.tracing.TracingFeature;
 import io.confluent.rest.Application;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
@@ -105,9 +106,8 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     config.register(RateLimitFeature.class);
     config.register(new ResourcesFeature(appConfig));
     config.register(new ResponseModule());
-
+    config.register(TracingFeature.class);
     config.register(ResourceAccesslistFeature.class);
-
     config.register(EnumConverterProvider.class);
     config.register(InstantConverterProvider.class);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMain.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMain.java
@@ -41,6 +41,7 @@ public class KafkaRestMain {
   /** Starts an embedded Jetty server running the REST server. */
   public static void main(String[] args) throws IOException {
     try {
+      log.info("Starting server with diagnostic patch KREST-7091, not suitable for production !!!");
       KafkaRestConfig config = new KafkaRestConfig((args.length > 0 ? args[0] : null));
 
       KafkaRestApplication app = new KafkaRestApplication(config);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -32,6 +32,7 @@ import io.confluent.kafkarest.exceptions.RestConstraintViolationExceptionMapper;
 import io.confluent.kafkarest.exceptions.StatusCodeException;
 import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
 import io.confluent.kafkarest.exceptions.v3.V3ExceptionMapper;
+import io.confluent.kafkarest.tracing.Tracer;
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
@@ -41,6 +42,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -152,13 +154,14 @@ public abstract class StreamingResponse<T> {
         this, transform, chunkedOutputFactory, maxDuration, gracePeriod);
   }
 
+  // TODO ddimitrov Make traceId an instance field in a way minimally intrusive to tests.
   /**
    * Stream requests in and start transforming them into responses.
    *
    * <p>This method will block until all requests are read in. The responses are computed and
    * written to {@code asyncResponse} asynchronously.
    */
-  public final void resume(AsyncResponse asyncResponse) {
+  public final void resume(AsyncResponse asyncResponse, UUID traceId) {
     log.debug("Resuming StreamingResponse");
     AsyncResponseQueue responseQueue = new AsyncResponseQueue(chunkedOutputFactory);
     responseQueue.asyncResume(asyncResponse);
@@ -173,7 +176,9 @@ public abstract class StreamingResponse<T> {
           if (executorService == null) {
             executorService = Executors.newSingleThreadScheduledExecutor();
             executorService.schedule(
-                () -> closeAll(responseQueue), gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
+                () -> closeAll(responseQueue, traceId),
+                gracePeriod.toMillis(),
+                TimeUnit.MILLISECONDS);
           }
           next();
           responseQueue.push(
@@ -185,7 +190,7 @@ public abstract class StreamingResponse<T> {
                               "Streaming connection open for longer than allowed",
                               "Connection will be closed.")))));
         } else if (!closingStarted) {
-          responseQueue.push(next().handle(this::handleNext));
+          responseQueue.push(next().handle((result, error) -> handleNext(result, error, traceId)));
         } else {
           break;
         }
@@ -197,7 +202,7 @@ public abstract class StreamingResponse<T> {
               ResultOrError.error(EXCEPTION_MAPPER.toErrorResponse(e))));
     } finally {
       close();
-      responseQueue.close();
+      responseQueue.close(traceId);
       if (executorService != null) {
         executorService.shutdown();
         try {
@@ -211,16 +216,18 @@ public abstract class StreamingResponse<T> {
     }
   }
 
-  private void closeAll(AsyncResponseQueue responseQueue) {
+  private void closeAll(AsyncResponseQueue responseQueue, UUID traceId) {
     closingStarted = true;
     close();
-    responseQueue.close();
+    responseQueue.close(traceId);
   }
 
-  private ResultOrError handleNext(T result, @Nullable Throwable error) {
+  private ResultOrError handleNext(T result, @Nullable Throwable error, UUID traceId) {
     if (error == null) {
+      Tracer.trace(traceId, "Successfully produced a record");
       return ResultOrError.result(result);
     } else {
+      Tracer.trace(traceId, "Error %s while producing a record", error);
       log.debug("Error processing streaming operation.", error);
       return ResultOrError.error(EXCEPTION_MAPPER.toErrorResponse(error.getCause()));
     }
@@ -374,9 +381,10 @@ public abstract class StreamingResponse<T> {
                   });
     }
 
-    private void close() {
+    private void close(UUID traceId) {
       tail.whenComplete(
           (unused, throwable) -> {
+            Tracer.trace(traceId, "Closing the produce batch or stream");
             try {
               sinkClosed = true;
               sink.close();

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/FirstInterceptTraceFilter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/FirstInterceptTraceFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.tracing;
+
+import java.io.IOException;
+import java.util.UUID;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+
+/**
+ * Initializes tracing when Kafka REST request tracing is enabled. Triggered before the incoming
+ * request has been matched (successfully or unsuccessfully) to a resource method.
+ */
+@PreMatching
+public class FirstInterceptTraceFilter implements ContainerRequestFilter {
+
+  private static final String FIRST_INTERCEPT_TRACE_TEMPLATE = "Received a %s request to %s";
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    UUID traceId = UUID.randomUUID();
+    requestContext.setProperty(Tracer.TRACE_ID_PROPERTY_NAME, traceId);
+    Tracer.trace(
+        traceId,
+        FIRST_INTERCEPT_TRACE_TEMPLATE,
+        requestContext.getMethod(),
+        requestContext.getUriInfo().getAbsolutePath());
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/RequestTraceFilter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/RequestTraceFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.tracing;
+
+import java.io.IOException;
+import java.util.UUID;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+
+/**
+ * Traces after the request handling when Kafka REST request tracing is enabled. Uses a priority
+ * even lower than {@link Priorities#USER} in order to be triggered after all the other request
+ * filters have been triggered.
+ */
+@Priority(Priorities.USER + 1000)
+public class RequestTraceFilter implements ContainerRequestFilter {
+
+  private static final String REQUEST_TRACE_TEMPLATE = "Request matched with %s";
+
+  @Context private ResourceInfo matchedResource;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    UUID traceId = (UUID) requestContext.getProperty(Tracer.TRACE_ID_PROPERTY_NAME);
+    if (traceId == null) {
+      throw new IllegalStateException("traceId cannot be null if request tracing has been enabled");
+    }
+    Tracer.trace(traceId, REQUEST_TRACE_TEMPLATE, matchedResource.getResourceMethod());
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/ResponseTraceFilter.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/ResponseTraceFilter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.tracing;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.UUID;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+
+/**
+ * Traces after the response handling when Kafka REST request tracing is enabled. Uses a priority
+ * even higher than {@link Priorities#AUTHENTICATION} in order to be triggered after all the other
+ * response filters have been triggered.
+ */
+@Priority(Priorities.AUTHENTICATION - 1000)
+public class ResponseTraceFilter implements ContainerResponseFilter {
+
+  private static final String RESPONSE_TRACE_TEMPLATE =
+      "Response with status code %d and Content-Length %d is being returned";
+
+  @Context private ResourceInfo matchedResource;
+
+  @Override
+  public void filter(
+      ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+      throws IOException {
+    UUID traceId = (UUID) requestContext.getProperty(Tracer.TRACE_ID_PROPERTY_NAME);
+    if (traceId == null) {
+      throw new IllegalStateException("traceId cannot be null if request tracing has been enabled");
+    }
+    Tracer.trace(
+        traceId, RESPONSE_TRACE_TEMPLATE, responseContext.getStatus(), responseContext.getLength());
+    Method matchedMethod = matchedResource.getResourceMethod();
+    if (matchedMethod != null && !matchedMethod.toString().contains("ProduceAction")) {
+      Tracer.cleanup(traceId);
+    }
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/Tracer.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/Tracer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.tracing;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO ddimitrov Should we make this injectable and provided to all the places from which we want
+//  to trace? On one hand making it injectable is the idiomatic way to make it a statically
+//  pluggable feature, on the other hand keeping it a static utility is the cheapest way to
+//  implement tracing.
+/**
+ * Used for tracing requests when Kafka REST request tracing is enabled.
+ *
+ * <p>"Request tracing" here includes tracing across both the request and the response handling.
+ */
+public final class Tracer {
+
+  public static final String TRACE_ID_PROPERTY_NAME = "io.confluent.kafkarest.tracing.traceId";
+
+  private static final Logger logger = LoggerFactory.getLogger(Tracer.class);
+
+  private static final LoadingCache<UUID, AtomicInteger> knownTraceIds =
+      CacheBuilder.newBuilder()
+          .maximumSize(1_000_000)
+          .expireAfterAccess(Duration.ofMinutes(1))
+          .build(CacheLoader.from(key -> new AtomicInteger(0)));
+
+  /**
+   * Makes the given message the next trace link in the trace chain of the given {@code traceId}.
+   *
+   * @param traceId The ID identifying the trace chain of the request which is being traced.
+   * @param message The next message to be traced and added to the trace chain of some request. It
+   *     should contain details for the corresponding step of the request/response handling. It can
+   *     be a template that can be populated with the arguments provided via the {@code args}
+   *     parameter.
+   * @param args Varargs for the {@code message} parameter in case it refers to a String template.
+   *     Should be null if {@code message} does not refer to a String template.
+   */
+  public static void trace(UUID traceId, String message, Object... args) {
+    if (traceId != null && logger.isTraceEnabled()) {
+      long timestampNs = System.nanoTime();
+      AtomicInteger traceCounter = knownTraceIds.getUnchecked(traceId);
+      String traceMessage = args == null ? message : String.format(message, args);
+      logger.trace(
+          "[Trace #{} for traceId {} @ {} ns]: {}",
+          traceCounter.incrementAndGet(),
+          traceId,
+          timestampNs,
+          traceMessage);
+    }
+  }
+
+  public static void cleanup(UUID traceId) {
+    knownTraceIds.invalidate(traceId);
+  }
+
+  public static boolean isEnabled() {
+    return logger.isTraceEnabled();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/TracingFeature.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/tracing/TracingFeature.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.tracing;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+public final class TracingFeature implements Feature {
+
+  @Override
+  public boolean configure(FeatureContext context) {
+    if (Tracer.isEnabled()) {
+      context.register(FirstInterceptTraceFilter.class);
+      context.register(RequestTraceFilter.class);
+      context.register(ResponseTraceFilter.class);
+      return true;
+    }
+    return false;
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -164,7 +164,7 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     EasyMock.verify(requests);
@@ -271,7 +271,7 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse1 = new FakeAsyncResponse();
     produceAction1.produce(
-        fakeAsyncResponse1, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse1, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     EasyMock.verify(requests);
@@ -364,10 +364,10 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
     FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     // check results
@@ -467,10 +467,10 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
     FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     verify(
@@ -550,10 +550,10 @@ public class ProduceActionTest {
     // run test
     FakeAsyncResponse fakeAsyncResponse = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse, "clusterId", "topicName", new JsonStream<>(() -> requests));
     FakeAsyncResponse fakeAsyncResponse2 = new FakeAsyncResponse();
     produceAction.produce(
-        fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
+        null, fakeAsyncResponse2, "clusterId", "topicName", new JsonStream<>(() -> requests));
 
     // check results
     verify(
@@ -612,7 +612,7 @@ public class ProduceActionTest {
     RestConstraintViolationException e =
         assertThrows(
             RestConstraintViolationException.class,
-            () -> produceAction.produce(fakeAsyncResponse, "clusterId", "topicName", null));
+            () -> produceAction.produce(null, fakeAsyncResponse, "clusterId", "topicName", null));
     assertEquals("Payload error. Null input provided. Data is required.", e.getMessage());
     assertEquals(42206, e.getErrorCode());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/StreamingResponseTest.java
@@ -101,7 +101,7 @@ public class StreamingResponseTest {
     produceResponseFuture.complete(produceResponse);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    streamingResponse.compose(result -> produceResponseFuture).resume(response);
+    streamingResponse.compose(result -> produceResponseFuture).resume(response, null);
 
     EasyMock.verify(mockedChunkedOutput);
     EasyMock.verify(mockedChunkedOutputFactory);
@@ -165,7 +165,7 @@ public class StreamingResponseTest {
     produceResponseFuture.complete(produceResponse);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    streamingResponse.compose(result -> produceResponseFuture).resume(response);
+    streamingResponse.compose(result -> produceResponseFuture).resume(response, null);
 
     EasyMock.verify(mockedChunkedOutput);
     EasyMock.verify(mockedChunkedOutputFactory);
@@ -207,7 +207,7 @@ public class StreamingResponseTest {
 
     FakeAsyncResponse response = new FakeAsyncResponse();
 
-    streamingResponse.compose(result -> new CompletableFuture<>()).resume(response);
+    streamingResponse.compose(result -> new CompletableFuture<>()).resume(response, null);
 
     EasyMock.verify(mockedChunkedOutput);
     EasyMock.verify(mockedChunkedOutputFactory);
@@ -247,7 +247,7 @@ public class StreamingResponseTest {
 
     FakeAsyncResponse response = new FakeAsyncResponse();
 
-    streamingResponse.compose(result -> new CompletableFuture<>()).resume(response);
+    streamingResponse.compose(result -> new CompletableFuture<>()).resume(response, null);
 
     EasyMock.verify(mockedChunkedOutput);
     EasyMock.verify(mockedChunkedOutputFactory);
@@ -356,7 +356,7 @@ public class StreamingResponseTest {
             result -> {
               return produceResponseFuture;
             })
-        .resume(response);
+        .resume(response, null);
 
     EasyMock.verify(mockedChunkedOutput);
     EasyMock.verify(mockedChunkedOutputFactory);


### PR DESCRIPTION
This is a POC of a basic request tracing mechanism that intercepts requests, sets up a trace ID for each request, and traces (via logging) various stages of the request and response handling.

The POC uses Jersey filters for the main tracing pointcuts - it intercepts with a pre-matching request filter, post-matching request filter, and a response filter. The trace ID that can be extracted from the `ContainerRequestContext` can be used in the corresponding resources for further tracing (e.g. tracing just before making a Kafka RPC and just after receiving a result from it). The POC does that just for the Produce v3 API where it traces the parsing and sending of records, the reception of results (or errors), and the closing of the so-called produce batch or stream and the corresponding response channel.

It has been tested with a Produce v3 workload of ~80 concurrent req/sec and seemed to work well, being able to provide various data points about E2E latency from the Kafka REST POV, Produce v3 request outliers, etc.