### PR TITLE
KREST-3009 Add ability to update partition count on a topic

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -2448,9 +2448,9 @@ components:
     UpdatePartitionCountRequestData:
       type: object
       required:
-        - partition_count
+        - partitions_count
       properties:
-        partition_count:
+        partitions_count:
           type: integer
           format: int32
 
@@ -2675,7 +2675,7 @@ components:
             schema:
               $ref: "#/components/schemas/UpdatePartitionCountRequestData"
             example: 
-               partition_count: 10
+               partitions_count: 10
 
 
   responses:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -898,6 +898,29 @@ paths:
         '5XX':
           $ref: '#/components/responses/ServerErrorResponse'
 
+    patch:
+      summary: 'Update partition count'
+      operationId: updatePartitionCountKafkaV3Topic
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+        Increases number of partitions on a topic.  
+      tags:
+        - Topic (v3)
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePartitionCountRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GetTopicResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsErrorResponse'
+        '5XX':
+          $ref: '#/components/responses/ServerErrorResponse'
+        
     delete:
       summary: 'Delete Topic'
       operationId: deleteKafkaV3Topic
@@ -2422,6 +2445,15 @@ components:
           type: string
           nullable: true
 
+    UpdatePartitionCountRequestData:
+      type: object
+      required:
+        - partition_count
+      properties:
+        partition_count:
+          type: integer
+          format: int32
+
   requestBodies:
     AlterBrokerConfigBatchRequest:
       description: 'The alter broker configuration parameter batch request.'
@@ -2499,7 +2531,6 @@ components:
                 host: '*'
                 operation: 'READ'
                 permission: 'ALLOW'
-
 
     CreateTopicRequest:
       description: 'The topic creation request.'
@@ -2636,6 +2667,16 @@ components:
             $ref: "#/components/schemas/UpdateConfigRequestData"
           example:
             value: 'gzip'
+
+    UpdatePartitionCountRequest:
+      description : 'The number of partitions to increase the partition count to.'
+      content:
+         application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePartitionCountRequestData"
+            example: 
+               partition_count: 10
+
 
   responses:
     CreateTopicResponse:

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -156,6 +156,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -251,7 +251,7 @@
                             <skip>true</skip>
                         </configuration>
                     </plugin>
-    
+
                     <!-- skip integration tests because they do not include smoke tests (other components have smoke tests) -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -78,5 +78,5 @@ public interface TopicManager {
   /** Deletes the Kafka {@link Topic} with the given {@code topicName}. */
   CompletableFuture<Void> deleteTopic(String clusterId, String topicName);
 
-  CompletableFuture<Void> updateTopicPartitionCount(String topicName, Integer partitionCount);
+  CompletableFuture<Void> updateTopicPartitionsCount(String topicName, Integer partitionsCount);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -77,4 +77,6 @@ public interface TopicManager {
 
   /** Deletes the Kafka {@link Topic} with the given {@code topicName}. */
   CompletableFuture<Void> deleteTopic(String clusterId, String topicName);
+
+  CompletableFuture<Void> updateTopicPartitionCount(String topicName, Integer partitionCount);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -27,6 +27,7 @@ import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
@@ -232,5 +234,13 @@ final class TopicManagerImpl implements TopicManager {
             cluster ->
                 KafkaFutures.toCompletableFuture(
                     adminClient.deleteTopics(singletonList(topicName)).all()));
+  }
+
+  @Override
+  public CompletableFuture<Void> updateTopicPartitionCount(
+      String topicName, Integer partitionCount) {
+    Map<String, NewPartitions> newPartitionsMap =
+        Collections.singletonMap(topicName, NewPartitions.increaseTo(partitionCount));
+    return KafkaFutures.toCompletableFuture(adminClient.createPartitions(newPartitionsMap).all());
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -237,10 +237,10 @@ final class TopicManagerImpl implements TopicManager {
   }
 
   @Override
-  public CompletableFuture<Void> updateTopicPartitionCount(
-      String topicName, Integer partitionCount) {
+  public CompletableFuture<Void> updateTopicPartitionsCount(
+      String topicName, Integer partitionsCount) {
     Map<String, NewPartitions> newPartitionsMap =
-        Collections.singletonMap(topicName, NewPartitions.increaseTo(partitionCount));
+        Collections.singletonMap(topicName, NewPartitions.increaseTo(partitionsCount));
     return KafkaFutures.toCompletableFuture(adminClient.createPartitions(newPartitionsMap).all());
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionCountRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionCountRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class PartitionCountRequest {
+
+  PartitionCountRequest() {}
+
+  @JsonProperty("partition_count")
+  public abstract Integer getPartitionCount();
+
+  public static Builder builder() {
+    return new AutoValue_PartitionCountRequest.Builder();
+  }
+
+  @JsonCreator
+  static PartitionCountRequest fromJson(@JsonProperty("partition_count") Integer partitionCount) {
+    return builder().setPartitionCount(partitionCount).build();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    Builder() {}
+
+    public abstract Builder setPartitionCount(Integer partitionCount);
+
+    public abstract PartitionCountRequest build();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionsCountRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/PartitionsCountRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -20,20 +20,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-public abstract class PartitionCountRequest {
+public abstract class PartitionsCountRequest {
 
-  PartitionCountRequest() {}
+  PartitionsCountRequest() {}
 
-  @JsonProperty("partition_count")
-  public abstract Integer getPartitionCount();
+  @JsonProperty("partitions_count")
+  public abstract Integer getPartitionsCount();
 
   public static Builder builder() {
-    return new AutoValue_PartitionCountRequest.Builder();
+    return new AutoValue_PartitionsCountRequest.Builder();
   }
 
   @JsonCreator
-  static PartitionCountRequest fromJson(@JsonProperty("partition_count") Integer partitionCount) {
-    return builder().setPartitionCount(partitionCount).build();
+  static PartitionsCountRequest fromJson(
+      @JsonProperty("partitions_count") Integer partitionsCount) {
+    return builder().setPartitionsCount(partitionsCount).build();
   }
 
   @AutoValue.Builder
@@ -41,8 +42,8 @@ public abstract class PartitionCountRequest {
 
     Builder() {}
 
-    public abstract Builder setPartitionCount(Integer partitionCount);
+    public abstract Builder setPartitionsCount(Integer partitionsCount);
 
-    public abstract PartitionCountRequest build();
+    public abstract PartitionsCountRequest build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -27,7 +27,7 @@ import io.confluent.kafkarest.entities.v3.CreateTopicRequest.ConfigEntry;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicsResponse;
-import io.confluent.kafkarest.entities.v3.PartitionCountRequest;
+import io.confluent.kafkarest.entities.v3.PartitionsCountRequest;
 import io.confluent.kafkarest.entities.v3.Resource;
 import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.entities.v3.TopicData;
@@ -140,20 +140,20 @@ public final class TopicsResource {
   @Produces(MediaType.APPLICATION_JSON)
   @PerformanceMetric("v3.topics.partitions")
   @ResourceName("api.v3.topics.partitions")
-  public void updatePartitionCount(
+  public void updatePartitionsCount(
       @Suspended AsyncResponse asyncResponse,
       @PathParam("clusterId") String clusterId,
       @PathParam("topicName") String topicName,
-      @Valid PartitionCountRequest partitionCount) {
+      @Valid PartitionsCountRequest partitionsCount) {
 
-    if (partitionCount == null) {
-      throw Errors.invalidPayloadException("Request body is empty. Partition_count is required.");
+    if (partitionsCount == null) {
+      throw Errors.invalidPayloadException("Request body is empty. Partitions_count is required.");
     }
 
     CompletableFuture<GetTopicResponse> response =
         topicManager
             .get()
-            .updateTopicPartitionCount(topicName, partitionCount.getPartitionCount())
+            .updateTopicPartitionsCount(topicName, partitionsCount.getPartitionsCount())
             .thenCompose(
                 nothing ->
                     topicManager

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -862,7 +862,7 @@ public class TopicManagerImplTest {
 
     replay(adminClient, createPartitionsResult);
 
-    topicManager.updateTopicPartitionCount("topicName", 1);
+    topicManager.updateTopicPartitionsCount("topicName", 1);
     verify(adminClient);
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicManagerImplTest.java
@@ -42,6 +42,7 @@ import io.confluent.kafkarest.entities.Topic;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -50,10 +51,12 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.NotFoundException;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreatePartitionsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
@@ -451,6 +454,8 @@ public class TopicManagerImplTest {
 
   @Mock private DeleteTopicsResult deleteTopicsResult;
 
+  @Mock private CreatePartitionsResult createPartitionsResult;
+
   private TopicManagerImpl topicManager;
 
   @BeforeEach
@@ -844,6 +849,21 @@ public class TopicManagerImplTest {
     } catch (ExecutionException e) {
       assertEquals(NotFoundException.class, e.getCause().getClass());
     }
+  }
+
+  @Test
+  public void alterTopicPartitions_validPartitionRequest_returnsTopic() {
+
+    expect(
+            adminClient.createPartitions(
+                Collections.singletonMap("topicName", anyObject(NewPartitions.class))))
+        .andReturn(createPartitionsResult);
+    expect(createPartitionsResult.all()).andReturn(KafkaFuture.completedFuture(null));
+
+    replay(adminClient, createPartitionsResult);
+
+    topicManager.updateTopicPartitionCount("topicName", 1);
+    verify(adminClient);
   }
 
   private static Map<String, TopicDescription> createTopicDescriptionMap(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -76,6 +76,9 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.eclipse.jetty.server.Server;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -375,22 +378,47 @@ public abstract class ClusterTestHarness {
     zookeeper.shutdown();
   }
 
+  protected Invocation.Builder request(String path, boolean useAlternateConnectorProvider) {
+    return request(path, null, null, null, true);
+  }
+
   protected Invocation.Builder request(String path) {
-    return request(path, null, null, null);
+    return request(path, null, null, null, false);
   }
 
   protected Invocation.Builder request(String path, Map<String, String> queryParams) {
-    return request(path, null, null, queryParams);
+    return request(path, null, null, queryParams, false);
   }
 
   protected Invocation.Builder request(String path, String templateName, Object templateValue) {
-    return request(path, templateName, templateValue, null);
+    return request(path, templateName, templateValue, null, false);
   }
 
   protected Invocation.Builder request(
-      String path, String templateName, Object templateValue, Map<String, String> queryParams) {
+      String path,
+      String templateName,
+      Object templateValue,
+      Map<String, String> queryParams,
+      boolean useAlternateConnectorProvider) {
 
-    Client client = getClient();
+    Client client;
+    if (useAlternateConnectorProvider) {
+      // The PATCH method requires a workaround of
+      // .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true) to be set for the
+      // Jersey client we use for testing to recognise the PATCH call.
+      // The default client does not support this property at Java 17 (it does at Java 8)
+      // so we need to use an alternative provider for any tests that use PATCH.
+      // Leaving existing client behaviour for other integration tests so we don't unintentionally
+      // change other test behaviour
+      ClientConfig clientConfig = new ClientConfig();
+      clientConfig.connectorProvider(new ApacheConnectorProvider());
+      client =
+          ClientBuilder.newClient(clientConfig)
+              .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
+    } else {
+      client = getClient();
+    }
+
     // Only configure base application here because as a client we shouldn't need the resources
     // registered
     restApp.configureBaseApplication(client);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -731,7 +731,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void updateTopicPartitions_IncreasePartitionCount_returnsTopicWithIncreasedPartitions() {
+  public void updateTopicPartitions_IncreasePartitionsCount_returnsTopicWithIncreasedPartitions() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -775,7 +775,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .method(
                 HttpMethod.PATCH,
-                Entity.entity("{\"partition_count\":3}", MediaType.APPLICATION_JSON));
+                Entity.entity("{\"partitions_count\":3}", MediaType.APPLICATION_JSON));
     assertEquals(Status.OK.getStatusCode(), getTopicResponse.getStatus());
 
     GetTopicResponse actualCreateTopicResponse =
@@ -785,7 +785,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void updateTopicPartitions_decreasePartitionCount_returns40002() {
+  public void updateTopicPartitions_decreasePartitionsCount_returns40002() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -794,12 +794,12 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .method(
                 HttpMethod.PATCH,
-                Entity.entity("{\"partition_count\":1}", MediaType.APPLICATION_JSON));
+                Entity.entity("{\"partitions_count\":1}", MediaType.APPLICATION_JSON));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
   }
 
   @Test
-  public void updateTopicPartitions_samePartitionCount_returns40002() {
+  public void updateTopicPartitions_samePartitionsCount_returns40002() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
@@ -808,7 +808,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .method(
                 HttpMethod.PATCH,
-                Entity.entity("{\"partition_count\":1}", MediaType.APPLICATION_JSON));
+                Entity.entity("{\"partitions_count\":1}", MediaType.APPLICATION_JSON));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
   }
 
@@ -822,7 +822,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .method(
                 HttpMethod.PATCH,
-                Entity.entity("{\"partition_count\":1}", MediaType.APPLICATION_JSON));
+                Entity.entity("{\"partitions_count\":1}", MediaType.APPLICATION_JSON));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -35,6 +35,7 @@ import io.confluent.kafkarest.entities.v3.TopicDataList;
 import io.confluent.kafkarest.integration.ClusterTestHarness;
 import java.util.Arrays;
 import java.util.Properties;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -48,6 +49,8 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   private static final String TOPIC_2 = "topic-2";
   private static final String TOPIC_3 = "topic-3";
 
+  private static final boolean USE_ALTERNATE_CLIENT_PROVIDER = true;
+
   public TopicsResourceIntegrationTest() {
     super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
   }
@@ -57,7 +60,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   public void setUp() throws Exception {
     super.setUp();
 
-    createTopic(TOPIC_1, 1, (short) 1);
+    createTopic(TOPIC_1, 2, (short) 1);
     createTopic(TOPIC_2, 1, (short) 1);
     createTopic(TOPIC_3, 1, (short) 1);
   }
@@ -99,7 +102,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                             .setTopicName(TOPIC_1)
                             .setInternal(false)
                             .setReplicationFactor(1)
-                            .setPartitionsCount(1)
+                            .setPartitionsCount(2)
                             .setPartitions(
                                 Resource.Relationship.create(
                                     baseUrl
@@ -252,7 +255,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(TOPIC_1)
                 .setInternal(false)
                 .setReplicationFactor(1)
-                .setPartitionsCount(1)
+                .setPartitionsCount(2)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -451,7 +454,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 Entity.entity(
                     "{\"topic_name\":\""
                         + TOPIC_1
-                        + "\",\"partitions_count\":1,\\"
+                        + "\",\"partitions_count\":2,\\"
                         + "replication_factor\":1}",
                     MediaType.APPLICATION_JSON));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -725,5 +728,101 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .get();
     assertEquals(Status.NOT_FOUND.getStatusCode(), deletedGetTopicResponse.getStatus());
+  }
+
+  @Test
+  public void updateTopicPartitions_IncreasePartitionCount_returnsTopicWithIncreasedPartitions() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    GetTopicResponse expected =
+        GetTopicResponse.create(
+            TopicData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/topics/" + TOPIC_1)
+                        .setResourceName("crn:///kafka=" + clusterId + "/topic=" + TOPIC_1)
+                        .build())
+                .setClusterId(clusterId)
+                .setTopicName(TOPIC_1)
+                .setInternal(false)
+                .setReplicationFactor(1)
+                .setPartitionsCount(3)
+                .setPartitions(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/topics/"
+                            + TOPIC_1
+                            + "/partitions"))
+                .setConfigs(
+                    Resource.Relationship.create(
+                        baseUrl + "/v3/clusters/" + clusterId + "/topics/" + TOPIC_1 + "/configs"))
+                .setPartitionReassignments(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/topics/"
+                            + TOPIC_1
+                            + "/partitions/-/reassignment"))
+                .setAuthorizedOperations(emptySet())
+                .build());
+
+    Response getTopicResponse =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1, USE_ALTERNATE_CLIENT_PROVIDER)
+            .accept(MediaType.APPLICATION_JSON)
+            .method(
+                HttpMethod.PATCH,
+                Entity.entity("{\"partition_count\":3}", MediaType.APPLICATION_JSON));
+    assertEquals(Status.OK.getStatusCode(), getTopicResponse.getStatus());
+
+    GetTopicResponse actualCreateTopicResponse =
+        getTopicResponse.readEntity(GetTopicResponse.class);
+
+    assertEquals(expected, actualCreateTopicResponse);
+  }
+
+  @Test
+  public void updateTopicPartitions_decreasePartitionCount_returns40002() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    Response getTopicResponse =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1, USE_ALTERNATE_CLIENT_PROVIDER)
+            .accept(MediaType.APPLICATION_JSON)
+            .method(
+                HttpMethod.PATCH,
+                Entity.entity("{\"partition_count\":1}", MediaType.APPLICATION_JSON));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
+  }
+
+  @Test
+  public void updateTopicPartitions_samePartitionCount_returns40002() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    Response getTopicResponse =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1, USE_ALTERNATE_CLIENT_PROVIDER)
+            .accept(MediaType.APPLICATION_JSON)
+            .method(
+                HttpMethod.PATCH,
+                Entity.entity("{\"partition_count\":1}", MediaType.APPLICATION_JSON));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
+  }
+
+  @Test
+  public void updateTopicPartitions_topicDoesntExist_returns40002() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+
+    Response getTopicResponse =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1, USE_ALTERNATE_CLIENT_PROVIDER)
+            .accept(MediaType.APPLICATION_JSON)
+            .method(
+                HttpMethod.PATCH,
+                Entity.entity("{\"partition_count\":1}", MediaType.APPLICATION_JSON));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -37,7 +37,7 @@ import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicsResponse;
-import io.confluent.kafkarest.entities.v3.PartitionCountRequest;
+import io.confluent.kafkarest.entities.v3.PartitionsCountRequest;
 import io.confluent.kafkarest.entities.v3.Resource;
 import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.entities.v3.TopicData;
@@ -696,7 +696,7 @@ public class TopicsResourceTest {
 
   @Test
   public void testUpdatePartitions() {
-    expect(topicManager.updateTopicPartitionCount(TOPIC_1.getName(), 3))
+    expect(topicManager.updateTopicPartitionsCount(TOPIC_1.getName(), 3))
         .andReturn(CompletableFuture.completedFuture(null));
     expect(topicManager.getTopic(TOPIC_1.getClusterId(), TOPIC_1.getName()))
         .andReturn(completedFuture(Optional.of(TOPIC_1)));
@@ -704,8 +704,8 @@ public class TopicsResourceTest {
     replay(topicManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    PartitionCountRequest request = PartitionCountRequest.builder().setPartitionCount(3).build();
-    topicsResource.updatePartitionCount(
+    PartitionsCountRequest request = PartitionsCountRequest.builder().setPartitionsCount(3).build();
+    topicsResource.updatePartitionsCount(
         response, TOPIC_1.getClusterId(), TOPIC_1.getName(), request);
 
     GetTopicResponse expected = GetTopicResponse.create(newTopicData("topic-1", true, 3, 3));
@@ -717,16 +717,16 @@ public class TopicsResourceTest {
   public void testUpdatePartitionsNoRequest() {
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    PartitionCountRequest request = null;
+    PartitionsCountRequest request = null;
 
     RestConstraintViolationException e =
         assertThrows(
             RestConstraintViolationException.class,
             () ->
-                topicsResource.updatePartitionCount(
+                topicsResource.updatePartitionsCount(
                     response, TOPIC_1.getClusterId(), TOPIC_1.getName(), request));
     assertEquals(
-        "Payload error. Request body is empty. Partition_count is required.", e.getMessage());
+        "Payload error. Request body is empty. Partitions_count is required.", e.getMessage());
     assertEquals(42206, e.getErrorCode());
   }
 
@@ -735,14 +735,14 @@ public class TopicsResourceTest {
 
     CompletableFuture<Void> future = new CompletableFuture();
     future.completeExceptionally(new Exception("Oh no"));
-    expect(topicManager.updateTopicPartitionCount(TOPIC_1.getName(), 2)).andReturn(future);
+    expect(topicManager.updateTopicPartitionsCount(TOPIC_1.getName(), 2)).andReturn(future);
 
     replay(topicManager);
 
     FakeAsyncResponse response = new FakeAsyncResponse();
-    PartitionCountRequest request = PartitionCountRequest.builder().setPartitionCount(2).build();
+    PartitionsCountRequest request = PartitionsCountRequest.builder().setPartitionsCount(2).build();
 
-    topicsResource.updatePartitionCount(
+    topicsResource.updatePartitionsCount(
         response, TOPIC_1.getClusterId(), TOPIC_1.getName(), request);
 
     assertEquals("Oh no", response.getException().getMessage());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -37,6 +37,7 @@ import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
 import io.confluent.kafkarest.entities.v3.CreateTopicResponse;
 import io.confluent.kafkarest.entities.v3.GetTopicResponse;
 import io.confluent.kafkarest.entities.v3.ListTopicsResponse;
+import io.confluent.kafkarest.entities.v3.PartitionCountRequest;
 import io.confluent.kafkarest.entities.v3.Resource;
 import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.entities.v3.TopicData;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import javax.ws.rs.NotFoundException;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -690,5 +692,59 @@ public class TopicsResourceTest {
     topicsResource.deleteTopic(response, TOPIC_1.getClusterId(), TOPIC_1.getName());
 
     assertEquals(NotFoundException.class, response.getException().getClass());
+  }
+
+  @Test
+  public void testUpdatePartitions() {
+    expect(topicManager.updateTopicPartitionCount(TOPIC_1.getName(), 3))
+        .andReturn(CompletableFuture.completedFuture(null));
+    expect(topicManager.getTopic(TOPIC_1.getClusterId(), TOPIC_1.getName()))
+        .andReturn(completedFuture(Optional.of(TOPIC_1)));
+
+    replay(topicManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    PartitionCountRequest request = PartitionCountRequest.builder().setPartitionCount(3).build();
+    topicsResource.updatePartitionCount(
+        response, TOPIC_1.getClusterId(), TOPIC_1.getName(), request);
+
+    GetTopicResponse expected = GetTopicResponse.create(newTopicData("topic-1", true, 3, 3));
+
+    assertEquals(expected, response.getValue());
+  }
+
+  @Test
+  public void testUpdatePartitionsNoRequest() {
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    PartitionCountRequest request = null;
+
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                topicsResource.updatePartitionCount(
+                    response, TOPIC_1.getClusterId(), TOPIC_1.getName(), request));
+    assertEquals(
+        "Payload error. Request body is empty. Partition_count is required.", e.getMessage());
+    assertEquals(42206, e.getErrorCode());
+  }
+
+  @Test
+  public void testUpdatePartitionsUpdateFails() {
+
+    CompletableFuture<Void> future = new CompletableFuture();
+    future.completeExceptionally(new Exception("Oh no"));
+    expect(topicManager.updateTopicPartitionCount(TOPIC_1.getName(), 2)).andReturn(future);
+
+    replay(topicManager);
+
+    FakeAsyncResponse response = new FakeAsyncResponse();
+    PartitionCountRequest request = PartitionCountRequest.builder().setPartitionCount(2).build();
+
+    topicsResource.updatePartitionCount(
+        response, TOPIC_1.getClusterId(), TOPIC_1.getName(), request);
+
+    assertEquals("Oh no", response.getException().getMessage());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
                 <version>$(hamcrest.version)</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.connectors</groupId>
+                <artifactId>jersey-apache-connector</artifactId>
+                <version>2.34</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Call looks like

```
curl -X PATCH http://localhost:8082/v3/clusters/3W-2oFuqSYuErBzrRrTKyw/topics/bob  -H "Content-Type: application/json" -d '{"partition_count":"10"}'  | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   688    0   664  100    24   6036    218 --:--:-- --:--:-- --:--:--  6254
{
  "kind": "KafkaTopic",
  "metadata": {
    "self": "http://localhost:8082/v3/clusters/3W-2oFuqSYuErBzrRrTKyw/topics/bob",
    "resource_name": "crn:///kafka=3W-2oFuqSYuErBzrRrTKyw/topic=bob"
  },
  "cluster_id": "3W-2oFuqSYuErBzrRrTKyw",
  "topic_name": "bob",
  "is_internal": false,
  "replication_factor": 1,
  "partitions_count": 10,
  "partitions": {
    "related": "http://localhost:8082/v3/clusters/3W-2oFuqSYuErBzrRrTKyw/topics/bob/partitions"
  },
  "configs": {
    "related": "http://localhost:8082/v3/clusters/3W-2oFuqSYuErBzrRrTKyw/topics/bob/configs"
  },
  "partition_reassignments": {
    "related": "http://localhost:8082/v3/clusters/3W-2oFuqSYuErBzrRrTKyw/topics/bob/partitions/-/reassignment"
  },
  "authorized_operations": []
}

```

Error messages are shown as returned by kafka

```
{"error_code":40002,"message":"Topic already has 2 partitions."}%  
{"error_code":40002,"message":"Topic currently has 2 partitions, which is higher than the requested 1."}% 
```

I don't think we have a PATCH call anywhere else in the code.  I think it's right here - we are modifying but not fully replacing an existing topic object's information.

The flip of that could be that it should be a PUT as we are fully and idempotently replacing the whole of the topic's partition_count object, but patch felt more future safe, in case we add other things to the request body in future?