### PR TITLE
DOCS-18367 - Add limitation to V3 produce API [OPEN SOURCE PLATFORM DOCS]

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1336,7 +1336,7 @@ paths:
         the connection is successfully established. To identify records that
         have encountered an error, check the error_code of each delivery report.
 
-        Note that only BINARY and JSON formats are supported.
+        Note that only BINARY, JSON, and STRING formats are supported.
 
                     
       tags:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1336,7 +1336,9 @@ paths:
         the connection is successfully established. To identify records that
         have encountered an error, check the error_code of each delivery report.
 
-        Note that only BINARY, JSON, and STRING formats are supported.
+        This API currently does not support Schema Registry
+        integration. Sending schemas is not supported. Only BINARY,
+        JSON, and STRING formats are supported.
 
                     
       tags:

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1326,14 +1326,19 @@ paths:
         [![Open Preview](https://img.shields.io/badge/Lifecycle%20Stage-Open%20Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
 
         Produce records to the given topic, returning delivery reports for each
-                    record produced. This API can be used in streaming mode by setting "Transfer-Encoding:
-                    chunked" header. For as long as the connection is kept open, the server will
-                    keep accepting records. Records are streamed to and from the server as Concatenated 
-                    JSON. For each record sent to the server, the server will
-                    asynchronously send back a delivery report, in the same order, each with its own
-                    error_code. An error_code of 200 indicates success. The HTTP status code will be HTTP 
-                    200 OK as long as the connection is successfully established. To identify records
-                    that have encountered an error, check the error_code of each delivery report.
+        record produced. This API can be used in streaming mode by setting
+        "Transfer-Encoding: chunked" header. For as long as the connection is
+        kept open, the server will keep accepting records. Records are streamed
+        to and from the server as Concatenated JSON. For each record sent to the
+        server, the server will asynchronously send back a delivery report, in
+        the same order, each with its own error_code. An error_code of 200
+        indicates success. The HTTP status code will be HTTP 200 OK as long as
+        the connection is successfully established. To identify records that
+        have encountered an error, check the error_code of each delivery report.
+
+        Note that only BINARY and JSON formats are supported.
+
+                    
       tags:
         - Records
       requestBody:


### PR DESCRIPTION
See: https://confluentinc.atlassian.net/browse/DOCS-18367

> Make a note here: 
> 
> https://docs.confluent.io/platform/current/kafka-rest/api.html#records-v3 
> 
> that only binary and json format are supported, not avro