### PR TITLE
KREST-7107 Shouldn't provide overly detailed info or stack traces in responses -…

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -274,7 +274,17 @@ public abstract class StreamingResponse<T> {
     @SuppressWarnings("unchecked")
     private ErrorResponse toErrorResponse(Throwable error) {
       Response response = mapper.toResponse((T) error);
-      return ErrorResponse.create(errorCode.apply(response), message.apply(response));
+      String originalMessage = message.apply(response);
+      // The example of exception message is `{"error_code":400,"message":"Bad Request: Error
+      // processing message: Unexpected character ('o' (code 111)): was expecting comma to separate
+      // Object entries\n at [Source:
+      // (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream);
+      // line: 1, column: 4]"}`
+      // We don't want to show users the source information, so we need to remove them after the
+      // newline.
+      String messageWithoutSource =
+          originalMessage == null ? null : originalMessage.split("\\n")[0].trim();
+      return ErrorResponse.create(errorCode.apply(response), messageWithoutSource);
     }
   }
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -280,10 +280,10 @@ public abstract class StreamingResponse<T> {
       // Object entries\n at [Source:
       // (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream);
       // line: 1, column: 4]"}`
-      // We don't want to show users the source information, so we need to remove them after the
-      // newline.
+      // We don't want to show users the source information, so we need to remove everything after
+      // the newline.
       String messageWithoutSource =
-          originalMessage == null ? null : originalMessage.split("\\n")[0].trim();
+          originalMessage == null ? "" : originalMessage.split("\\n")[0].trim();
       return ErrorResponse.create(errorCode.apply(response), messageWithoutSource);
     }
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -199,6 +199,27 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
+  public void produceWithInvalidData_throwsBadRequest() throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    String request = "{ \"records\": {\"subject\": \"foobar\" } }";
+
+    Response response =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .request()
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    ErrorResponse actual = response.readEntity(ErrorResponse.class);
+    assertEquals(400, actual.getErrorCode());
+    assertEquals(
+        "Unrecognized field \"records\" (class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), not marked as ignorable (6 known properties: \"value\", \"originalSize\", \"partitionId\", \"headers\", \"key\", \"timestamp\"])",
+        actual.getMessage());
+  }
+
+  @Test
   public void produceJson() throws Exception {
     String clusterId = testEnv.kafkaCluster().getClusterId();
     String key = "foo";


### PR DESCRIPTION
… Follow up

This is cherry-pick of https://github.com/confluentinc/kafka-rest/pull/1071/filesThis fix is related to v3 version.
```
     curl -X POST \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
     --data '{"records":[{"key":"abc","value":"alarm clock"},{"key":"htanaka","value":"batteries"},{"key":"awalther","value":"bookshelves"}]}' \
     "http://localhost:8082/v3/clusters/vD3GG4PqT0-C1UcpR1j-Ag/topics/tst/records"
{"error_code":400,"message":"Unrecognized field \"records\" (class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), not marked as ignorable (6 known properties: \"value\", \"originalSize\", \"partitionId\", \"headers\", \"key\", \"timestamp\"])\n at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 129] (through reference chain: io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder[\"records\"])"}
The source part shouldn't include the source part
```
This fix is security related, so need to start from 5.4.x, then pint merge to 7.4.x and master, but since the fix from this PR was added from 6.2.x, so this one we only need to 6.2.x to 7.4.x and master
