### PR TITLE
KREST-8294 Permit charset for v3 produce

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStreamMessageBodyReader.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStreamMessageBodyReader.java
@@ -63,7 +63,8 @@ public final class JsonStreamMessageBodyReader implements MessageBodyReader<Json
       if (charset != null) {
         if (!charset.equalsIgnoreCase("UTF-8") && !charset.equalsIgnoreCase("ISO-8859-1")) {
           throw new WebApplicationException(
-              "Unsupported charset in Content-Type header.", Status.BAD_REQUEST);
+              "Unsupported charset in Content-Type header. Supports \"UTF-8\" and \"ISO-8859-1\".",
+              Status.BAD_REQUEST);
         }
       }
     }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStreamMessageBodyReader.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStreamMessageBodyReader.java
@@ -28,6 +28,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.MessageBodyReader;
 
 /** A {@link MessageBodyReader} for {@link JsonStream}. */
@@ -41,7 +42,9 @@ public final class JsonStreamMessageBodyReader implements MessageBodyReader<Json
   @Override
   public boolean isReadable(
       Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-    return JsonStream.class.equals(type) && MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    return JsonStream.class.equals(type)
+        && MediaType.APPLICATION_JSON_TYPE.getType().equalsIgnoreCase(mediaType.getType())
+        && MediaType.APPLICATION_JSON_TYPE.getSubtype().equalsIgnoreCase(mediaType.getSubtype());
   }
 
   @Override
@@ -53,6 +56,18 @@ public final class JsonStreamMessageBodyReader implements MessageBodyReader<Json
       MultivaluedMap<String, String> httpHeaders,
       InputStream entityStream)
       throws WebApplicationException {
+
+    // We know that the media type is 'application/json' but there might be an optional charset too
+    if (mediaType.getParameters() != null) {
+      String charset = mediaType.getParameters().get(MediaType.CHARSET_PARAMETER);
+      if (charset != null) {
+        if (!charset.equalsIgnoreCase("UTF-8") && !charset.equalsIgnoreCase("ISO-8859-1")) {
+          throw new WebApplicationException(
+              "Unsupported charset in Content-Type header.", Status.BAD_REQUEST);
+        }
+      }
+    }
+
     JavaType wrappedType = objectMapper.constructType(genericType).containedType(0);
     return new JsonStream<>(
         () -> {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionNoSchemaIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionNoSchemaIntegrationTest.java
@@ -215,6 +215,109 @@ public class ProduceActionNoSchemaIntegrationTest extends ClusterTestHarness {
   }
 
   @Test
+  public void produceStringCharsetUtf8() throws Exception {
+    String clusterId = getClusterId();
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.STRING)
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.STRING)
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .setOriginalSize(0L)
+            .build();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON + "; charset=UTF-8"));
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+    ProduceResponse actual = readProduceResponse(response);
+    ConsumerRecord<String, String> produced =
+        getMessage(
+            TOPIC_NAME,
+            actual.getPartitionId(),
+            actual.getOffset(),
+            new StringDeserializer(),
+            new StringDeserializer());
+    assertEquals(key, produced.key());
+    assertEquals(value, produced.value());
+  }
+
+  @Test
+  public void produceStringCharsetIso88591() throws Exception {
+    String clusterId = getClusterId();
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.STRING)
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.STRING)
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .setOriginalSize(0L)
+            .build();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON + "; charset=ISO-8859-1"));
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+    ProduceResponse actual = readProduceResponse(response);
+    ConsumerRecord<String, String> produced =
+        getMessage(
+            TOPIC_NAME,
+            actual.getPartitionId(),
+            actual.getOffset(),
+            new StringDeserializer(),
+            new StringDeserializer());
+    assertEquals(key, produced.key());
+    assertEquals(value, produced.value());
+  }
+
+  @Test
+  public void produceStringCharsetInvalid() throws Exception {
+    String clusterId = getClusterId();
+    String key = "foo";
+    String value = "bar";
+    ProduceRequest request =
+        ProduceRequest.builder()
+            .setKey(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.STRING)
+                    .setData(TextNode.valueOf(key))
+                    .build())
+            .setValue(
+                ProduceRequestData.builder()
+                    .setFormat(EmbeddedFormat.STRING)
+                    .setData(TextNode.valueOf(value))
+                    .build())
+            .setOriginalSize(0L)
+            .build();
+
+    Response response =
+        request("/v3/clusters/" + clusterId + "/topics/" + TOPIC_NAME + "/records")
+            .accept(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(request, MediaType.APPLICATION_JSON + "; charset=DEADBEEF"));
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
+
+  @Test
   public void produceStringWithEmptyData() throws Exception {
     String clusterId = getClusterId();
     ProduceRequest request =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProduceActionTest.java
@@ -720,7 +720,8 @@ public class ProduceActionTest {
     return recordSerializerProvider;
   }
 
-  private static ProduceController getProduceControllerMock(Provider produceControllerProvider) {
+  private static ProduceController getProduceControllerMock(
+      Provider<ProduceController> produceControllerProvider) {
     ProduceController produceController = mock(ProduceController.class);
     expect(produceControllerProvider.get()).andReturn(produceController).anyTimes();
     return produceController;


### PR DESCRIPTION
This permits a Content-Type header that includes UTF-8 or ISO-8859-1 as a charset header parameters such as `Content-Type=application/json; charset=UTF-8`.