### PR TITLE
Set dependency.check.version to 7.4.4 to fix build failure (v0.4388.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.kafka-rest.version>7.4.0-1038</io.confluent.kafka-rest.version>
+	<dependency.check.version>7.4.4</dependency.check.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
The build currently fails with:

```text
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:6.1.6:check (default) on project kafka-rest-parent: Fatal exception(s) analyzing kafka-rest-parent: One or more exceptions occurred during analysis:
```

This was fixed in common via https://github.com/confluentinc/common/pull/496, but that doesn't help with the v0.4388.x cloud release branch.