### PR TITLE
Fix default consumer timeout

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerReadTask.java
@@ -70,7 +70,8 @@ class KafkaConsumerReadTask<KafkaKeyT, KafkaValueT, ClientKeyT, ClientValueT> {
     this.maxResponseBytes =
         Math.min(maxBytes, config.getLong(KafkaRestConfig.CONSUMER_REQUEST_MAX_BYTES_CONFIG));
     Duration defaultRequestTimeout =
-        parent.getConsumerInstanceConfig().getRequestWaitMs() != null
+        parent.getConsumerInstanceConfig().getRequestWaitMs() != null 
+        && parent.getConsumerInstanceConfig().getRequestWaitMs() > 0
             ? Duration.ofMillis(parent.getConsumerInstanceConfig().getRequestWaitMs())
             : Duration.ofMillis(config.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG));
     this.requestTimeout =


### PR DESCRIPTION
The default timeout does not check for zero. This results in default timeout to be set as zero in case a zero is passed in the request param.