### PR TITLE
KREST-11230 Fix tests to expect right media-type application/json

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
@@ -34,6 +34,7 @@ import io.confluent.rest.EmbeddedServerTestHarness;
 import io.confluent.rest.RestConfigException;
 import java.util.Arrays;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.protocol.Errors;
@@ -91,6 +92,6 @@ public class BrokersResourceTest
         response,
         io.confluent.kafkarest.Errors.KAFKA_AUTHENTICATION_ERROR_CODE,
         Errors.SASL_AUTHENTICATION_FAILED.message(),
-        Versions.KAFKA_V2_JSON);
+        MediaType.APPLICATION_JSON);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/RootResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/RootResourceTest.java
@@ -18,7 +18,6 @@ package io.confluent.kafkarest.resources.v2;
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.confluent.kafkarest.KafkaRestApplication;
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -29,6 +28,7 @@ import io.confluent.rest.RestConfigException;
 import java.util.Map;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
@@ -55,8 +55,7 @@ public class RootResourceTest
     // entities. See https://java.net/jira/browse/JAX_RS_SPEC-363 for the corresponding JAX-RS
     // bug. We verify the little bit we can (status code) here.
     assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), response.getStatus());
-    // These verify that we're seeing the *expected* but *incorrect* behavior.
-    assertNull(response.getMediaType());
+    assertEquals(response.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
@@ -253,7 +254,7 @@ public class TopicsResourceBinaryProduceTest
         response,
         ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY_CODE,
         null,
-        Versions.KAFKA_V2_JSON);
+        MediaType.APPLICATION_JSON);
   }
 
   private void testProduceToTopicException(
@@ -267,7 +268,7 @@ public class TopicsResourceBinaryProduceTest
           rawResponse,
           RestServerErrorException.DEFAULT_ERROR_CODE,
           AbstractProduceAction.UNEXPECTED_PRODUCER_EXCEPTION,
-          Versions.KAFKA_V2_JSON);
+          MediaType.APPLICATION_JSON);
     } else {
       assertOKResponse(rawResponse, Versions.KAFKA_V2_JSON);
       ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.easymock.EasyMockExtension;
 import org.easymock.Mock;
@@ -411,6 +412,6 @@ public class TopicsResourceTest
         response,
         Errors.TOPIC_NOT_FOUND_ERROR_CODE,
         Errors.TOPIC_NOT_FOUND_MESSAGE,
-        Versions.KAFKA_V2_JSON);
+        MediaType.APPLICATION_JSON);
   }
 }


### PR DESCRIPTION
Error messages are now interpreted as json(see below commit), with media-type now set as "application/json". Update tests to expect "application/json" for errors.

https://github.com/confluentinc/rest-utils/commit/c32438da97d22116e4d1e58912b9bceac1f62d05