### PR TITLE
KREST-1701 - Blank message for missing topic

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/TopicConfigManagerImplTest.java
@@ -209,6 +209,7 @@ public class TopicConfigManagerImplTest {
       fail();
     } catch (ExecutionException e) {
       assertEquals(UnknownTopicOrPartitionException.class, e.getCause().getClass());
+      assertEquals("This server does not host this topic-partition.", e.getCause().getMessage());
     }
   }
 
@@ -357,6 +358,7 @@ public class TopicConfigManagerImplTest {
       fail();
     } catch (ExecutionException e) {
       assertEquals(UnknownTopicOrPartitionException.class, e.getCause().getClass());
+      assertEquals("This server does not host this topic-partition.", e.getCause().getMessage());
     }
   }
 
@@ -451,6 +453,7 @@ public class TopicConfigManagerImplTest {
       fail();
     } catch (ExecutionException e) {
       assertEquals(UnknownTopicOrPartitionException.class, e.getCause().getClass());
+      assertEquals("This server does not host this topic-partition.", e.getCause().getMessage());
     }
 
     verify(adminClient);
@@ -673,6 +676,7 @@ public class TopicConfigManagerImplTest {
       fail();
     } catch (ExecutionException e) {
       assertEquals(UnknownTopicOrPartitionException.class, e.getCause().getClass());
+      assertEquals("This server does not host this topic-partition.", e.getCause().getMessage());
     }
   }
 


### PR DESCRIPTION
For a variety of configs API operations, the error message accompanying an HTTP 404 for a missing topic was blank. The underlying problem is a blank message in the exception from Kafka and this blank message was faithfully copied into the HTTP response. This change copies an existing technique for exception handling in these cases from another API operation.