### PR TITLE
Make sure SchemaRegistryRestApplication check for leader election finish

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -218,6 +218,7 @@ public abstract class ClusterTestHarness {
           new SchemaRegistryRestApplication(new SchemaRegistryConfig(schemaRegProperties));
       schemaRegServer = schemaRegApp.createServer();
       schemaRegServer.start();
+      schemaRegApp.postServerStart();
     }
 
     int restPort = choosePort();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
@@ -82,8 +82,10 @@ public final class SchemaRegistryFixture implements BeforeEachCallback, AfterEac
   @Override
   public void beforeEach(ExtensionContext extensionContext) throws Exception {
     checkState(server == null);
-    server = new SchemaRegistryRestApplication(createConfigs()).createServer();
+    SchemaRegistryRestApplication schemaRegApp = new SchemaRegistryRestApplication(createConfigs());
+    server = schemaRegApp.createServer();
     server.start();
+    schemaRegApp.postServerStart();
     baseUri = server.getURI();
     client =
         new CachedSchemaRegistryClient(


### PR DESCRIPTION
This PR should fix the issue that encountered in https://github.com/confluentinc/kafka-rest/runs/10398565843.