### PR TITLE
Remove confluent-cloud-plugins and confluent-security-plugins as downstream in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 #!/usr/bin/env groovy
 common {
   slackChannel = '#kafka-rest-warn'
-  downStreamRepos = ["confluent-security-plugins", "ce-kafka-rest",
-    "confluent-cloud-plugins"]
+  downStreamRepos = ["ce-kafka-rest"]
   nanoVersion = true
   mvnSkipDeploy = true
 }


### PR DESCRIPTION
This PR removes the confluent-cloud-plugins and confluent-security-plugins repos as downstream repos in Jenkinsfile file (leaving them as downstream repos in service.yml/Semaphore). This change allows confluent-cloud-plugins and confluent-security-plugins to deprecate Jenkins without causing this repos downstream build to fail. A similar change to was made here: https://github.com/confluentinc/rest-utils/pull/443 to remove schema-registry from the Jenkinsfile.