### PR TITLE
KREST-8306 update batch acl openapi

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -116,7 +116,7 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/BatchCreateAclRequest'
       responses:
-        '201':
+        '204':
           description: 'No Content'
         '400':
           $ref: '#/components/responses/BadRequestErrorResponse'


### PR DESCRIPTION
Batch acl returns a no content, which is actually a 204 not a 201