### PR TITLE
KREST-9942: Remove SnakeYaml from dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.32</version>
-            </dependency>
-            <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-client</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
Remove the SnakeYaml definition from the dependency management to use the latest version defined in common. See: https://github.com/confluentinc/common/pull/514