### PR TITLE
Address a coincidence causing a build breakage

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/AbstractConfigManager.java
@@ -173,7 +173,7 @@ abstract class AbstractConfigManager<
    */
   final CompletableFuture<Void> safeAlterConfigs(
       String clusterId, ConfigResource resourceId, B prototype, List<AlterConfigCommand> commands) {
-    return safeAlterConfigs(clusterId, resourceId, prototype, commands, false);
+    return safeAlterOrValidateConfigs(clusterId, resourceId, prototype, commands, false);
   }
 
   /**
@@ -181,11 +181,11 @@ abstract class AbstractConfigManager<
    * the {@code validateOnly} flag is set, the operation is only dry-ran (the configs do not get
    * altered as a result).
    */
-  // KREST-8518 A separate overload is provided instead of changing the pre-existing
+  // KREST-8518 A separate method is provided instead of changing the pre-existing
   // safeAlterConfigs method in order to minimize any risks related to external usage of that method
   // (as this manager can be injected in projects inheriting from kafka-rest) and to minimize the
   // amount of necessary changes (e.g. by avoiding the need to heavily refactor tests).
-  final CompletableFuture<Void> safeAlterConfigs(
+  final CompletableFuture<Void> safeAlterOrValidateConfigs(
       String clusterId,
       ConfigResource resourceId,
       B prototype,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicConfigManagerImpl.java
@@ -119,7 +119,7 @@ final class TopicConfigManagerImpl extends AbstractConfigManager<TopicConfig, To
   @Override
   public CompletableFuture<Void> alterTopicConfigs(
       String clusterId, String topicName, List<AlterConfigCommand> commands, boolean validateOnly) {
-    return safeAlterConfigs(
+    return safeAlterOrValidateConfigs(
         clusterId,
         new ConfigResource(ConfigResource.Type.TOPIC, topicName),
         TopicConfig.builder().setClusterId(clusterId).setTopicName(topicName),


### PR DESCRIPTION
ce-kafka-rest happens to have a config manager that has defined on its own a validateOnly version of safeAlterConfigs, so introducing one in the base config manager (with a final modifier) causes a breakage.

For now let's avoid the breakage by renaming the base method and avoiding the unwanted override, and later we can consider whether it's better to remove the ce-kafka-rest method and use the base method instead.
- The problem could also be addressed by just removing the `final` modifier of the newly added base method so that an override does happen, but that seems slightly more invasive than just isolating the newly added base method.
- The ce-kafka-rest downstream validation will probably still fail because of a new unrelated problem that sneaked in the last hours.

Tested by local builds of kafka-rest and ce-kafka-rest.