### PR TITLE
Add 413 response error for produce v3 api

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1437,6 +1437,8 @@ paths:
           $ref: '#/components/responses/ForbiddenErrorResponse'
         '404':
           $ref: '#/components/responses/NotFoundErrorResponse'
+        '413':
+          $ref: '#/components/responses/RequestEntityTooLargeErrorResponse'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeErrorResponse'
         '422':
@@ -4492,6 +4494,20 @@ components:
                             </table>
                         </body>
                     </html>'
+
+    RequestEntityTooLargeErrorResponse:
+      description: 'This implies client is sending the request payload that is larger than the max message size the
+        server will accept.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            produce_records_expects_json:
+              description: "Thrown by /records API if payload size exceeds the message max size"
+              value:
+                error_code: 413
+                message:  "The request included a message larger than the max message size the server will accept."
 
     UnsupportedMediaTypeErrorResponse:
       description: 'This implies client is sending the request payload format in an supported format.'

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -4496,8 +4496,8 @@ components:
                     </html>'
 
     RequestEntityTooLargeErrorResponse:
-      description: 'This implies client is sending the request payload that is larger than the max message size the
-        server will accept.'
+      description: 'This implies the client is sending a request payload that is larger than the maximum message size the
+        server can accept.'
       content:
         application/json:
           schema:
@@ -4507,10 +4507,10 @@ components:
               description: "Thrown by /records API if payload size exceeds the message max size"
               value:
                 error_code: 413
-                message:  "The request included a message larger than the max message size the server will accept."
+                message:  "The request included a message larger than the maximum message size the server can accept."
 
     UnsupportedMediaTypeErrorResponse:
-      description: 'This implies client is sending the request payload format in an supported format.'
+      description: 'This implies the client is sending the request payload format in an unsupported format.'
       content:
         application/json:
           schema:


### PR DESCRIPTION
Follow up the PR https://github.com/confluentinc/rest-utils/pull/411, this is to update API doc for produce records v3 API in kafka-rest