### PR TITLE
KREST-2863 - Validate topic name in createTopic

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -64,6 +64,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.apache.kafka.common.errors.InvalidTopicException;
 
 @Path("/v3/clusters/{clusterId}/topics")
 @ResourceName("api.v3.topics.*")
@@ -179,6 +180,12 @@ public final class TopicsResource {
     }
 
     String topicName = request.getTopicName();
+    try {
+      org.apache.kafka.common.internals.Topic.validate(topicName);
+    } catch (InvalidTopicException e) {
+      throw Errors.invalidPayloadException("Invalid topic name.");
+    }
+
     Optional<Integer> partitionsCount = request.getPartitionsCount();
     Optional<Short> replicationFactor = request.getReplicationFactor();
     Map<Integer, List<Integer>> replicasAssignments = request.getReplicasAssignments();


### PR DESCRIPTION
An unvalidated topic name was being used in a code path which could execute before Kafka had rejected the topic name during topic creation. The topic name is validated using a Kafka utility method which prevents this unfortunate situation.

Previously, an invalid topic name (specifically which was not URL-safe) caused an HTTP 500, but now an invalid topic name gives HTTP 422.