### PR TITLE
Krest 11086 revert commit that set explicit mediatype

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapper.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapper.java
@@ -18,7 +18,6 @@ package io.confluent.kafkarest.exceptions;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.common.errors.SerializationException;
 
@@ -41,9 +40,6 @@ public final class KafkaRestExceptionMapper extends KafkaExceptionMapper {
 
   private Response getResponse(Throwable exception, Response.Status status, int errorCode) {
     ErrorMessage errorMessage = new ErrorMessage(errorCode, exception.getMessage());
-    return Response.status(status)
-        .entity(errorMessage)
-        .type(MediaType.APPLICATION_JSON_TYPE)
-        .build();
+    return Response.status(status).entity(errorMessage).build();
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapperTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/exceptions/KafkaRestExceptionMapperTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.confluent.rest.entities.ErrorMessage;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.common.errors.SerializationException;
@@ -49,6 +48,5 @@ public class KafkaRestExceptionMapperTest {
     ErrorMessage errorMessage = (ErrorMessage) response.getEntity();
     assertEquals(errorCode, errorMessage.getErrorCode());
     assertEquals(exceptionMessage, throwable.getMessage());
-    assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AbstractConsumerTest.java
@@ -49,7 +49,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -337,7 +336,7 @@ public class AbstractConsumerTest extends ClusterTestHarness {
         response,
         Errors.CONSUMER_INSTANCE_NOT_FOUND_ERROR_CODE,
         Errors.CONSUMER_INSTANCE_NOT_FOUND_MESSAGE,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON_BINARY);
   }
 
   protected void deleteConsumer(String instanceUri) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import kafka.security.authorizer.AclAuthorizer;
 import kafka.server.KafkaConfig;
@@ -198,7 +197,7 @@ public class AuthorizationErrorTest
           response,
           Errors.KAFKA_AUTHORIZATION_ERROR_CODE,
           "Not authorized to access topics",
-          MediaType.APPLICATION_JSON);
+          Versions.KAFKA_V2_JSON_BINARY);
     } else {
       assertOKResponse(response, Versions.KAFKA_V2_JSON_BINARY);
     }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ConsumerBinaryTest.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -175,7 +174,7 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
         response,
         Errors.INVALID_CONSUMER_CONFIG_ERROR_CODE,
         Errors.INVALID_CONSUMER_CONFIG_MESSAGE,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 
   @Test
@@ -192,6 +191,6 @@ public class ConsumerBinaryTest extends AbstractConsumerTest {
         createResponse,
         Errors.CONSUMER_ALREADY_EXISTS_ERROR_CODE,
         Errors.CONSUMER_ALREADY_EXISTS_MESSAGE,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataApiTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/MetadataApiTest.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -155,7 +154,7 @@ public class MetadataApiTest extends ClusterTestHarness {
         invalidResponse,
         KafkaExceptionMapper.KAFKA_UNKNOWN_TOPIC_PARTITION_CODE,
         null,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 
   @Test
@@ -182,7 +181,7 @@ public class MetadataApiTest extends ClusterTestHarness {
         invalidResponse,
         Errors.PARTITION_NOT_FOUND_ERROR_CODE,
         Errors.PARTITION_NOT_FOUND_MESSAGE,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 
   private void verifyPartitionGet(String topicName, int numReplicas, int numPartitions) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/BrokersResourceTest.java
@@ -34,7 +34,6 @@ import io.confluent.rest.EmbeddedServerTestHarness;
 import io.confluent.rest.RestConfigException;
 import java.util.Arrays;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.protocol.Errors;
@@ -92,6 +91,6 @@ public class BrokersResourceTest
         response,
         io.confluent.kafkarest.Errors.KAFKA_AUTHENTICATION_ERROR_CODE,
         Errors.SASL_AUTHENTICATION_FAILED.message(),
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/RootResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/RootResourceTest.java
@@ -18,6 +18,7 @@ package io.confluent.kafkarest.resources.v2;
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.confluent.kafkarest.KafkaRestApplication;
 import io.confluent.kafkarest.KafkaRestConfig;
@@ -28,7 +29,6 @@ import io.confluent.rest.RestConfigException;
 import java.util.Map;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +55,8 @@ public class RootResourceTest
     // entities. See https://java.net/jira/browse/JAX_RS_SPEC-363 for the corresponding JAX-RS
     // bug. We verify the little bit we can (status code) here.
     assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), response.getStatus());
-    assertEquals(response.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+    // These verify that we're seeing the *expected* but *incorrect* behavior.
+    assertNull(response.getMediaType());
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
@@ -254,7 +253,7 @@ public class TopicsResourceBinaryProduceTest
         response,
         ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY_CODE,
         null,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 
   private void testProduceToTopicException(
@@ -268,7 +267,7 @@ public class TopicsResourceBinaryProduceTest
           rawResponse,
           RestServerErrorException.DEFAULT_ERROR_CODE,
           AbstractProduceAction.UNEXPECTED_PRODUCER_EXCEPTION,
-          MediaType.APPLICATION_JSON);
+          Versions.KAFKA_V2_JSON);
     } else {
       assertOKResponse(rawResponse, Versions.KAFKA_V2_JSON);
       ProduceResponse response = TestUtils.tryReadEntityOrLog(rawResponse, ProduceResponse.class);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceTest.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.easymock.EasyMockExtension;
 import org.easymock.Mock;
@@ -412,6 +411,6 @@ public class TopicsResourceTest
         response,
         Errors.TOPIC_NOT_FOUND_ERROR_CODE,
         Errors.TOPIC_NOT_FOUND_MESSAGE,
-        MediaType.APPLICATION_JSON);
+        Versions.KAFKA_V2_JSON);
   }
 }


### PR DESCRIPTION
This reverts two commits that are related to explicit application/json media type on error response.