### PR TITLE
Remove the use of non-public API MockTime (in ce-kafka but not in AK)

### DIFF
--- a/checkstyle/import_control.xml
+++ b/checkstyle/import_control.xml
@@ -135,7 +135,6 @@
   <allow class="org.apache.kafka.common.network.ListenerName" />
   <allow class="org.apache.kafka.common.protocol.Errors" />
   <allow class="org.apache.kafka.common.security.JaasUtils" />
-  <allow class="org.apache.kafka.server.util.MockTime" />
   <allow class="org.apache.kafka.test.TestSslUtils" />
   <!-- c. Non-public Confluent Community Kafka APIs -->
   <allow class="kafka.admin.AclCommand" />

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -48,11 +48,6 @@
             <version>${kafka.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-server-common</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${io.confluent.schema-registry.version}</version>

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -82,7 +82,6 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.server.util.MockTime;
 import org.eclipse.jetty.server.Server;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -301,11 +300,7 @@ public abstract class ClusterTestHarness {
                     .map(
                         config ->
                             CompletableFuture.supplyAsync(
-                                () ->
-                                    TestUtils.createServer(
-                                        config,
-                                        new MockTime(
-                                            System.currentTimeMillis(), System.nanoTime()))))
+                                () -> TestUtils.createServer(config, Option.empty())))
                     .collect(toList()))
             .join();
     log.info("Started all {} brokers for {}", numBrokers, getClass().getSimpleName());

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
@@ -37,10 +37,10 @@ import kafka.utils.TestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.server.util.MockTime;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import scala.Option;
 
 /** An extension that runs a Kafka broker. */
 public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCallback {
@@ -57,9 +57,6 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
           .put(KafkaConfig.OffsetsTopicPartitionsProp(), "1")
           .put(KafkaConfig.OffsetsTopicReplicationFactorProp(), "1")
           .build();
-
-  private static final MockTime MOCK_TIME =
-      new MockTime(System.currentTimeMillis(), System.nanoTime());
 
   private final int brokerId;
   @Nullable private final SslFixture certificates;
@@ -97,7 +94,7 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
   @Override
   public void beforeEach(ExtensionContext extensionContext) throws Exception {
     logDir = Files.createTempDirectory(String.format("kafka-%d-", brokerId));
-    broker = TestUtils.createServer(KafkaConfig.fromProps(getBrokerConfigs()), MOCK_TIME);
+    broker = TestUtils.createServer(KafkaConfig.fromProps(getBrokerConfigs()), Option.empty());
   }
 
   private Properties getBrokerConfigs() {


### PR DESCRIPTION
This PR removes MockTime dependency to avoid upstream issue.