### PR TITLE
KREST-8518 Add dry-run/validate-only versions of some topic APIs

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -854,12 +854,17 @@ paths:
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Creates a topic.
-        Also supports a dry-run mode that only validates whether the topic creation would succeed.
+        Also supports a dry-run mode that only validates whether the topic creation would succeed
+        if the ``validate_only`` request property is explicitly specified and set to true.
       tags:
         - Topic (v3)
       requestBody:
         $ref: '#/components/requestBodies/CreateTopicRequest'
       responses:
+        # returned when dry-run mode is being used and a topic has not been created
+        '200':
+          $ref: '#/components/responses/CreateTopicResponse'
+        # returned in regular mode when a topic has been created
         '201':
           $ref: '#/components/responses/CreateTopicResponse'
         '400':
@@ -985,12 +990,14 @@ paths:
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Updates or deletes a set of topic configs.
-        Also supports a dry-run mode that only validates whether the operation would succeed.
+        Also supports a dry-run mode that only validates whether the operation would succeed if the
+        ``validate_only`` request property is explicitly specified and set to true.
       tags:
         - Configs (v3)
       requestBody:
         $ref: '#/components/requestBodies/AlterTopicConfigBatchRequest'
       responses:
+        # returned in both regular and dry-run modes
         '204':
           description: 'No Content'
         '400':
@@ -2493,12 +2500,22 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/AlterConfigBatchRequestData'
-          example:
-            data:
-              - name: 'cleanup.policy'
-                operation: 'DELETE'
-              - name: 'compression.type'
-                value: 'gzip'
+          examples:
+            batch_alter_topic_configs:
+              value:
+                data:
+                  - name: 'cleanup.policy'
+                    operation: 'DELETE'
+                  - name: 'compression.type'
+                    value: 'gzip'
+            validate_only_batch_alter_topic_configs:
+              value:
+                data:
+                  - name: 'cleanup.policy'
+                    operation: 'DELETE'
+                  - name: 'compression.type'
+                    value: 'gzip'
+                validate_only: true
 
     CreateAclRequest:
       description: 'The ACL creation request.'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -854,6 +854,7 @@ paths:
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Creates a topic.
+        Also supports a dry-run mode that only validates whether the topic creation would succeed.
       tags:
         - Topic (v3)
       requestBody:
@@ -984,6 +985,7 @@ paths:
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Updates or deletes a set of topic configs.
+        Also supports a dry-run mode that only validates whether the operation would succeed.
       tags:
         - Configs (v3)
       requestBody:
@@ -1610,6 +1612,8 @@ components:
                   - SET
                   - DELETE
                 nullable: true
+        validate_only:
+          type: boolean
 
     AnyValue:
       nullable: true
@@ -1819,6 +1823,8 @@ components:
               value:
                 type: string
                 nullable: true
+        validate_only:
+          type: boolean
 
     ConfigSource:
       type: string
@@ -2570,6 +2576,12 @@ components:
                     value: 'compact'
                   - name: 'compression.type'
                     value: 'gzip'
+            dry_run_create_topic:
+              value:
+                topic_name: 'topic-Z'
+                partitions_count: 64
+                replication_factor: 3
+                validate_only: true
 
     ProduceRequest:
       description: 'A single record to be produced to Kafka. To produce multiple records on the same

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
@@ -173,22 +173,7 @@ abstract class AbstractConfigManager<
    */
   final CompletableFuture<Void> safeAlterConfigs(
       String clusterId, ConfigResource resourceId, B prototype, List<AlterConfigCommand> commands) {
-    return listConfigs(clusterId, resourceId, prototype)
-        .thenApply(
-            configs -> {
-              Set<String> configNames =
-                  configs.stream().map(AbstractConfig::getName).collect(Collectors.toSet());
-              for (AlterConfigCommand command : commands) {
-                if (!configNames.contains(command.getName())) {
-                  throw new NotFoundException(
-                      String.format(
-                          "Config %s cannot be found for %s %s in cluster %s.",
-                          command.getName(), resourceId.type(), resourceId.name(), clusterId));
-                }
-              }
-              return configs;
-            })
-        .thenCompose(config -> alterConfigs(resourceId, commands));
+    return safeAlterConfigs(clusterId, resourceId, prototype, commands, false);
   }
 
   /**

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
@@ -173,7 +173,7 @@ abstract class AbstractConfigManager<
    */
   final CompletableFuture<Void> safeAlterConfigs(
       String clusterId, ConfigResource resourceId, B prototype, List<AlterConfigCommand> commands) {
-    return safeAlterConfigs(clusterId, resourceId, prototype, commands, false);
+    return safeAlterOrValidateConfigs(clusterId, resourceId, prototype, commands, false);
   }
 
   /**
@@ -181,11 +181,11 @@ abstract class AbstractConfigManager<
    * the {@code validateOnly} flag is set, the operation is only dry-ran (the configs do not get
    * altered as a result).
    */
-  // KREST-8518 A separate overload is provided instead of changing the pre-existing
+  // KREST-8518 A separate method is provided instead of changing the pre-existing
   // safeAlterConfigs method in order to minimize any risks related to external usage of that method
   // (as this manager can be injected in projects inheriting from kafka-rest) and to minimize the
   // amount of necessary changes (e.g. by avoiding the need to heavily refactor tests).
-  final CompletableFuture<Void> safeAlterConfigs(
+  final CompletableFuture<Void> safeAlterOrValidateConfigs(
       String clusterId,
       ConfigResource resourceId,
       B prototype,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManager.java
@@ -57,4 +57,16 @@ public interface TopicConfigManager {
    */
   CompletableFuture<Void> alterTopicConfigs(
       String clusterId, String topicName, List<AlterConfigCommand> commands);
+
+  /**
+   * Atomically alter configs according to {@code commands}, checking if the configs exist first. If
+   * the {@code validateOnly} flag is set, the operation is only dry-ran (the configs do not get
+   * altered as a result).
+   */
+  // KREST-8518 A separate overload is provided instead of changing the pre-existing createTopic
+  // method in order to minimize any risks related to external usage of that method (as TopicManager
+  // can be injected in projects inheriting from kafka-rest) and to minimize the amount of necessary
+  // changes (e.g. by avoiding the need to heavily refactor tests).
+  CompletableFuture<Void> alterTopicConfigs(
+      String clusterId, String topicName, List<AlterConfigCommand> commands, boolean validateOnly);
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -119,7 +119,7 @@ final class TopicConfigManagerImpl extends AbstractConfigManager<TopicConfig, To
   @Override
   public CompletableFuture<Void> alterTopicConfigs(
       String clusterId, String topicName, List<AlterConfigCommand> commands, boolean validateOnly) {
-    return safeAlterConfigs(
+    return safeAlterOrValidateConfigs(
         clusterId,
         new ConfigResource(ConfigResource.Type.TOPIC, topicName),
         TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -115,4 +115,15 @@ final class TopicConfigManagerImpl extends AbstractConfigManager<TopicConfig, To
         TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
         commands);
   }
+
+  @Override
+  public CompletableFuture<Void> alterTopicConfigs(
+      String clusterId, String topicName, List<AlterConfigCommand> commands, boolean validateOnly) {
+    return safeAlterConfigs(
+        clusterId,
+        new ConfigResource(ConfigResource.Type.TOPIC, topicName),
+        TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),
+        commands,
+        validateOnly);
+  }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -75,6 +75,24 @@ public interface TopicManager {
       Map<Integer, List<Integer>> replicasAssignments,
       Map<String, Optional<String>> configs);
 
+  /**
+   * Creates a new Kafka {@link Topic} with either partitions count and replication factor or
+   * explicitly specified partition-to-replicas assignments. If the {@code validateOnly} flag is
+   * set, the operation is only dry-ran (a topic does not get created as a result).
+   */
+  // KREST-8518 A separate overload is provided instead of changing the pre-existing createTopic
+  // method in order to minimize any risks related to external usage of that method (as TopicManager
+  // can be injected in projects inheriting from kafka-rest) and to minimize the amount of necessary
+  // changes (e.g. by avoiding the need to heavily refactor tests).
+  CompletableFuture<Void> createTopic(
+      String clusterId,
+      String topicName,
+      Optional<Integer> partitionsCount,
+      Optional<Short> replicationFactor,
+      Map<Integer, List<Integer>> replicasAssignments,
+      Map<String, Optional<String>> configs,
+      boolean validateOnly);
+
   /** Deletes the Kafka {@link Topic} with the given {@code topicName}. */
   CompletableFuture<Void> deleteTopic(String clusterId, String topicName);
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterConfigBatchRequestData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/AlterConfigBatchRequestData.java
@@ -35,13 +35,26 @@ public abstract class AlterConfigBatchRequestData {
   @JsonProperty("data")
   public abstract ImmutableList<AlterEntry> getData();
 
+  // KREST-8518 This option is currently recognized solely by the Batch Alter Topic Config API.
+  // Nevertheless, it makes sense to add it in this generic Batch Alter Config entity as it
+  // should eventually be supported by all the other similar APIs.
+  @JsonProperty("validate_only")
+  public abstract Optional<Boolean> getValidateOnly();
+
   public static AlterConfigBatchRequestData create(List<AlterEntry> data) {
-    return new AutoValue_AlterConfigBatchRequestData(ImmutableList.copyOf(data));
+    return new AutoValue_AlterConfigBatchRequestData(ImmutableList.copyOf(data), Optional.empty());
+  }
+
+  public static AlterConfigBatchRequestData create(
+      List<AlterEntry> data, Optional<Boolean> validateOnly) {
+    return new AutoValue_AlterConfigBatchRequestData(ImmutableList.copyOf(data), validateOnly);
   }
 
   @JsonCreator
-  static AlterConfigBatchRequestData fromJson(@JsonProperty("data") List<AlterEntry> data) {
-    return create(data);
+  static AlterConfigBatchRequestData fromJson(
+      @JsonProperty("data") List<AlterEntry> data,
+      @JsonProperty("validate_only") Optional<Boolean> validateOnly) {
+    return create(data, validateOnly);
   }
 
   public final List<AlterConfigCommand> toAlterConfigCommands() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/CreateTopicRequest.java
@@ -45,6 +45,9 @@ public abstract class CreateTopicRequest {
   @JsonProperty("configs")
   public abstract ImmutableList<ConfigEntry> getConfigs();
 
+  @JsonProperty("validate_only")
+  public abstract Optional<Boolean> getValidateOnly();
+
   public static Builder builder() {
     return new AutoValue_CreateTopicRequest.Builder()
         .setReplicasAssignments(Collections.emptyMap());
@@ -57,7 +60,8 @@ public abstract class CreateTopicRequest {
       @JsonProperty("replication_factor") @Nullable Short replicationFactor,
       @JsonProperty("replicas_assignments") @Nullable
           Map<Integer, List<Integer>> replicasAssignments,
-      @JsonProperty("configs") @Nullable List<ConfigEntry> configs) {
+      @JsonProperty("configs") @Nullable List<ConfigEntry> configs,
+      @JsonProperty("validate_only") @Nullable Boolean validateOnly) {
     return builder()
         .setTopicName(topicName)
         .setPartitionsCount(partitionsCount)
@@ -65,6 +69,7 @@ public abstract class CreateTopicRequest {
         .setReplicasAssignments(
             replicasAssignments != null ? replicasAssignments : Collections.emptyMap())
         .setConfigs(configs != null ? configs : ImmutableList.of())
+        .setValidateOnly(validateOnly)
         .build();
   }
 
@@ -82,6 +87,8 @@ public abstract class CreateTopicRequest {
     public abstract Builder setReplicasAssignments(Map<Integer, List<Integer>> replicasAssignments);
 
     public abstract Builder setConfigs(List<ConfigEntry> configs);
+
+    public abstract Builder setValidateOnly(@Nullable Boolean validateOnly);
 
     public abstract CreateTopicRequest build();
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
@@ -58,10 +58,17 @@ public final class AlterTopicConfigBatchAction {
       @PathParam("clusterId") String clusterId,
       @PathParam("topicName") String topicName,
       @Valid AlterTopicConfigBatchRequest request) {
+    boolean validateOnly = request.getValue().getValidateOnly().orElse(false);
     CompletableFuture<Void> response =
-        topicConfigManager
-            .get()
-            .alterTopicConfigs(clusterId, topicName, request.getValue().toAlterConfigCommands());
+        validateOnly
+            ? topicConfigManager
+                .get()
+                .alterTopicConfigs(
+                    clusterId, topicName, request.getValue().toAlterConfigCommands(), true)
+            : topicConfigManager
+                .get()
+                .alterTopicConfigs(
+                    clusterId, topicName, request.getValue().toAlterConfigCommands());
 
     AsyncResponseBuilder.from(Response.status(Status.NO_CONTENT))
         .entity(response)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -230,8 +230,10 @@ public final class TopicsResource {
                     configs)
                 .thenApply(none -> CreateTopicResponse.create(topicData));
 
+    // The response status will differ depending on whether a topic has actually been created.
+    Response.Status responseStatus = validateOnly ? Status.OK : Status.CREATED;
     AsyncResponseBuilder.from(
-            Response.status(Status.CREATED).location(URI.create(topicData.getMetadata().getSelf())))
+            Response.status(responseStatus).location(URI.create(topicData.getMetadata().getSelf())))
         .entity(response)
         .asyncResume(asyncResponse);
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -205,17 +205,30 @@ public final class TopicsResource {
                 /* isInternal= */ false,
                 /* authorizedOperations= */ emptySet()));
 
+    boolean validateOnly = request.getValidateOnly().orElse(false);
     CompletableFuture<CreateTopicResponse> response =
-        topicManager
-            .get()
-            .createTopic(
-                clusterId,
-                topicName,
-                partitionsCount,
-                replicationFactor,
-                replicasAssignments,
-                configs)
-            .thenApply(none -> CreateTopicResponse.create(topicData));
+        validateOnly
+            ? topicManager
+                .get()
+                .createTopic(
+                    clusterId,
+                    topicName,
+                    partitionsCount,
+                    replicationFactor,
+                    replicasAssignments,
+                    configs,
+                    true)
+                .thenApply(none -> CreateTopicResponse.create(topicData))
+            : topicManager
+                .get()
+                .createTopic(
+                    clusterId,
+                    topicName,
+                    partitionsCount,
+                    replicationFactor,
+                    replicasAssignments,
+                    configs)
+                .thenApply(none -> CreateTopicResponse.create(topicData));
 
     AsyncResponseBuilder.from(
             Response.status(Status.CREATED).location(URI.create(topicData.getMetadata().getSelf())))

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -377,6 +377,76 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
+  public void validateOnlyCreateTopic_nonExistingTopic_returnsNonCreatedTopic() {
+    String baseUrl = restConnect;
+    String clusterId = getClusterId();
+    String topicName = "topic-4";
+
+    CreateTopicResponse expected =
+        CreateTopicResponse.create(
+            TopicData.builder()
+                .setMetadata(
+                    Resource.Metadata.builder()
+                        .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/topics/" + topicName)
+                        .setResourceName("crn:///kafka=" + clusterId + "/topic=" + topicName)
+                        .build())
+                .setClusterId(clusterId)
+                .setTopicName(topicName)
+                .setInternal(false)
+                .setReplicationFactor(1)
+                .setPartitionsCount(0)
+                .setPartitions(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/topics/"
+                            + topicName
+                            + "/partitions"))
+                .setConfigs(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/topics/"
+                            + topicName
+                            + "/configs"))
+                .setPartitionReassignments(
+                    Resource.Relationship.create(
+                        baseUrl
+                            + "/v3/clusters/"
+                            + clusterId
+                            + "/topics/"
+                            + topicName
+                            + "/partitions/-/reassignment"))
+                .setAuthorizedOperations(emptySet())
+                .build());
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(
+                Entity.entity(
+                    "{\"topic_name\":\""
+                        + topicName
+                        + "\",\"partitions_count\":1,"
+                        + "\"replication_factor\":1,"
+                        + "\"validate_only\":true}",
+                    MediaType.APPLICATION_JSON));
+    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+
+    CreateTopicResponse actual = response.readEntity(CreateTopicResponse.class);
+    assertEquals(expected, actual);
+
+    testWithRetry(
+        () ->
+            assertFalse(
+                getTopicNames().contains(topicName),
+                String.format(
+                    "Topic names should not contain %s after dry-run creation", topicName)));
+  }
+
+  @Test
   public void createTopic_nonExistingTopic_customReplicasAssignments_returnsCreatedTopic() {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
@@ -456,6 +526,24 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         + TOPIC_1
                         + "\",\"partitions_count\":2,\\"
                         + "replication_factor\":1}",
+                    MediaType.APPLICATION_JSON));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void validateOnlyCreateTopic_existingTopic_returnsBadRequest() {
+    String clusterId = getClusterId();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(
+                Entity.entity(
+                    "{\"topic_name\":\""
+                        + TOPIC_1
+                        + "\",\"partitions_count\":2,\\"
+                        + "replication_factor\":1,"
+                        + "\"validate_only\":true}",
                     MediaType.APPLICATION_JSON));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -433,7 +433,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         + "\"replication_factor\":1,"
                         + "\"validate_only\":true}",
                     MediaType.APPLICATION_JSON));
-    assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
 
     CreateTopicResponse actual = response.readEntity(CreateTopicResponse.class);
     assertEquals(expected, actual);


### PR DESCRIPTION
This cherry-picks the changes from #1090 into the 4309 image branch.

Original description:

_This change introduces an additional "validate only" parameter to the requests for two important topic APIs:_
- _Create Topic_
- _Batch Alter Topic Config_

_When this parameter, which is a boolean flag, is set, the corresponding operation would be dry-run, i.e. its execution would be validated as if its actually run, but there would be no side effects from the operation. E.g. if run in that mode, a Create Topic request won't actually create a topic._

_As this requires just using simple overloads of the corresponding Admin APIs, this change mostly focuses on introducing the new parameters in minimally disruptive way in exchange for some verbosity and maybe even redundancy._
- _E.g. none of the existing tests had to be changed, including the resource test, which expect specific manager calls, and the manager impl tests, which expect specific Admin Client calls._