### PR TITLE
Fix the line longer than 100 characters issue

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -215,7 +215,10 @@ public class ProduceActionIntegrationTest {
     ErrorResponse actual = response.readEntity(ErrorResponse.class);
     assertEquals(400, actual.getErrorCode());
     assertEquals(
-        "Unrecognized field \"records\" (class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), not marked as ignorable (6 known properties: \"value\", \"originalSize\", \"partitionId\", \"headers\", \"key\", \"timestamp\"])",
+        "Unrecognized field \"records\" "
+            + "(class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), "
+            + "not marked as ignorable (6 known properties: \"value\", \"originalSize\", "
+            + "\"partitionId\", \"headers\", \"key\", \"timestamp\"])",
         actual.getMessage());
   }
 


### PR DESCRIPTION
After pint merged https://github.com/confluentinc/kafka-rest/pull/1072 from 6.2.x to master, all the branches looks good except the 7.3.x

This is the error
```
13:34:39  [ERROR] /home/jenkins/workspace/confluentinc_kafka-rest_7.3.x/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java:225: Line is longer than 100 characters (found 247). [LineLength]
```