### PR TITLE
Able to drop connection if produce request is larger than a threshold

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestApplication.java
@@ -155,7 +155,7 @@ public class KafkaRestApplication extends Application<KafkaRestConfig> {
     }
 
     config.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
-    config.register(new JsonStreamMessageBodyReader(getJsonMapper()));
+    config.register(new JsonStreamMessageBodyReader(getJsonMapper(), appConfig));
     config.register(new BackendsModule());
     config.register(new ConfigModule(appConfig));
     config.register(new ControllersModule());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -227,6 +227,17 @@ public class KafkaRestConfig extends RestConfig {
   public static final ConfigDef.Range PRODUCE_BATCH_MAXIMUM_ENTRIES_VALIDATOR =
       ConfigDef.Range.between(1, 50);
 
+  public static final String PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG =
+      "api.v3.produce.request.size.limit.max.bytes";
+  private static final String PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_DOC =
+      "Specify this number to limit produce request size. Once that limit is reached then "
+          + "the produce request will be rejected with a 400 is returned to the client. "
+          + "In addition, the connection will be dropped to prevent further produce requests. "
+          + "If this limit is set to a non-positive number, no limit is applied. Default is 0.";
+  public static final String PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_DEFAULT = "0";
+  public static final ConfigDef.Range PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_VALIDATOR =
+      ConfigDef.Range.atLeast(0);
+
   public static final String CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG = "consumer.iterator.timeout.ms";
   private static final String CONSUMER_ITERATOR_TIMEOUT_MS_DOC =
       "Timeout for blocking consumer iterator operations. This should be set to a small enough "
@@ -611,6 +622,13 @@ public class KafkaRestConfig extends RestConfig {
             PRODUCE_BATCH_MAXIMUM_ENTRIES_VALIDATOR,
             Importance.LOW,
             PRODUCE_BATCH_MAXIMUM_ENTRIES_DOC)
+        .define(
+            PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG,
+            Type.LONG,
+            PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_DEFAULT,
+            PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_VALIDATOR,
+            Importance.LOW,
+            PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_DOC)
         .define(
             CONSUMER_ITERATOR_TIMEOUT_MS_CONFIG,
             Type.INT,
@@ -1144,6 +1162,10 @@ public class KafkaRestConfig extends RestConfig {
 
   public final int getRateLimitDefaultCost() {
     return getInt(RATE_LIMIT_DEFAULT_COST_CONFIG);
+  }
+
+  public final long getProduceRequestSizeLimitMaxBytesConfig() {
+    return getLong(PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG);
   }
 
   public final ImmutableMap<String, Integer> getRateLimitCosts() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -233,6 +233,9 @@ public class KafkaRestConfig extends RestConfig {
       "Specify this number to limit produce request size. Once that limit is reached then "
           + "the produce request will be rejected with a 400 is returned to the client. "
           + "In addition, the connection will be dropped to prevent further produce requests. "
+          + "Due to the produce request size counting algorithm's limitation, it is recommended "
+          + "to add 8192 (8KiB) buffer to the intended number that you want to set for the limit "
+          + "to avoid rejecting legitimate produce requests."
           + "If this limit is set to a non-positive number, no limit is applied. Default is 0.";
   public static final String PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_DEFAULT = "0";
   public static final ConfigDef.Range PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_VALIDATOR =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/ProduceRequestTooLargeException.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/exceptions/ProduceRequestTooLargeException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.exceptions;
+
+/** This exception is thrown when a produce request exceeds the size threshold. */
+public class ProduceRequestTooLargeException extends RuntimeException {
+  public ProduceRequestTooLargeException() {
+    this("Produce request size is larger than allowed threshold");
+  }
+
+  public ProduceRequestTooLargeException(String message) {
+    super(message);
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStream.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStream.java
@@ -75,7 +75,9 @@ public final class JsonStream<T> implements Closeable {
    * read while parsing a produce request so that we can act accordingly if the input stream is too
    * large; as an input stream is unbounded, we provide a method to reset the byte counter so that
    * it will be called by {@link JsonStream} on the boundary whenever a produce request is
-   * successfully parsed.
+   * successfully parsed; note that this class might not provide 100% accuracy produce request size
+   * counting due to the default buffer size of Jackson parser is 8000, so it is recommended to use
+   * this class only to validate produce request of big size.
    */
   public static class SizeLimitEntityStream extends InputStream {
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStream.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/JsonStream.java
@@ -17,9 +17,12 @@ package io.confluent.kafkarest.response;
 
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.google.common.base.Suppliers;
+import io.confluent.kafkarest.exceptions.ProduceRequestTooLargeException;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 /**
@@ -28,9 +31,15 @@ import java.util.function.Supplier;
  */
 public final class JsonStream<T> implements Closeable {
   private final Supplier<MappingIterator<T>> delegate;
+  private final SizeLimitEntityStream inputStream;
 
   public JsonStream(Supplier<MappingIterator<T>> delegate) {
+    this(delegate, null);
+  }
+
+  public JsonStream(Supplier<MappingIterator<T>> delegate, SizeLimitEntityStream inputStream) {
     this.delegate = Suppliers.memoize(delegate::get);
+    this.inputStream = inputStream;
   }
 
   public boolean hasNext() {
@@ -44,13 +53,120 @@ public final class JsonStream<T> implements Closeable {
     if (delegate.get() == null) {
       throw new NoSuchElementException();
     }
-    return delegate.get().nextValue();
+    T value = delegate.get().nextValue();
+    if (inputStream != null) {
+      inputStream.resetCounter();
+    }
+    return value;
   }
 
   @Override
   public void close() throws IOException {
+    if (inputStream != null) {
+      inputStream.invalidateCounter();
+    }
     if (delegate.get() != null) {
       delegate.get().close();
+    }
+  }
+
+  /**
+   * This class provides an {@link InputStream} where we can keep track of how many bytes have been
+   * read while parsing a produce request so that we can act accordingly if the input stream is too
+   * large; as an input stream is unbounded, we provide a method to reset the byte counter so that
+   * it will be called by {@link JsonStream} on the boundary whenever a produce request is
+   * successfully parsed.
+   */
+  public static class SizeLimitEntityStream extends InputStream {
+
+    private final InputStream delegate;
+    private final long sizeThreshold;
+    // this keeps track of how many bytes have been read while parsing a produce request
+    private final AtomicLong produceRequestByteCounter = new AtomicLong(0);
+
+    public SizeLimitEntityStream(InputStream delegate, long sizeThreshold) {
+      this.delegate = delegate;
+      this.sizeThreshold = sizeThreshold;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int v = delegate.read();
+      if (v != -1) {
+        validateSize(1);
+      }
+      return v;
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      int v = delegate.read(b);
+      if (v != -1) {
+        validateSize(v);
+      }
+      return v;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      int v = delegate.read(b, off, len);
+      if (v != -1) {
+        validateSize(v);
+      }
+      return v;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      long v = delegate.skip(n);
+      validateSize(v);
+      return v;
+    }
+
+    @Override
+    public int available() throws IOException {
+      return delegate.available();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+      delegate.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+      delegate.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+      return delegate.markSupported();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    /** This method must be called every time a ProduceRequest is successfully parsed */
+    private void resetCounter() {
+      produceRequestByteCounter.set(0);
+    }
+
+    /**
+     * This method must be called when {@link JsonStream} is closed and must be called only once.
+     * The reason is that when JsonStream is closed, it would still attempt to parse the InputStream
+     * if the delegate MappingIterator isn't cached in Suppliers.memoize. We set the counter to
+     * Long.MIN_VALUE to make sure validateSize never throws.
+     */
+    private void invalidateCounter() {
+      produceRequestByteCounter.set(Long.MIN_VALUE);
+    }
+
+    private void validateSize(long add) {
+      if (produceRequestByteCounter.addAndGet(add) > sizeThreshold) {
+        throw new ProduceRequestTooLargeException();
+      }
     }
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -28,6 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafkarest.common.CompletableFutures;
 import io.confluent.kafkarest.exceptions.BadRequestException;
+import io.confluent.kafkarest.exceptions.ProduceRequestTooLargeException;
 import io.confluent.kafkarest.exceptions.RestConstraintViolationExceptionMapper;
 import io.confluent.kafkarest.exceptions.StatusCodeException;
 import io.confluent.kafkarest.exceptions.v3.ErrorResponse;
@@ -276,6 +277,15 @@ public abstract class StreamingResponse<T> {
     public CompletableFuture<T> next() {
       try {
         return CompletableFuture.completedFuture(inputStream.nextValue());
+      } catch (JsonMappingException e) {
+        if (e.getCause() instanceof ProduceRequestTooLargeException) {
+          // we stop the stream if we detect a produce request over the size limit
+          throw new BadRequestException(
+              String.format("Error processing message: %s", e.getCause().getMessage()),
+              e.getCause());
+        } else {
+          return CompletableFutures.failedFuture(e);
+        }
       } catch (Throwable e) {
         return CompletableFutures.failedFuture(e);
       }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/TestUtils.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -431,5 +432,18 @@ public class TestUtils {
         ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClassName);
     consumerConfig.putAll(deserializerProps);
     return new KafkaConsumer<>(consumerConfig);
+  }
+
+  /** Generate a random alphanumeric string with specific length */
+  public static String generateAlphanumericString(Random random, int length) {
+    int leftLimit = 48; // numeral '0'
+    int rightLimit = 122; // letter 'z'
+    return random
+        .ints(leftLimit, rightLimit + 1)
+        // this make sure that the character is alphanumeric
+        .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionRequestSizeLimitIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionRequestSizeLimitIntegrationTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.integration.v3;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.TestUtils;
+import io.confluent.kafkarest.testing.DefaultKafkaRestTestEnvironment;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.util.InputStreamResponseListener;
+import org.eclipse.jetty.client.util.OutputStreamContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag("IntegrationTest")
+public class ProduceActionRequestSizeLimitIntegrationTest {
+  private static final Logger log =
+      LoggerFactory.getLogger(ProduceActionRequestSizeLimitIntegrationTest.class);
+  private static final Random RNG = new Random();
+  private static final String TEST_MESSAGE_TEMPLATE =
+      "{ " + "\"value\" : { " + "\"type\" : \"JSON\", " + "\"data\" : \"%s\" " + "}}";
+  private static final String TEST_TOPIC_NAME = "test-topic-1";
+  private static final ObjectMapper TEST_RESPONSE_OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private static final int TEST_DATA_SIZE = 1024 * 1024;
+  private static final int LIMIT_SIZE = 1024 * 1024 + 8 * 1024;
+
+  private HttpClient httpClient;
+
+  @RegisterExtension
+  public final DefaultKafkaRestTestEnvironment testEnv = new DefaultKafkaRestTestEnvironment(false);
+
+  @BeforeEach
+  public void setUp(TestInfo testInfo) throws Exception {
+    Properties properties = new Properties();
+    // Adding custom KafkaRestConfigs for individual test-cases/test-methods below.
+    if (!testInfo.getDisplayName().contains("ProduceRequestSizeNoLimit")) {
+      properties.put(
+          KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, String.valueOf(LIMIT_SIZE));
+    }
+    testEnv.kafkaRest().startApp(properties);
+    testEnv.kafkaCluster().createTopic(TEST_TOPIC_NAME, 1, (short) 1);
+
+    SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+    sslContextFactory.setSslContext(testEnv.certificates().getSslContext("kafka-rest"));
+    httpClient = new HttpClient(sslContextFactory);
+    httpClient.start();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    httpClient.stop();
+    testEnv.kafkaRest().closeApp();
+  }
+
+  @Test
+  @DisplayName("testStreaming_ProduceRequestSizeNoLimit")
+  public void testStreaming_ProduceRequestSizeNoLimit() throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    URI uri =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TEST_TOPIC_NAME + "/records")
+            .getUri();
+
+    final OutputStreamContentProvider contentProvider = new OutputStreamContentProvider();
+    InputStreamResponseListener responseListener = new InputStreamResponseListener();
+
+    httpClient
+        .POST(uri)
+        .header(HttpHeader.TRANSFER_ENCODING, "chunked")
+        .content(contentProvider, MediaType.APPLICATION_JSON)
+        .send(responseListener); // async request
+
+    httpClient
+        .getExecutor()
+        .execute(
+            () -> {
+              // send data in a separate thread
+              try (OutputStream outputStream = contentProvider.getOutputStream()) {
+                for (int i = 0; i < 5; i++) {
+                  outputStream.write(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8));
+                }
+              } catch (IOException e) {
+                log.error("Error writing to output stream", e);
+              }
+            });
+
+    List<TestProduceResponse> produceResponses = new ArrayList<>();
+    // waiting for response
+    Response response = responseListener.get(1, TimeUnit.MINUTES);
+    if (response.getStatus() == HttpStatus.OK_200) {
+      // Obtain the input stream on the response content
+      try (InputStream input = responseListener.getInputStream()) {
+        // Read the response content as stream
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+        String line;
+        while ((line = reader.readLine()) != null) {
+          produceResponses.add(
+              TEST_RESPONSE_OBJECT_MAPPER.readValue(line, TestProduceResponse.class));
+        }
+      }
+    }
+
+    // 5 requests, therefore, we have 5 responses
+    assertEquals(5, produceResponses.size());
+    for (int i = 0; i < produceResponses.size(); i++) {
+      // all successful
+      assertEquals(HttpStatus.OK_200, produceResponses.get(i).errorCode);
+      assertEquals(i, produceResponses.get(i).offset);
+    }
+  }
+
+  @Test
+  @DisplayName("testStreaming_ProduceRequestSizeWithLimit_withinLimit")
+  public void testStreaming_ProduceRequestSizeWithLimit_withinLimit() throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    URI uri =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TEST_TOPIC_NAME + "/records")
+            .getUri();
+
+    final OutputStreamContentProvider contentProvider = new OutputStreamContentProvider();
+    InputStreamResponseListener responseListener = new InputStreamResponseListener();
+
+    httpClient
+        .POST(uri)
+        .header(HttpHeader.TRANSFER_ENCODING, "chunked")
+        .content(contentProvider, MediaType.APPLICATION_JSON)
+        .send(responseListener); // async request
+
+    httpClient
+        .getExecutor()
+        .execute(
+            () -> {
+              // send data in a separate thread
+              try (OutputStream outputStream = contentProvider.getOutputStream()) {
+                // all the messages are within limit
+                for (int i = 0; i < 10; i++) {
+                  outputStream.write(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8));
+                }
+              } catch (IOException e) {
+                log.error("Error writing to output stream", e);
+              }
+            });
+
+    List<TestProduceResponse> produceResponses = new ArrayList<>();
+    // waiting for response
+    Response response = responseListener.get(1, TimeUnit.MINUTES);
+    if (response.getStatus() == HttpStatus.OK_200) {
+      // Obtain the input stream on the response content
+      try (InputStream input = responseListener.getInputStream()) {
+        // Read the response content as stream
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+        String line;
+        while ((line = reader.readLine()) != null) {
+          produceResponses.add(
+              TEST_RESPONSE_OBJECT_MAPPER.readValue(line, TestProduceResponse.class));
+        }
+      }
+    }
+
+    // 10 requests so we should get 10 responses
+    assertEquals(10, produceResponses.size());
+    for (int i = 0; i < produceResponses.size(); i++) {
+      // all successful
+      assertEquals(HttpStatus.OK_200, produceResponses.get(i).errorCode);
+      assertEquals(i, produceResponses.get(i).offset);
+    }
+  }
+
+  @Test
+  @DisplayName("testStreaming_ProduceRequestSizeWithLimit_violateLimitFirstMessage")
+  public void testStreaming_ProduceRequestSizeWithLimit_violateLimitFirstMessage()
+      throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    URI uri =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TEST_TOPIC_NAME + "/records")
+            .getUri();
+
+    final OutputStreamContentProvider contentProvider = new OutputStreamContentProvider();
+    InputStreamResponseListener responseListener = new InputStreamResponseListener();
+
+    httpClient
+        .POST(uri)
+        .header(HttpHeader.TRANSFER_ENCODING, "chunked")
+        .content(contentProvider, MediaType.APPLICATION_JSON)
+        .send(responseListener); // async request
+
+    httpClient
+        .getExecutor()
+        .execute(
+            () -> {
+              // send data in a separate thread
+              try (OutputStream outputStream = contentProvider.getOutputStream()) {
+                // this is over limit size
+                outputStream.write(
+                    generateData(TEST_DATA_SIZE + 16 * 1024).getBytes(StandardCharsets.UTF_8));
+                // those requests are not sent
+                for (int i = 0; i < 10; i++) {
+                  outputStream.write(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8));
+                }
+              } catch (IOException e) {
+                log.error("Error writing to output stream", e);
+              }
+            });
+
+    List<TestProduceResponse> produceResponses = new ArrayList<>();
+    // waiting for response
+    Response response = responseListener.get(1, TimeUnit.MINUTES);
+    if (response.getStatus() == HttpStatus.OK_200) {
+      // Obtain the input stream on the response content
+      try (InputStream input = responseListener.getInputStream()) {
+        // Read the response content as stream
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+        String line;
+        while ((line = reader.readLine()) != null) {
+          produceResponses.add(
+              TEST_RESPONSE_OBJECT_MAPPER.readValue(line, TestProduceResponse.class));
+        }
+      }
+    }
+
+    // as the first produce request is over the limit, we should have only one response
+    assertEquals(1, produceResponses.size());
+    TestProduceResponse produceResponse = produceResponses.get(0);
+    assertEquals(HttpStatus.BAD_REQUEST_400, produceResponse.errorCode);
+    assertThat(
+        produceResponse.message,
+        containsString("Produce request size is larger than allowed threshold"));
+  }
+
+  @Test
+  @DisplayName("testStreaming_ProduceRequestSizeWithLimit_violateLimitSecondMessage")
+  public void testStreaming_ProduceRequestSizeWithLimit_violateLimitSecondMessage()
+      throws Exception {
+    String clusterId = testEnv.kafkaCluster().getClusterId();
+    URI uri =
+        testEnv
+            .kafkaRest()
+            .target()
+            .path("/v3/clusters/" + clusterId + "/topics/" + TEST_TOPIC_NAME + "/records")
+            .getUri();
+
+    final OutputStreamContentProvider contentProvider = new OutputStreamContentProvider();
+    InputStreamResponseListener responseListener = new InputStreamResponseListener();
+
+    httpClient
+        .POST(uri)
+        .header(HttpHeader.TRANSFER_ENCODING, "chunked")
+        .content(contentProvider, MediaType.APPLICATION_JSON)
+        .send(responseListener); // async request
+
+    httpClient
+        .getExecutor()
+        .execute(
+            () -> {
+              // send data in a separate thread
+              try (OutputStream outputStream = contentProvider.getOutputStream()) {
+                outputStream.write(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8));
+                // this is over limit size
+                outputStream.write(
+                    generateData(TEST_DATA_SIZE + 16 * 1024).getBytes(StandardCharsets.UTF_8));
+                // those requests are not sent
+                for (int i = 0; i < 10; i++) {
+                  outputStream.write(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8));
+                }
+              } catch (IOException e) {
+                log.error("Error writing to output stream", e);
+              }
+            });
+
+    List<TestProduceResponse> produceResponses = new ArrayList<>();
+    // waiting for response
+    Response response = responseListener.get(1, TimeUnit.MINUTES);
+    if (response.getStatus() == HttpStatus.OK_200) {
+      // Obtain the input stream on the response content
+      try (InputStream input = responseListener.getInputStream()) {
+        // Read the response content as stream
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+        String line;
+        while ((line = reader.readLine()) != null) {
+          produceResponses.add(
+              TEST_RESPONSE_OBJECT_MAPPER.readValue(line, TestProduceResponse.class));
+        }
+      }
+    }
+
+    // as the second produce request is over the limit, we should have only two responses
+    assertEquals(2, produceResponses.size());
+    TestProduceResponse response1 = produceResponses.get(0);
+    assertEquals(HttpStatus.OK_200, response1.errorCode);
+    assertEquals(0, response1.offset);
+
+    TestProduceResponse response2 = produceResponses.get(1);
+    assertEquals(HttpStatus.BAD_REQUEST_400, response2.errorCode);
+    assertThat(
+        response2.message, containsString("Produce request size is larger than allowed threshold"));
+  }
+
+  private static String generateData(int size) {
+    String value = TestUtils.generateAlphanumericString(RNG, size);
+    return String.format(TEST_MESSAGE_TEMPLATE, value);
+  }
+
+  /** A class that encapsulates either ErrorResponse or ProduceResponse */
+  private static class TestProduceResponse {
+    @JsonProperty("offset")
+    private long offset = -1L;
+
+    @JsonProperty("error_code")
+    private int errorCode = -1;
+
+    @JsonProperty("message")
+    private String message = "";
+
+    public void setOffset(long offset) {
+      this.offset = offset;
+    }
+
+    public void setErrorCode(int errorCode) {
+      this.errorCode = errorCode;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
+    }
+  }
+}

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/response/JsonStreamTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/response/JsonStreamTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.response;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.confluent.kafkarest.KafkaRestConfig;
+import io.confluent.kafkarest.TestUtils;
+import io.confluent.kafkarest.entities.v3.ProduceRequest;
+import io.confluent.kafkarest.exceptions.ProduceRequestTooLargeException;
+import io.confluent.kafkarest.response.JsonStream.SizeLimitEntityStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+import java.util.Random;
+import java.util.TimeZone;
+import java.util.UUID;
+import javax.ws.rs.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+// CHECKSTYLE:OFF:ClassDataAbstractionCoupling
+class JsonStreamTest {
+  private static final Random RNG = new Random();
+  private static final String TEST_MESSAGE_TEMPLATE =
+      "{ " + "\"value\" : { " + "\"type\" : \"JSON\", " + "\"data\" : \"%s\" " + "}}";
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper()
+          .registerModule(new GuavaModule())
+          .registerModule(new Jdk8Module())
+          .registerModule(new JavaTimeModule())
+          .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+          .setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"))
+          .setTimeZone(TimeZone.getTimeZone("UTC"));
+  private static final int TEST_DATA_SIZE = 1024 * 1024;
+
+  @Test
+  public void testReadOneProduceRequest_NoLimit() throws Exception {
+    Properties properties = new Properties();
+    properties.put(KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, "0");
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    File tempFile = createTempFile(UUID.randomUUID().toString());
+    // Use FileOutputStream and FileInputStream on the same file to simulate
+    // writing from clients and reading in server
+    try (FileOutputStream fos = new FileOutputStream(tempFile);
+        FileInputStream fis = new FileInputStream(tempFile);
+        JsonStream<ProduceRequest> jsonStream = createJsonStream(fis, config); ) {
+      FileChannel outputChannel = fos.getChannel();
+      // write a produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has one ProduceRequest");
+      assertTrue(
+          jsonStream.nextValue().getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+      assertFalse(jsonStream.hasNext(), "No more ProduceRequest");
+    }
+  }
+
+  @Test
+  public void testReadOneProduceRequest_WithinLimit() throws Exception {
+    final long sizeLimit = TEST_DATA_SIZE + 8 * 1024;
+    Properties properties = new Properties();
+    properties.put(
+        KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, String.valueOf(sizeLimit));
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    File tempFile = createTempFile(UUID.randomUUID().toString());
+    // Use FileOutputStream and FileInputStream on the same file to simulate
+    // writing from clients and reading in server
+    try (FileOutputStream fos = new FileOutputStream(tempFile);
+        FileInputStream fis = new FileInputStream(tempFile);
+        JsonStream<ProduceRequest> jsonStream = createJsonStream(fis, config); ) {
+      FileChannel outputChannel = fos.getChannel();
+      // write a produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has one ProduceRequest");
+      ProduceRequest produceRequest = jsonStream.nextValue();
+      assertTrue(
+          produceRequest.getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+      assertTrue(
+          produceRequest.getOriginalSize() < sizeLimit,
+          "Produce request is smaller than size limit");
+      assertFalse(jsonStream.hasNext(), "No more ProduceRequest");
+    }
+  }
+
+  @Test
+  public void testReadOneProduceRequest_BeyondLimit() throws Exception {
+    final long sizeLimit = 8 * 1024;
+    Properties properties = new Properties();
+    properties.put(
+        KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, String.valueOf(sizeLimit));
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    File tempFile = createTempFile(UUID.randomUUID().toString());
+    // Use FileOutputStream and FileInputStream on the same file to simulate
+    // writing from clients and reading in server
+    try (FileOutputStream fos = new FileOutputStream(tempFile);
+        FileInputStream fis = new FileInputStream(tempFile);
+        JsonStream<ProduceRequest> jsonStream = createJsonStream(fis, config); ) {
+      FileChannel outputChannel = fos.getChannel();
+      // write a produce request message that is bigger than limit
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has one ProduceRequest");
+      Exception exception = assertThrows(JsonMappingException.class, jsonStream::nextValue);
+      assertTrue(exception.getCause() instanceof ProduceRequestTooLargeException);
+    }
+  }
+
+  @Test
+  public void testStreamingProduceRequest_NoLimit() throws Exception {
+    Properties properties = new Properties();
+    properties.put(KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, "0");
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    File tempFile = createTempFile(UUID.randomUUID().toString());
+    // Use FileOutputStream and FileInputStream on the same file to simulate
+    // writing from clients and reading in server
+    try (FileOutputStream fos = new FileOutputStream(tempFile);
+        FileInputStream fis = new FileInputStream(tempFile);
+        JsonStream<ProduceRequest> jsonStream = createJsonStream(fis, config); ) {
+      FileChannel outputChannel = fos.getChannel();
+      // write a produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has one ProduceRequest");
+      assertTrue(
+          jsonStream.nextValue().getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+
+      // write another produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has another ProduceRequest");
+      assertTrue(
+          jsonStream.nextValue().getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+      assertFalse(jsonStream.hasNext(), "No more ProduceRequest");
+    }
+  }
+
+  @Test
+  public void testStreamingProduceRequest_WithinLimit() throws Exception {
+    final long sizeLimit = TEST_DATA_SIZE + 8 * 1024;
+    Properties properties = new Properties();
+    properties.put(
+        KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, String.valueOf(sizeLimit));
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    File tempFile = createTempFile(UUID.randomUUID().toString());
+    // Use FileOutputStream and FileInputStream on the same file to simulate
+    // writing from clients and reading in server
+    try (FileOutputStream fos = new FileOutputStream(tempFile);
+        FileInputStream fis = new FileInputStream(tempFile);
+        JsonStream<ProduceRequest> jsonStream = createJsonStream(fis, config); ) {
+      FileChannel outputChannel = fos.getChannel();
+      // write a produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has one ProduceRequest");
+      ProduceRequest produceRequest = jsonStream.nextValue();
+      assertTrue(
+          produceRequest.getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+      assertTrue(
+          produceRequest.getOriginalSize() < sizeLimit,
+          "Produce request is smaller than size limit");
+
+      // write another produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has another ProduceRequest");
+      produceRequest = jsonStream.nextValue();
+      assertTrue(
+          produceRequest.getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+      assertTrue(
+          produceRequest.getOriginalSize() < sizeLimit,
+          "Produce request is smaller than size limit");
+      assertFalse(jsonStream.hasNext(), "No more ProduceRequest");
+    }
+  }
+
+  @Test
+  public void testStreamingProduceRequest_BeyondLimitSecondMessage() throws Exception {
+    final long sizeLimit = TEST_DATA_SIZE + 8 * 1024;
+    Properties properties = new Properties();
+    properties.put(
+        KafkaRestConfig.PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG, String.valueOf(sizeLimit));
+    KafkaRestConfig config = new KafkaRestConfig(properties);
+
+    File tempFile = createTempFile(UUID.randomUUID().toString());
+    // Use FileOutputStream and FileInputStream on the same file to simulate
+    // writing from clients and reading in server
+    try (FileOutputStream fos = new FileOutputStream(tempFile);
+        FileInputStream fis = new FileInputStream(tempFile);
+        JsonStream<ProduceRequest> jsonStream = createJsonStream(fis, config); ) {
+      FileChannel outputChannel = fos.getChannel();
+      // write a produce request message
+      outputChannel.write(
+          ByteBuffer.wrap(generateData(TEST_DATA_SIZE).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has one ProduceRequest");
+      ProduceRequest produceRequest = jsonStream.nextValue();
+      assertTrue(
+          produceRequest.getOriginalSize() > TEST_DATA_SIZE,
+          "Produce request is larger than data size");
+      assertTrue(
+          produceRequest.getOriginalSize() < sizeLimit,
+          "Produce request is smaller than size limit");
+      // write another produce request message that is bigger than limit
+      outputChannel.write(
+          ByteBuffer.wrap(
+              generateData(TEST_DATA_SIZE + 16 * 1024).getBytes(StandardCharsets.UTF_8)));
+      assertTrue(jsonStream.hasNext(), "Has second ProduceRequest");
+      Exception exception = assertThrows(JsonMappingException.class, jsonStream::nextValue);
+      assertTrue(exception.getCause() instanceof ProduceRequestTooLargeException);
+    }
+  }
+
+  // this function mimics the creation of JsonStream in JsonStreamMessageBodyReader.readFrom
+  // function
+  private static JsonStream<ProduceRequest> createJsonStream(
+      InputStream entityStream, KafkaRestConfig config) {
+    JavaType wrappedType = OBJECT_MAPPER.constructType(ProduceRequest.class);
+    SizeLimitEntityStream wrappedInputStream =
+        (config.getProduceRequestSizeLimitMaxBytesConfig() > 0)
+            ? new SizeLimitEntityStream(
+                entityStream, config.getProduceRequestSizeLimitMaxBytesConfig())
+            : null;
+    return new JsonStream<>(
+        () -> {
+          try {
+            JsonParser parser =
+                OBJECT_MAPPER.createParser(
+                    wrappedInputStream == null ? entityStream : wrappedInputStream);
+            return OBJECT_MAPPER.readValues(parser, wrappedType);
+          } catch (IOException e) {
+            throw new BadRequestException("Unexpected error while starting JSON stream: ", e);
+          }
+        },
+        wrappedInputStream);
+  }
+
+  private static String generateData(int size) {
+    String value = TestUtils.generateAlphanumericString(RNG, size);
+    return String.format(TEST_MESSAGE_TEMPLATE, value);
+  }
+
+  private static File createTempFile(String prefix) throws IOException {
+    final File tempFile = File.createTempFile(prefix, ".jsonl");
+    tempFile.deleteOnExit();
+    return tempFile;
+  }
+}
+// CHECKSTYLE:ON:ClassDataAbstractionCoupling


### PR DESCRIPTION
As part of OOM prevention, we should be able to stop the streaming/non-streaming produce connection if the produce request being parsed is too large. 

The current implementation allows such big requests coming through in JsonStream and it might be too late when it is successfully parsed, because the rate limit phase only comes after. For example, user can send 2GiB produce request to REST and when it is parsing the message, assuming Jackson needs the same space to parse, then it is already over 4GiB in memory at some point.

This PR introduces a wrapper for InputStream (`SizeLimitEntityStream`) that is being used in JsonStream so that we are able to keep track of how many bytes have been read when parsing a ProduceRequest, and when the number of bytes exceed a certain threshold (configurable by `api.v3.produce.request.size.limit.max.byte` in KafkaRestConfig), we drop the connection.
`SizeLimitEntityStream` instance must be used in JsonStream because only this class can be aware of the boundary of parsed ProduceRequest.

Reference JIRA https://confluentinc.atlassian.net/browse/KREST-11220

This is part of OOM work that listed in [the epic](https://confluentinc.atlassian.net/browse/KREST-11042) description
