### PR TITLE
Fix build breakage caused by KAFKA-14334

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -107,7 +107,8 @@ public class AuthorizationErrorTest
             1,
             false,
             1,
-            (short) 1);
+            (short) 1,
+            false);
     brokerProps.put(KafkaConfig.BrokerIdProp(), Integer.toString(i));
     brokerProps.put(KafkaConfig.ZkConnectProp(), zkConnect);
     brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -333,7 +333,8 @@ public abstract class ClusterTestHarness {
             1,
             false,
             1,
-            (short) 1);
+            (short) 1,
+            false);
     props.setProperty("auto.create.topics.enable", "false");
     // We *must* override this to use the port we allocated (Kafka currently allocates one port
     // that it always uses for ZK


### PR DESCRIPTION
KAFKA-14334 changed a kafka.utils.TestUtils method [by adding a default argument](https://github.com/confluentinc/kafka/commit/dbf5826cd545820652ed6d136727aa80a03f4f54#diff-b8f9f9d1b191457cbdb332a3429f0ad65b50fa4cef5af8562abcfd1f177a2cfeR216-R218) (Scala). Unfortunately this is a breaking change for Java downstream dependencies.

Verified with a local `mvn clean package -DskipTests` build.