### PR TITLE
KREST-10170 Increase timeout to remove flakyness due to timeouts

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerJsonTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerJsonTest.java
@@ -198,8 +198,8 @@ public class ConsumerJsonTest extends AbstractConsumerTest {
             consumer1ReadyForConsumeLoop,
             consumer0ReadyForConsumeLoop /* otherConsumerReadyForConsumeLoop */));
 
-    boolean isConsumer0Done = consumer0Done.await(60, TimeUnit.SECONDS);
-    boolean isConsumer1Done = consumer1Done.await(60, TimeUnit.SECONDS);
+    boolean isConsumer0Done = consumer0Done.await(120, TimeUnit.SECONDS);
+    boolean isConsumer1Done = consumer1Done.await(120, TimeUnit.SECONDS);
 
     assertTrue(
         isConsumer0Done && isConsumer1Done, "test timed out waiting for consumers to finish.");


### PR DESCRIPTION
Pass-rate is 78% right now, increase timeout to improve pass-rate. One such failed instance -

`org.opentest4j.AssertionFailedError: test timed out waiting for consumers to finish. ==> expected:  but was:  	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55) 	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:40) 	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:210) 	at io.confluent.kafkarest.integration.ConsumerJsonTest.testConsumeWithMultipleParallelConsumers(ConsumerJsonTest.java:204) 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 	at java.lang.reflect.Method.invoke(Method.java:498)`