### PR TITLE
cherry-pick: fix test (#1115)

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/SchemaManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/SchemaManagerImplTest.java
@@ -664,6 +664,7 @@ public class SchemaManagerImplTest {
     expect(schemaMock.getSchemaType())
         .andThrow(new UnsupportedOperationException("exception message"));
     expect(schemaMock.getSchemaType()).andReturn("JSON");
+    expect(schemaMock.getSchema()).andReturn("testSchema");
 
     replay(schemaRegistryClientMock, schemaMock);
 


### PR DESCRIPTION
* KREST-8965 Fix test

SchemaRegistry now allows "null" schema, handle that.