### PR TITLE
KREST-10318 Topic create without DESCRIBE_CONFIGS

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/TopicsResource.java
@@ -193,6 +193,27 @@ public final class TopicsResource {
         request.getConfigs().stream()
             .collect(Collectors.toMap(ConfigEntry::getName, ConfigEntry::getValue));
 
+    // The partitions count for the topic is set in three ways, in this order of precedence:
+    // 1) If a map of replica assignments is provided, the partition count is calculated.
+    // 2) If a partition count is provided, use that value.
+    // 3) Otherwise, no value is provided and the topic uses the default partition count.
+    Optional<Integer> requestPartitionsCount =
+        replicasAssignments.isEmpty()
+            ? partitionsCount
+            : Optional.of(replicasAssignments.values().size());
+
+    // The replication factor for the topic is set in three ways, in this order of precedence:
+    // 1) If a map of replica assignments is provided, the replication factor is calculated.
+    // 2) If a replication factor is provided, use that value.
+    // 3) Otherwise, no value is provided and the topic uses the default replication factor.
+    Optional<Short> requestReplicationFactor =
+        replicasAssignments.isEmpty()
+            ? replicationFactor
+            : Optional.of((short) replicasAssignments.values().iterator().next().size());
+
+    // The CreateTopicResponse is created from TopicData, although this is only really used to
+    // build the response in a way compatible with the original implementation. This requires
+    // a value for the replication factor, which is supplied, calculated or defaulted to 0.
     // We have no way of knowing the default replication factor in the Kafka broker. Also in case
     // of explicitly specified partition-to-replicas assignments, all partitions should have the
     // same number of replicas.
@@ -220,8 +241,8 @@ public final class TopicsResource {
             .createTopic2(
                 clusterId,
                 topicName,
-                partitionsCount,
-                replicationFactor,
+                requestPartitionsCount,
+                requestReplicationFactor,
                 replicasAssignments,
                 configs,
                 validateOnly)

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -48,6 +48,7 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
   private static final String TOPIC_1 = "topic-1";
   private static final String TOPIC_2 = "topic-2";
   private static final String TOPIC_3 = "topic-3";
+  private static final String TOPIC_NON_EXISTENT = "no-such-topic";
 
   private static final boolean USE_ALTERNATE_CLIENT_PROVIDER = true;
 
@@ -874,7 +875,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
 
   @Test
   public void updateTopicPartitions_decreasePartitionsCount_returns40002() {
-    String baseUrl = restConnect;
     String clusterId = getClusterId();
 
     Response getTopicResponse =
@@ -888,7 +888,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
 
   @Test
   public void updateTopicPartitions_samePartitionsCount_returns40002() {
-    String baseUrl = restConnect;
     String clusterId = getClusterId();
 
     Response getTopicResponse =
@@ -896,21 +895,22 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
             .accept(MediaType.APPLICATION_JSON)
             .method(
                 HttpMethod.PATCH,
-                Entity.entity("{\"partitions_count\":1}", MediaType.APPLICATION_JSON));
+                Entity.entity("{\"partitions_count\":2}", MediaType.APPLICATION_JSON));
     assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
   }
 
   @Test
-  public void updateTopicPartitions_topicDoesntExist_returns40002() {
-    String baseUrl = restConnect;
+  public void updateTopicPartitions_topicDoesntExist_returns404() {
     String clusterId = getClusterId();
 
     Response getTopicResponse =
-        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_1, USE_ALTERNATE_CLIENT_PROVIDER)
+        request(
+                "/v3/clusters/" + clusterId + "/topics/" + TOPIC_NON_EXISTENT,
+                USE_ALTERNATE_CLIENT_PROVIDER)
             .accept(MediaType.APPLICATION_JSON)
             .method(
                 HttpMethod.PATCH,
                 Entity.entity("{\"partitions_count\":1}", MediaType.APPLICATION_JSON));
-    assertEquals(Status.BAD_REQUEST.getStatusCode(), getTopicResponse.getStatus());
+    assertEquals(Status.NOT_FOUND.getStatusCode(), getTopicResponse.getStatus());
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -593,8 +593,8 @@ public class TopicsResourceTest {
             topicManager.createTopic2(
                 CLUSTER_ID,
                 TOPIC_1.getName(),
-                /* partitionsCount= */ Optional.empty(),
-                /* replicationFactor= */ Optional.empty(),
+                /* partitionsCount= */ Optional.of((int) 3),
+                /* replicationFactor= */ Optional.of((short) 2),
                 replicasAssignments,
                 singletonMap("cleanup.policy", Optional.of("compact")),
                 false))


### PR DESCRIPTION
The operation to create a topic has a response schema which doesn't really match the underlying behaviour of Kafka particularly well. The response contains the `replication_factor` and `partitions_count` which are sometimes not possible to establish depending on authorization. Prior to this PR, in the case where the principal creating the topic has CREATE authority but not DESCRIBE_CONFIGS, the `POST /v3/clusters/{}/topics` request fails with `{"error_code":40301,"message":"Topic authorization failed."}` even when the topic is created successfully. The authorization failure is actually to access the replication factor, which comes back in the CreateTopicsResponse in the Kafka protocol, *provided* that the principal has DESCRIBE_CONFIGS authority. If principal does not have authority, the CreateTopicsResponse actually contains an inner error code, and that's translated into an exception which is thrown when the replication factor is accessed in the result.

This PR returns the `replication_factor` and `partitions_count` from the CreateTopicsResponse if present. If however, they are not present because of the authorization failure, the code does its best to return the values based on the request parameters. For example, if the request says `replication_factor:2` then the response contains that also, even if the authorization failure occurred. In some cases, the request doesn't provide enough information to return the values in which case 0 is returned.

It would be better if the response schema didn't require these fields because the information is not always available. However, that would be an incompatible change in the API.