### PR TITLE
KREST-1797 - CreateTopic returns partitions and repl factor

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -65,26 +65,10 @@ public interface TopicManager {
 
   /**
    * Creates a new Kafka {@link Topic} with either partitions count and replication factor or
-   * explicitly specified partition-to-replicas assignments.
-   */
-  CompletableFuture<Void> createTopic(
-      String clusterId,
-      String topicName,
-      Optional<Integer> partitionsCount,
-      Optional<Short> replicationFactor,
-      Map<Integer, List<Integer>> replicasAssignments,
-      Map<String, Optional<String>> configs);
-
-  /**
-   * Creates a new Kafka {@link Topic} with either partitions count and replication factor or
    * explicitly specified partition-to-replicas assignments. If the {@code validateOnly} flag is
-   * set, the operation is only dry-ran (a topic does not get created as a result).
+   * set, the operation is only dry-run (a topic does not get created as a result).
    */
-  // KREST-8518 A separate overload is provided instead of changing the pre-existing createTopic
-  // method in order to minimize any risks related to external usage of that method (as TopicManager
-  // can be injected in projects inheriting from kafka-rest) and to minimize the amount of necessary
-  // changes (e.g. by avoiding the need to heavily refactor tests).
-  CompletableFuture<Void> createTopic(
+  CompletableFuture<Topic> createTopic(
       String clusterId,
       String topicName,
       Optional<Integer> partitionsCount,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManager.java
@@ -64,11 +64,24 @@ public interface TopicManager {
   CompletableFuture<Optional<Topic>> getLocalTopic(String topicName);
 
   /**
+   * The original method to create a new Kafka {@link Topic} which was not able to pass back a
+   * result. Now superseded by {@code createTopic2}.
+   */
+  @Deprecated
+  CompletableFuture<Void> createTopic(
+      String clusterId,
+      String topicName,
+      Optional<Integer> partitionsCount,
+      Optional<Short> replicationFactor,
+      Map<Integer, List<Integer>> replicasAssignments,
+      Map<String, Optional<String>> configs);
+
+  /**
    * Creates a new Kafka {@link Topic} with either partitions count and replication factor or
    * explicitly specified partition-to-replicas assignments. If the {@code validateOnly} flag is
    * set, the operation is only dry-run (a topic does not get created as a result).
    */
-  CompletableFuture<Topic> createTopic(
+  CompletableFuture<Topic> createTopic2(
       String clusterId,
       String topicName,
       Optional<Integer> partitionsCount,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.kafkarest.common.KafkaFutures;
 import io.confluent.kafkarest.entities.Acl;
-import io.confluent.kafkarest.entities.Cluster;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.PartitionReplica;
 import io.confluent.kafkarest.entities.Topic;
@@ -36,12 +35,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -157,7 +155,7 @@ final class TopicManagerImpl implements TopicManager {
                     topicNames,
                     new DescribeTopicsOptions()
                         .includeAuthorizedOperations(includeAuthorizedOperations))
-                .all())
+                .allTopicNames())
         .thenApply(
             topics ->
                 topics.values().stream()
@@ -199,25 +197,7 @@ final class TopicManagerImpl implements TopicManager {
   }
 
   @Override
-  public CompletableFuture<Void> createTopic(
-      String clusterId,
-      String topicName,
-      Optional<Integer> partitionsCount,
-      Optional<Short> replicationFactor,
-      Map<Integer, List<Integer>> replicasAssignments,
-      Map<String, Optional<String>> configs) {
-    return createTopic(
-        clusterId,
-        topicName,
-        partitionsCount,
-        replicationFactor,
-        replicasAssignments,
-        configs,
-        false);
-  }
-
-  @Override
-  public CompletableFuture<Void> createTopic(
+  public CompletableFuture<Topic> createTopic(
       String clusterId,
       String topicName,
       Optional<Integer> partitionsCount,
@@ -237,22 +217,44 @@ final class TopicManagerImpl implements TopicManager {
             ? new NewTopic(topicName, partitionsCount, replicationFactor).configs(nullableConfigs)
             : new NewTopic(topicName, replicasAssignments).configs(nullableConfigs);
 
-    Function<? super Cluster, ? extends CompletionStage<Void>> createTopicCall =
-        validateOnly
-            ? cluster ->
-                KafkaFutures.toCompletableFuture(
-                    adminClient
-                        .createTopics(
-                            singletonList(createTopicRequest),
-                            new CreateTopicsOptions().validateOnly(true))
-                        .all())
-            : cluster ->
-                KafkaFutures.toCompletableFuture(
-                    adminClient.createTopics(singletonList(createTopicRequest)).all());
     return clusterManager
         .getCluster(clusterId)
         .thenApply(cluster -> checkEntityExists(cluster, "Cluster %s cannot be found.", clusterId))
-        .thenCompose(createTopicCall);
+        .thenCompose(
+            cluster -> createTopicInternal(clusterId, topicName, createTopicRequest, validateOnly));
+  }
+
+  private CompletableFuture<Topic> createTopicInternal(
+      String clusterId, String topicName, NewTopic createTopicRequest, boolean validateOnly) {
+
+    CreateTopicsResult createTopicsResult =
+        adminClient.createTopics(
+            singletonList(createTopicRequest),
+            new CreateTopicsOptions().validateOnly(validateOnly));
+
+    return CompletableFuture.completedFuture(Topic.builder())
+        .thenApply(
+            topicBuilder ->
+                topicBuilder
+                    .setClusterId(clusterId)
+                    .setName(topicName)
+                    .setInternal(false)
+                    .setAuthorizedOperations(emptySet()))
+        .thenCombine(
+            KafkaFutures.toCompletableFuture(createTopicsResult.numPartitions(topicName)),
+            (topicBuilder, responseNumPartitions) -> {
+              ArrayList<Partition> dummyPartitions = new ArrayList<>(responseNumPartitions);
+              for (int i = 0; i < responseNumPartitions; i++) {
+                dummyPartitions.add(Partition.create(clusterId, topicName, i, emptyList()));
+              }
+              return topicBuilder.addAllPartitions(dummyPartitions);
+            })
+        .thenCombine(
+            KafkaFutures.toCompletableFuture(createTopicsResult.replicationFactor(topicName)),
+            (topicBuilder, responseReplicationFactor) -> {
+              return topicBuilder.setReplicationFactor(responseReplicationFactor.shortValue());
+            })
+        .thenApply(Topic.Builder::build);
   }
 
   @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/TopicManagerImpl.java
@@ -197,7 +197,26 @@ final class TopicManagerImpl implements TopicManager {
   }
 
   @Override
-  public CompletableFuture<Topic> createTopic(
+  public CompletableFuture<Void> createTopic(
+      String clusterId,
+      String topicName,
+      Optional<Integer> partitionsCount,
+      Optional<Short> replicationFactor,
+      Map<Integer, List<Integer>> replicasAssignments,
+      Map<String, Optional<String>> configs) {
+    return createTopic2(
+            clusterId,
+            topicName,
+            partitionsCount,
+            replicationFactor,
+            replicasAssignments,
+            configs,
+            false)
+        .thenAccept(unused -> {});
+  }
+
+  @Override
+  public CompletableFuture<Topic> createTopic2(
       String clusterId,
       String topicName,
       Optional<Integer> partitionsCount,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Topic.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/Topic.java
@@ -40,6 +40,10 @@ public abstract class Topic {
 
   public abstract Set<Acl.Operation> getAuthorizedOperations();
 
+  public static Builder builder() {
+    return new AutoValue_Topic.Builder();
+  }
+
   public static Topic create(
       String clusterId,
       String name,
@@ -56,12 +60,48 @@ public abstract class Topic {
       short replicationFactor,
       boolean isInternal,
       @Nullable Set<Acl.Operation> authorizedOperations) {
-    return new AutoValue_Topic(
-        clusterId,
-        name,
-        ImmutableList.copyOf(partitions),
-        replicationFactor,
-        isInternal,
-        authorizedOperations == null ? emptySet() : authorizedOperations);
+    return builder()
+        .setClusterId(clusterId)
+        .setName(name)
+        .addAllPartitions(partitions)
+        .setReplicationFactor(replicationFactor)
+        .setInternal(isInternal)
+        .setAuthorizedOperations(authorizedOperations == null ? emptySet() : authorizedOperations)
+        .build();
+  }
+
+  public Builder toBuilder() {
+    return builder()
+        .setClusterId(getClusterId())
+        .setName(getName())
+        .addAllPartitions(getPartitions())
+        .setReplicationFactor(getReplicationFactor())
+        .setInternal(isInternal())
+        .setAuthorizedOperations(getAuthorizedOperations());
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    Builder() {}
+
+    public abstract Builder setClusterId(String clusterId);
+
+    public abstract Builder setName(String name);
+
+    abstract ImmutableList.Builder<Partition> partitionsBuilder();
+
+    public final Builder addAllPartitions(Iterable<Partition> partitions) {
+      partitionsBuilder().addAll(partitions);
+      return this;
+    }
+
+    public abstract Builder setReplicationFactor(short replicationFactor);
+
+    public abstract Builder setInternal(boolean isInternal);
+
+    public abstract Builder setAuthorizedOperations(Set<Acl.Operation> authorizedOperations);
+
+    public abstract Topic build();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -210,7 +210,7 @@ public final class TopicsResource {
 
     CompletableFuture<CreateTopicResponse> response =
         topicManager
-            .createTopic(
+            .createTopic2(
                 clusterId,
                 topicName,
                 partitionsCount,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -209,36 +209,16 @@ public final class TopicsResource {
     TopicManager topicManager = topicManagerProvider.get();
 
     CompletableFuture<CreateTopicResponse> response =
-        validateOnly
-            ? topicManager
-                .createTopic(
-                    clusterId,
-                    topicName,
-                    partitionsCount,
-                    replicationFactor,
-                    replicasAssignments,
-                    configs,
-                    true)
-                .thenCompose(
-                    nothing ->
-                        topicManager
-                            .getTopic(clusterId, topicName)
-                            .thenApply(
-                                topic -> CreateTopicResponse.create(toTopicData(topic.get()))))
-            : topicManager
-                .createTopic(
-                    clusterId,
-                    topicName,
-                    partitionsCount,
-                    replicationFactor,
-                    replicasAssignments,
-                    configs)
-                .thenCompose(
-                    nothing ->
-                        topicManager
-                            .getTopic(clusterId, topicName)
-                            .thenApply(
-                                topic -> CreateTopicResponse.create(toTopicData(topic.get()))));
+        topicManager
+            .createTopic(
+                clusterId,
+                topicName,
+                partitionsCount,
+                replicationFactor,
+                replicasAssignments,
+                configs,
+                validateOnly)
+            .thenApply(topic -> CreateTopicResponse.create(toTopicData(topic)));
 
     // The response status will differ depending on whether a topic has actually been created.
     Response.Status responseStatus = validateOnly ? Status.OK : Status.CREATED;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -326,7 +326,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(topicName)
                 .setInternal(false)
                 .setReplicationFactor(1)
-                .setPartitionsCount(0)
+                .setPartitionsCount(1)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -394,7 +394,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setTopicName(topicName)
                 .setInternal(false)
                 .setReplicationFactor(1)
-                .setPartitionsCount(0)
+                .setPartitionsCount(1)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -463,8 +463,8 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
                 .setInternal(false)
-                .setReplicationFactor(2) // As determined by the actual replicas asignments below.
-                .setPartitionsCount(0)
+                .setReplicationFactor(2) // As determined by the actual replicas assignments below.
+                .setPartitionsCount(3)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl
@@ -636,8 +636,8 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
                 .setInternal(false)
-                .setReplicationFactor(0)
-                .setPartitionsCount(0)
+                .setReplicationFactor(2)
+                .setPartitionsCount(1)
                 .setPartitions(
                     Resource.Relationship.create(
                         baseUrl

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -461,7 +461,7 @@ public class TopicsResourceTest {
   @Test
   public void createTopic_nonExistingTopic_createsTopic() {
     expect(
-            topicManager.createTopic(
+            topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
                 Optional.of(TOPIC_1.getPartitions().size()),
@@ -501,7 +501,7 @@ public class TopicsResourceTest {
   @Test
   public void createTopic_nonExistingTopic_defaultPartitionsCount_createsTopic() {
     expect(
-            topicManager.createTopic(
+            topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
                 /* partitionsCount= */ Optional.empty(),
@@ -540,7 +540,7 @@ public class TopicsResourceTest {
   @Test
   public void createTopic_nonExistingTopic_defaultReplicationFactor_createsTopic() {
     expect(
-            topicManager.createTopic(
+            topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
                 Optional.of(TOPIC_1.getPartitions().size()),
@@ -589,7 +589,7 @@ public class TopicsResourceTest {
     responsePartitions.add(Partition.create(CLUSTER_ID, TOPIC_1.getName(), 2, emptyList()));
 
     expect(
-            topicManager.createTopic(
+            topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
                 /* partitionsCount= */ Optional.empty(),
@@ -628,7 +628,7 @@ public class TopicsResourceTest {
   @Test
   public void createTopic_existingTopic_throwsTopicExists() {
     expect(
-            topicManager.createTopic(
+            topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
                 Optional.of(TOPIC_1.getPartitions().size()),
@@ -657,7 +657,7 @@ public class TopicsResourceTest {
   @Test
   public void createTopic_nonExistingCluster_throwsNotFound() {
     expect(
-            topicManager.createTopic(
+            topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
                 Optional.of(TOPIC_1.getPartitions().size()),


### PR DESCRIPTION
Previously the response for v3 CreateTopic only contained the partition count and replication factor if they were supplied in the request. Now, this information is returned in the response always. This mirrors the behaviour of the Kafka AdminClient.createTopics.