### PR TITLE
DGS-9099 Enable Data Contract rules in Kafka REST Proxy

### DIFF
--- a/bin/kafka-rest-run-class
+++ b/bin/kafka-rest-run-class
@@ -22,7 +22,7 @@ for dir in $base_dir/kafka-rest/target/kafka-rest-*-development; do
 done
 
 # Production jars
-for library in "confluent-security/kafka-rest" "confluent-common" "confluent-telemetry" "rest-utils" "kafka-rest-bin" "kafka-rest-lib" "monitoring-interceptors"; do
+for library in "confluent-security/kafka-rest" "confluent-common" "confluent-telemetry" "rest-utils" "kafka-rest-bin" "kafka-rest-lib" "kafka-serde-tools" "monitoring-interceptors"; do
   CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*
 done
 


### PR DESCRIPTION
This small change to the startup class allows the jars for the Data Contract rules to be included in the classpath for the Kafka REST Proxy

The kafka-serde-tools subdir includes the client-side jars for the data quality rules and client-side field-level encryption.