### PR TITLE
KREST-12630 Add missing dependency due to zookeeper upgrade

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -134,6 +134,11 @@
             <artifactId>easymock</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>4.2.22</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>4.2.22</version>
+                <version>4.1.12.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Zookeeper dependency is updated in https://github.com/confluentinc/ce-kafka/pull/11994, which now requires extra dependency for running tests.