### PR TITLE
DOCS-18055 -  `List All Broker Configs` to `List Dynamic Broker Configs`

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -369,11 +369,11 @@ paths:
       - $ref: '#/components/parameters/ClusterId'
 
     get:
-      summary: 'List All Broker Configs'
+      summary: 'List Dynamic Broker Configs'
       description: |-
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-        Return the list of configuration parameters for all the brokers in the given Kafka cluster.
+        Return the list of dynamic configuration parameters for all the brokers in the given Kafka cluster.
       tags:
         - Configs
       responses:


### PR DESCRIPTION
According to [this support ticket](https://confluent.zendesk.com/agent/tickets/122747) and this[ Docs Jira](https://confluentinc.atlassian.net/browse/DOCS-18055), GET broker configs returns only the dynamic configurations for the brokers.

The change rendered in HTML:

![image](https://user-images.githubusercontent.com/25937539/222581464-dd73e59d-059b-4fc3-bbcc-6705c6608c6e.png)