### PR TITLE
KREST-10244 Fix produce-request-rate metric

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
@@ -158,7 +158,7 @@ final class ProducerMetrics {
 
   private void setupRequestSensor(Map<String, String> metricsTags, String sensorTags) {
     Sensor requestSensor = createSensor(REQUEST_SENSOR_NAME, sensorTags);
-    addAvg(requestSensor, REQUEST_RATE_METRIC_NAME, REQUEST_RATE_METRIC_DOC, metricsTags);
+    addRate(requestSensor, REQUEST_RATE_METRIC_NAME, REQUEST_RATE_METRIC_DOC, metricsTags);
     addWindowedCount(
         requestSensor,
         REQUEST_COUNT_WINDOWED_METRIC_NAME,

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafkarest.KafkaRestConfig;
 import java.util.Map;
@@ -292,7 +293,8 @@ final class ProducerMetrics {
                 .toArray(Percentile[]::new)));
   }
 
-  private MetricName getMetricName(String name, String doc, Map<String, String> metricsTags) {
+  @VisibleForTesting
+  protected MetricName getMetricName(String name, String doc, Map<String, String> metricsTags) {
     return metrics.metricInstance(
         new MetricNameTemplate(name, GROUP_NAME, doc, metricsTags.keySet()), metricsTags);
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
@@ -62,7 +62,7 @@ public class ProducerMetricsTest {
   private ProducerMetrics producerMetrics;
   private KafkaRestConfig config;
 
-  private Map tags = ImmutableMap.of("tag", "value");
+  private final Map<String, String> tags = ImmutableMap.of("tag", "value");
 
   @BeforeEach
   public void setUp()

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
@@ -21,6 +21,7 @@ import static java.util.function.LongUnaryOperator.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -39,10 +40,17 @@ import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +61,8 @@ public class ProducerMetricsTest {
 
   private ProducerMetrics producerMetrics;
   private KafkaRestConfig config;
+
+  private Map tags = ImmutableMap.of("tag", "value");
 
   @BeforeEach
   public void setUp()
@@ -79,7 +89,7 @@ public class ProducerMetricsTest {
 
     config.setMetrics(metrics);
 
-    producerMetrics = new ProducerMetrics(config, ImmutableMap.of("tag", "value"));
+    producerMetrics = new ProducerMetrics(config, tags);
   }
 
   @Test
@@ -267,5 +277,92 @@ public class ProducerMetricsTest {
     mBeanServer.unregisterMBean(new ObjectName("kafka.rest:type=produce-api-metrics,tag=value"));
     mBeanServer.unregisterMBean(
         new ObjectName("kafka.rest:type=produce-api-metrics," + "otherTag=otherValue2,tag=value2"));
+  }
+
+  @Test
+  public void test_requestSensor_hasCorrectMetricObjectTypeSetup() {
+    {
+      MetricName name = producerMetrics.getMetricName("request-rate", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Rate);
+    }
+    {
+      MetricName name = producerMetrics.getMetricName("request-count-windowed", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof WindowedCount);
+    }
+  }
+
+  @Test
+  public void test_requestSizeSensor_hasCorrectMetricObjectTypeSetup() {
+    // RequestSizeSensor setups up a meter, which internally comprises of a rate & cumulative-sum.
+    // So to check a meter is created, check for rate & cum-sum.
+    {
+      MetricName name = producerMetrics.getMetricName("request-byte-rate", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Rate);
+    }
+    {
+      MetricName name = producerMetrics.getMetricName("request-byte-total", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof CumulativeSum);
+    }
+  }
+
+  @Test
+  public void test_responseSensor_hasCorrectMetricObjectTypeSetup() {
+    {
+      MetricName name = producerMetrics.getMetricName("response-rate", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Rate);
+    }
+    {
+      MetricName name = producerMetrics.getMetricName("response-count-windowed", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof WindowedCount);
+    }
+  }
+
+  @Test
+  public void test_recordErrorSensor_hasCorrectMetricObjectTypeSetup() {
+    {
+      MetricName name = producerMetrics.getMetricName("record-error-rate", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Rate);
+    }
+    {
+      MetricName name = producerMetrics.getMetricName("error-count-windowed", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof WindowedCount);
+    }
+  }
+
+  @Test
+  public void test_recordRateLimitedSensor_hasCorrectMetricObjectTypeSetup() {
+    {
+      MetricName name = producerMetrics.getMetricName("record-rate-limited-rate", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Rate);
+    }
+    {
+      MetricName name =
+          producerMetrics.getMetricName("record-rate-limited-count-windowed", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof WindowedCount);
+    }
+  }
+
+  @Test
+  public void test_requestLatencySensor_hasCorrectMetricObjectTypeSetup() {
+    {
+      MetricName name = producerMetrics.getMetricName("request-latency-max", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Max);
+    }
+    {
+      MetricName name = producerMetrics.getMetricName("request-latency-avg", "", tags);
+      KafkaMetric metric = config.getMetrics().metric(name);
+      assertTrue(metric.measurable() instanceof Avg);
+    }
   }
 }


### PR DESCRIPTION
Simple fix, correctly use "rate" metric to record "produce-request-rate", instead of "avg".