### PR TITLE
Incorrect merge conflict resolution lead to buggy synchronization block

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerState.java
@@ -341,13 +341,13 @@ public abstract class KafkaConsumerState<KafkaKeyT, KafkaValueT, ClientKeyT, Cli
         .map(OffsetAndTimestamp::offset);
   }
 
-  public synchronized boolean expired(Instant now) {
+  public boolean expired(Instant now) {
     synchronized (this.expirationLock) {
       return !expiration.isAfter(now);
     }
   }
 
-  public synchronized void updateExpiration() {
+  public void updateExpiration() {
     synchronized (this.expirationLock) {
       this.expiration = clock.instant().plus(consumerInstanceTimeout);
     }


### PR DESCRIPTION
Original fix was: https://github.com/confluentinc/kafka-rest/pull/942/

However, we didn't resolve the conflict correctly causing the same issue to resurface.