### PR TITLE
Make sure that ErrorMessage is intepret as json type in response writer

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapper.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapper.java
@@ -18,6 +18,7 @@ package io.confluent.kafkarest.exceptions;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.common.errors.SerializationException;
 
@@ -40,6 +41,9 @@ public final class KafkaRestExceptionMapper extends KafkaExceptionMapper {
 
   private Response getResponse(Throwable exception, Response.Status status, int errorCode) {
     ErrorMessage errorMessage = new ErrorMessage(errorCode, exception.getMessage());
-    return Response.status(status).entity(errorMessage).build();
+    return Response.status(status)
+        .entity(errorMessage)
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .build();
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapperTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapperTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.confluent.rest.entities.ErrorMessage;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.common.errors.SerializationException;
@@ -48,5 +49,6 @@ public class KafkaRestExceptionMapperTest {
     ErrorMessage errorMessage = (ErrorMessage) response.getEntity();
     assertEquals(errorCode, errorMessage.getErrorCode());
     assertEquals(exceptionMessage, throwable.getMessage());
+    assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
   }
 }


### PR DESCRIPTION
As the title says. The reason is that without explicit MediaType, we might encounter the below error with OPTIONS request

```
org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException: MessageBodyWriter not found for media type=text/plain, type=class io.confluent.rest.entities.ErrorMessage, genericType=class io.confluent.rest.entities.ErrorMessage
```