### PR TITLE
Change MockTime package to correct one org.apache.kafka.common.utils

### DIFF
--- a/checkstyle/import_control.xml
+++ b/checkstyle/import_control.xml
@@ -142,7 +142,7 @@
   <allow class="kafka.server.KafkaConfig" />
   <allow class="kafka.server.KafkaServer" />
   <allow class="kafka.utils.CoreUtils" />
-  <allow class="kafka.utils.MockTime" />
+  <allow class="org.apache.kafka.common.utils.MockTime" />
   <allow class="kafka.utils.TestUtils" />
   <allow class="kafka.zk.EmbeddedZookeeper" />
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -54,7 +54,6 @@ import javax.ws.rs.client.WebTarget;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.utils.CoreUtils;
-import kafka.utils.MockTime;
 import kafka.utils.TestUtils;
 import kafka.zk.EmbeddedZookeeper;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -75,6 +74,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.MockTime;
 import org.eclipse.jetty.server.Server;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -290,11 +290,7 @@ public abstract class ClusterTestHarness {
                     .map(
                         config ->
                             CompletableFuture.supplyAsync(
-                                () ->
-                                    TestUtils.createServer(
-                                        config,
-                                        new MockTime(
-                                            System.currentTimeMillis(), System.nanoTime()))))
+                                () -> TestUtils.createServer(config, new MockTime())))
                     .collect(toList()))
             .join();
     log.info("Started all {} brokers for {}", numBrokers, getClass().getSimpleName());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
@@ -33,11 +33,11 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
-import kafka.utils.MockTime;
 import kafka.utils.TestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -58,8 +58,7 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
           .put(KafkaConfig.OffsetsTopicReplicationFactorProp(), "1")
           .build();
 
-  private static final MockTime MOCK_TIME =
-      new MockTime(System.currentTimeMillis(), System.nanoTime());
+  private static final MockTime MOCK_TIME = new MockTime();
 
   private final int brokerId;
   @Nullable private final SslFixture certificates;


### PR DESCRIPTION
Due to the change in https://github.com/apache/kafka/pull/13092/files, MockTime class has been moved to the new package org.apache.kafka.common.utils.

This PR fixes the issue by setting the correct package for MockTime