### PR TITLE
KREST-9691 Add integration tests for the produce rate-limits for a single tenant.

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -40,6 +40,7 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.KafkaJsonDeserializer;
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
+import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.v3.ProduceRequest;
 import io.confluent.kafkarest.entities.v3.ProduceRequest.EnumSubjectNameStrategy;
@@ -53,6 +54,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
@@ -65,10 +67,13 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 // TODO ddimitrov This continues being way too flaky.
@@ -82,11 +87,50 @@ public class ProduceActionIntegrationTest {
   private static final String DEFAULT_VALUE_SUBJECT = "topic-1-value";
 
   @RegisterExtension
-  public final DefaultKafkaRestTestEnvironment testEnv = new DefaultKafkaRestTestEnvironment();
+  public final DefaultKafkaRestTestEnvironment testEnv = new DefaultKafkaRestTestEnvironment(false);
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp(TestInfo testInfo) throws Exception {
+    Properties restConfigs = new Properties();
+    if (testInfo.getDisplayName().contains("CallerIsRateLimited")) {
+      restConfigs.put(KafkaRestConfig.RATE_LIMIT_ENABLE_CONFIG, "true");
+      restConfigs.put(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED, "true");
+      restConfigs.put(KafkaRestConfig.RATE_LIMIT_BACKEND_CONFIG, "resilience4j");
+      // For all rate-limit tests, threshold/limit is 1, so that 1/2 requests fail the test
+      // quickly, keeping it deterministic.
+      if (testInfo
+          .getDisplayName()
+          .contains("test_whenGlobalByteLimitReached_thenCallerIsRateLimited")) {
+
+        restConfigs.put(KafkaRestConfig.PRODUCE_MAX_BYTES_GLOBAL_PER_SECOND, "1");
+      }
+      if (testInfo
+          .getDisplayName()
+          .contains("test_whenClusterByteLimitReached_thenCallerIsRateLimited")) {
+
+        restConfigs.put(KafkaRestConfig.PRODUCE_MAX_BYTES_PER_SECOND, "1");
+      }
+      if (testInfo
+          .getDisplayName()
+          .contains("test_whenGlobalRequestCountLimitReached_thenCallerIsRateLimited")) {
+
+        restConfigs.put(KafkaRestConfig.PRODUCE_MAX_REQUESTS_GLOBAL_PER_SECOND, "1");
+      }
+      if (testInfo
+          .getDisplayName()
+          .contains("test_whenClusterRequestCountLimitReached_thenCallerIsRateLimited")) {
+
+        restConfigs.put(KafkaRestConfig.PRODUCE_MAX_REQUESTS_PER_SECOND, "1");
+      }
+    }
+    testEnv.kafkaRest().startApp(restConfigs);
+
     testEnv.kafkaCluster().createTopic(TOPIC_NAME, 3, (short) 1);
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    testEnv.kafkaRest().closeApp();
   }
 
   @Test
@@ -3719,6 +3763,107 @@ public class ProduceActionIntegrationTest {
     assertEquals(key, ByteString.copyFrom(produced.key()));
     assertEquals(valueSize, produced.serializedValueSize());
     assertEquals(Arrays.toString(value), Arrays.toString(produced.value()));
+  }
+
+  private void doByteLimitReachedTest() throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.JSON)
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.JSON)
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .setOriginalSize(0L)
+            .build();
+
+    Response response =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .request()
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+    List<ErrorResponse> actual = readErrorResponses(response);
+    assertEquals(actual.size(), 1);
+    // Check request was rate-limited, so return http error-code is 429.
+    // NOTE - Byte rate-limit is set as 1 in setup() making sure 1st request itself fails.
+    assertEquals(actual.get(0).getErrorCode(), 429);
+  }
+
+  @Test
+  public void test_whenGlobalByteLimitReached_thenCallerIsRateLimited() throws Exception {
+    doByteLimitReachedTest();
+  }
+
+  @Test
+  public void test_whenClusterByteLimitReached_thenCallerIsRateLimited() throws Exception {
+    doByteLimitReachedTest();
+  }
+
+  private void doCountLimitTest() throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.JSON)
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.JSON)
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .setOriginalSize(0L)
+            .build();
+
+    Response response1 =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .request()
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+    Response response2 =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .request()
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+    assertEquals(Status.OK.getStatusCode(), response2.getStatus());
+
+    List<ErrorResponse> actual = readErrorResponses(response2);
+    assertEquals(actual.size(), 1);
+    // Check request was rate-limited, so return http error-code is 429.
+    // NOTE - Count rate-limit is set as 1 in setup() making sure 2nd request fails
+    // deteministically.
+    assertEquals(actual.get(0).getErrorCode(), 429);
+  }
+
+  @Test
+  public void test_whenGlobalRequestCountLimitReached_thenCallerIsRateLimited() throws Exception {
+    doCountLimitTest();
+  }
+
+  @Test
+  public void test_whenClusterRequestCountLimitReached_thenCallerIsRateLimited() throws Exception {
+    doCountLimitTest();
   }
 
   private static ProduceResponse readProduceResponse(Response response) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -92,12 +92,14 @@ public class ProduceActionIntegrationTest {
   @BeforeEach
   public void setUp(TestInfo testInfo) throws Exception {
     Properties restConfigs = new Properties();
+    // Adding custom KafkaRestConfigs for individual test-cases/test-methods below.
     if (testInfo.getDisplayName().contains("CallerIsRateLimited")) {
       restConfigs.put(KafkaRestConfig.RATE_LIMIT_ENABLE_CONFIG, "true");
       restConfigs.put(KafkaRestConfig.PRODUCE_RATE_LIMIT_ENABLED, "true");
       restConfigs.put(KafkaRestConfig.RATE_LIMIT_BACKEND_CONFIG, "resilience4j");
-      // For all rate-limit tests, threshold/limit is 1, so that 1/2 requests fail the test
-      // quickly, keeping it deterministic.
+      // The happy-path testing, i.e. rest calls below threshold succeed are already covered by the
+      // other existing tests. The 4 tests below, 1 per rate-limit config, set a very low rate-limit
+      // of "1", to deterministically make sure limits apply and rest-calls see 429s.
       if (testInfo
           .getDisplayName()
           .contains("test_whenGlobalByteLimitReached_thenCallerIsRateLimited")) {
@@ -129,7 +131,7 @@ public class ProduceActionIntegrationTest {
   }
 
   @AfterEach
-  public void cleanUp() {
+  public void tearDown() {
     testEnv.kafkaRest().closeApp();
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -71,7 +71,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -70,6 +70,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -3804,11 +3805,13 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
+  @DisplayName("test_whenGlobalByteLimitReached_thenCallerIsRateLimited")
   public void test_whenGlobalByteLimitReached_thenCallerIsRateLimited() throws Exception {
     doByteLimitReachedTest();
   }
 
   @Test
+  @DisplayName("test_whenClusterByteLimitReached_thenCallerIsRateLimited")
   public void test_whenClusterByteLimitReached_thenCallerIsRateLimited() throws Exception {
     doByteLimitReachedTest();
   }
@@ -3859,11 +3862,13 @@ public class ProduceActionIntegrationTest {
   }
 
   @Test
+  @DisplayName("test_whenGlobalRequestCountLimitReached_thenCallerIsRateLimited")
   public void test_whenGlobalRequestCountLimitReached_thenCallerIsRateLimited() throws Exception {
     doCountLimitTest();
   }
 
   @Test
+  @DisplayName("test_whenClusterRequestCountLimitReached_thenCallerIsRateLimited")
   public void test_whenClusterRequestCountLimitReached_thenCallerIsRateLimited() throws Exception {
     doCountLimitTest();
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -3851,13 +3851,14 @@ public class ProduceActionIntegrationTest {
             .request()
             .accept(MediaType.APPLICATION_JSON)
             .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-    assertEquals(Status.OK.getStatusCode(), response2.getStatus());
+    assertEquals(Status.OK.getStatusCode(), response1.getStatus());
 
+    assertEquals(Status.OK.getStatusCode(), response2.getStatus());
     List<ErrorResponse> actual = readErrorResponses(response2);
     assertEquals(actual.size(), 1);
     // Check request was rate-limited, so return http error-code is 429.
     // NOTE - Count rate-limit is set as 1 in setup() making sure 2nd request fails
-    // deteministically.
+    // deterministically.
     assertEquals(actual.get(0).getErrorCode(), 429);
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -3783,6 +3783,9 @@ public class ProduceActionIntegrationTest {
                     .setFormat(EmbeddedFormat.JSON)
                     .setData(TextNode.valueOf(value))
                     .build())
+            // 0 value here is meaningless as setting originalSize is mandatory for AutoValue.
+            // Value set here is ignored any-ways, as "true" originalSize is calculated & set,
+            // when the JSON request is de-serialized into an ProduceRecord object.
             .setOriginalSize(0L)
             .build();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -3783,9 +3783,10 @@ public class ProduceActionIntegrationTest {
                     .setFormat(EmbeddedFormat.JSON)
                     .setData(TextNode.valueOf(value))
                     .build())
-            // 0 value here is meaningless as setting originalSize is mandatory for AutoValue.
+            // 0 value here is meaningless and only set as originalSize is mandatory for AutoValue.
             // Value set here is ignored any-ways, as "true" originalSize is calculated & set,
-            // when the JSON request is de-serialized into an ProduceRecord object.
+            // when the JSON request is de-serialized into an ProduceRecord object on the
+            // server-side.
             .setOriginalSize(0L)
             .build();
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -41,7 +41,6 @@ public class ProduceRateLimitersTest {
   @Test
   @Inject
   public void test_thatRateLimitingCanBeDisabled() {
-
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "false");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));
@@ -87,7 +86,6 @@ public class ProduceRateLimitersTest {
   @Test
   @Inject
   public void test_whenBelowThreshold_CallsArentRateLimited() {
-
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
     properties.put(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS, Integer.toString(3600000));

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/ProduceRateLimitersTest.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -39,7 +40,7 @@ public class ProduceRateLimitersTest {
 
   @Test
   @Inject
-  public void rateLimitingDisabledNoWaitTimeGiven() {
+  public void test_thatRateLimitingCanBeDisabled() {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "false");
@@ -71,7 +72,8 @@ public class ProduceRateLimitersTest {
             Boolean.parseBoolean(properties.getProperty(PRODUCE_RATE_LIMIT_ENABLED)),
             Duration.ofMillis(
                 Integer.parseInt(properties.getProperty(PRODUCE_RATE_LIMIT_CACHE_EXPIRY_MS))));
-    produceRateLimiters.rateLimit("clusterId", 10L);
+
+    assertDoesNotThrow(() -> produceRateLimiters.rateLimit("clusterId", 10L));
 
     verify(
         countLimitProvider,
@@ -84,7 +86,7 @@ public class ProduceRateLimitersTest {
 
   @Test
   @Inject
-  public void waitTimesReturnedForMultipleClusters() {
+  public void test_whenBelowThreshold_CallsArentRateLimited() {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
@@ -158,7 +160,7 @@ public class ProduceRateLimitersTest {
 
   @Test
   @Inject
-  public void rateLimitedOnCountExceptionThrown() {
+  public void test_whenLocalCountRateLimiterBreached_thenExceptionThrown() {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
@@ -229,7 +231,7 @@ public class ProduceRateLimitersTest {
 
   @Test
   @Inject
-  public void rateLimitedOnBytesExceptionThrown() {
+  public void test_whenLocalBytesRateLimiterBreached_thenExceptionThrown() {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
@@ -300,7 +302,7 @@ public class ProduceRateLimitersTest {
   }
 
   @Test
-  public void cacheExpiresforeRateLimit() throws InterruptedException {
+  public void test_thatCacheForRateLimitersExpires() throws InterruptedException {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
@@ -358,6 +360,7 @@ public class ProduceRateLimitersTest {
     produceRateLimiters.rateLimit("clusterId", 10L);
 
     Thread.sleep(50);
+    // Cache should have expired, and count reset back to 10L.
     produceRateLimiters.rateLimit("clusterId", 10L);
 
     verify(
@@ -371,7 +374,7 @@ public class ProduceRateLimitersTest {
 
   @Test
   @Inject
-  public void globalCountLimitHit() {
+  public void test_whenGlobalCountLimitHit_thenExceptionThrown() {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");
@@ -428,7 +431,7 @@ public class ProduceRateLimitersTest {
 
   @Test
   @Inject
-  public void globalBytesLimitHit() {
+  public void test_whenGlobalBytesLimitHit_thenExceptionThrown() {
 
     Properties properties = new Properties();
     properties.put(PRODUCE_RATE_LIMIT_ENABLED, "true");

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/DefaultKafkaRestTestEnvironment.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/DefaultKafkaRestTestEnvironment.java
@@ -23,6 +23,17 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public final class DefaultKafkaRestTestEnvironment
     implements BeforeEachCallback, AfterEachCallback {
 
+  private boolean manageRest = true;
+
+  public DefaultKafkaRestTestEnvironment() {}
+
+  // If manageRest is set to true, this will manage starting & stopping rest-instance of this test.
+  // If manageRest is set to false, the user of this class is expected to start & stop rest-instance
+  // appropriately, example - ProduceActionItegrationTest.java
+  public DefaultKafkaRestTestEnvironment(boolean manageRest) {
+    this.manageRest = manageRest;
+  }
+
   private final SslFixture certificates =
       SslFixture.builder()
           .addKey("kafka-1")
@@ -72,12 +83,16 @@ public final class DefaultKafkaRestTestEnvironment
     zookeeper.beforeEach(extensionContext);
     kafkaCluster.beforeEach(extensionContext);
     schemaRegistry.beforeEach(extensionContext);
-    kafkaRest.beforeEach(extensionContext);
+    if (this.manageRest) {
+      kafkaRest.beforeEach(extensionContext);
+    }
   }
 
   @Override
   public void afterEach(ExtensionContext extensionContext) {
-    kafkaRest.afterEach(extensionContext);
+    if (this.manageRest) {
+      kafkaRest.afterEach(extensionContext);
+    }
     schemaRegistry.afterEach(extensionContext);
     kafkaCluster.afterEach(extensionContext);
     zookeeper.afterEach(extensionContext);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/DefaultKafkaRestTestEnvironment.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/DefaultKafkaRestTestEnvironment.java
@@ -25,8 +25,7 @@ public final class DefaultKafkaRestTestEnvironment
 
   private boolean manageRest = true;
 
-  public DefaultKafkaRestTestEnvironment() {
-  }
+  public DefaultKafkaRestTestEnvironment() {}
 
   // If manageRest is set to true, this will manage the life-cycle of the rest-instance through the
   // junit-extensions(BeforeEach & AfterEach). This includes starting & stopping rest-instance of

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/DefaultKafkaRestTestEnvironment.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/DefaultKafkaRestTestEnvironment.java
@@ -25,11 +25,15 @@ public final class DefaultKafkaRestTestEnvironment
 
   private boolean manageRest = true;
 
-  public DefaultKafkaRestTestEnvironment() {}
+  public DefaultKafkaRestTestEnvironment() {
+  }
 
-  // If manageRest is set to true, this will manage starting & stopping rest-instance of this test.
-  // If manageRest is set to false, the user of this class is expected to start & stop rest-instance
-  // appropriately, example - ProduceActionItegrationTest.java
+  // If manageRest is set to true, this will manage the life-cycle of the rest-instance through the
+  // junit-extensions(BeforeEach & AfterEach). This includes starting & stopping rest-instance of
+  // this test.
+  // If manageRest is set to false, the user of this class is taking the responsibility of managing
+  // rest-instance for the overall test. Example - ProduceActionIntegrationTest.java, manages
+  // the rest-instance, and sets custom KafkaRestConfigs for different test-case.
   public DefaultKafkaRestTestEnvironment(boolean manageRest) {
     this.manageRest = manageRest;
   }


### PR DESCRIPTION
1. In ProduceActionIntegrationTest, add integration-test for the 4 rate-limits. The happy-path testing, i.e. rest calls below threshold succeed are already covered by the existing tests. The 4 new tests, 1 per rate-limit config, sets a very low rate-limit of "1", to deterministically make sure limits apply and rest-calls see 429s.
2. ProduceRateLimitersTest.java, minor refactoring to improve readability.