### PR TITLE
KREST-6569 - Cope with partitions disappearing

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManager.java
@@ -41,6 +41,13 @@ public interface PartitionManager {
       String clusterId, String topicName, int partitionId);
 
   /**
+   * Returns the Kafka {@link Partition} with the given {@code partitionId}. Returns an empty
+   * optional if any of the entities are missing.
+   */
+  CompletableFuture<Optional<Partition>> getPartitionAllowMissing(
+      String clusterId, String topicName, int partitionId);
+
+  /**
    * Returns the Kafka {@link Partition} with the given {@code partitionId}, belonging to the {@link
    * io.confluent.kafkarest.entities.Cluster} that this application is connected to.
    */

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/PartitionManagerImpl.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.kafkarest.common.CompletableFutures;
 import io.confluent.kafkarest.common.KafkaFutures;
 import io.confluent.kafkarest.entities.Partition;
@@ -104,6 +105,19 @@ final class PartitionManagerImpl implements PartitionManager {
               }
               throw new CompletionException(exception.getCause());
             });
+  }
+
+  @Override
+  public CompletableFuture<Optional<Partition>> getPartitionAllowMissing(
+      String clusterId, String topicName, int partitionId) {
+    return topicManager
+        .getTopic(clusterId, topicName)
+        .thenApply(topic -> topic.map(Topic::getPartitions).orElse(ImmutableList.of()))
+        .thenApply(
+            partitions ->
+                partitions.stream()
+                    .filter(partition -> partition.getPartitionId() == partitionId)
+                    .findAny());
   }
 
   @Override


### PR DESCRIPTION
The `GET v3/clusters/{}/brokers/{}/partition-replicas` operation issues multiple calls to AdminClient. In the event that a topic is deleted between the first call and the later calls, it's possible that topic-partitions found in the first call are not found in the later calls. The appropriate action in this case is just to remove them from the response, rather than failing with a 404.