### PR TITLE
KREST-2300 Deflake KafkaConsumerManagerTest.testBackoffMsControlsPollCalls test

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -367,19 +367,16 @@ public class KafkaConsumerManager {
 
   class RunnableReadTask implements Runnable, Delayed {
     private final ReadTaskState taskState;
-    private final Instant started;
     private final Instant requestExpiration;
     private final Duration backoff;
     // Expiration if this task is waiting, considering both the expiration of the whole task and
     // a single backoff, if one is in progress
     private Instant waitExpiration;
-    private final Clock clock = Clock.systemUTC();
 
     public RunnableReadTask(ReadTaskState taskState, KafkaRestConfig config) {
       this.taskState = taskState;
-      this.started = clock.instant();
       this.requestExpiration =
-          this.started.plus(
+          clock.instant().plus(
               Duration.ofMillis(config.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG)));
       this.backoff =
           Duration.ofMillis(config.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG));
@@ -390,7 +387,10 @@ public class KafkaConsumerManager {
      * Delays for a minimum of {@code delayMs} or until the read request expires
      */
     public void delayFor(Duration delay) {
-      if (!requestExpiration.isAfter(clock.instant())) {
+      // the first condition means that the request has expired,
+      // the second one means that the request has been retried for
+      // the last time, so if it goes to this block again, it will be expired
+      if (!requestExpiration.isAfter(clock.instant()) || requestExpiration.equals(waitExpiration)) {
         // no need to delay if the request has expired
         taskState.task.finish();
         log.trace("Finished executing  consumer read task ({}) due to request expiry",

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -432,7 +432,9 @@ public class KafkaConsumerManager {
 
     @Override
     public long getDelay(TimeUnit unit) {
-      Duration delay = Duration.between(clock.instant(), waitExpiration);
+      // Note that, Duration.between excludes the end instant,
+      // so we need to add 1 millisecond so that the task will be run at the desire time
+      Duration delay = Duration.between(clock.instant(), waitExpiration.plusMillis(1));
       return unit.convert(delay.toMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -32,7 +32,6 @@ import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.kafkarest.entities.v2.ConsumerOffsetCommitRequest;
 import io.confluent.kafkarest.entities.v2.ConsumerSubscriptionRecord;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -397,12 +396,11 @@ public class KafkaConsumerManagerTest {
     setUpConsumer(props);
     bootstrapConsumer(consumer);
     CopyOnWriteArrayList<Long> pollTimestampsMillis = new CopyOnWriteArrayList<>();
-    Clock clock = Clock.systemUTC();
     consumer.schedulePollTask(
         new Runnable() {
           @Override
           public void run() {
-            pollTimestampsMillis.add(clock.millis());
+            pollTimestampsMillis.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()));
             consumer.schedulePollTask(this);
           }
         });

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -31,6 +31,8 @@ import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.kafkarest.entities.v2.ConsumerOffsetCommitRequest;
 import io.confluent.kafkarest.entities.v2.ConsumerSubscriptionRecord;
+
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -395,11 +397,12 @@ public class KafkaConsumerManagerTest {
     setUpConsumer(props);
     bootstrapConsumer(consumer);
     CopyOnWriteArrayList<Long> pollTimestampsMillis = new CopyOnWriteArrayList<>();
+    Clock clock = Clock.systemUTC();
     consumer.schedulePollTask(
         new Runnable() {
           @Override
           public void run() {
-            pollTimestampsMillis.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()));
+            pollTimestampsMillis.add(clock.millis());
             consumer.schedulePollTask(this);
           }
         });

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -47,29 +47,12 @@ import org.apache.kafka.common.TopicPartition;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
-import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import io.confluent.kafkarest.KafkaRestConfig;
-import io.confluent.kafkarest.entities.v2.BinaryConsumerRecord;
-import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
-import io.confluent.kafkarest.entities.EmbeddedFormat;
-import io.confluent.kafkarest.entities.TopicPartitionOffset;
-import io.confluent.rest.RestConfigException;
 import org.junit.runner.RunWith;
 
 /**

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -385,7 +385,6 @@ public class KafkaConsumerManagerTest {
         consumerManager.deleteConsumer(groupName, consumer.cid());
     }
 
-  @Ignore
   @Test
   public void testBackoffMsControlsPollCalls() throws Exception {
     long timeoutMillis = 5000L;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/MockConsumer.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/MockConsumer.java
@@ -52,7 +52,7 @@ public class MockConsumer<K, V> extends org.apache.kafka.clients.consumer.MockCo
         SortedSet<OffsetAndTimestamp> offsets =
             offsetForTimes.computeIfAbsent(
                 new TopicPartition(topic, partition),
-                key -> new TreeSet<>(Comparator.comparing(OffsetAndTimestamp::timestamp)));
+                key -> createSortedSetOfOffsetAndTimestamps());
         offsets.add(new OffsetAndTimestamp(offset, timestamp.toEpochMilli()));
     }
 
@@ -62,7 +62,7 @@ public class MockConsumer<K, V> extends org.apache.kafka.clients.consumer.MockCo
         Map<TopicPartition, OffsetAndTimestamp> result = new HashMap<>();
         for (Entry<TopicPartition, Long> entry : timestampsToSearch.entrySet()) {
             SortedSet<OffsetAndTimestamp> offsets =
-                offsetForTimes.getOrDefault(entry.getKey(), new TreeSet<>());
+                offsetForTimes.getOrDefault(entry.getKey(), createSortedSetOfOffsetAndTimestamps());
             SortedSet<OffsetAndTimestamp> tail =
                 offsets.tailSet(new OffsetAndTimestamp(0L, entry.getValue()));
             if (tail.isEmpty()) {
@@ -72,5 +72,9 @@ public class MockConsumer<K, V> extends org.apache.kafka.clients.consumer.MockCo
             }
         }
         return unmodifiableMap(result);
+    }
+
+    private static SortedSet<OffsetAndTimestamp> createSortedSetOfOffsetAndTimestamps() {
+        return new TreeSet<>(Comparator.comparing(OffsetAndTimestamp::timestamp));
     }
 }


### PR DESCRIPTION
This PR fixes the logic in `KafkaConsumerManager` class in the way it handles consumer backoff for readRecords

The approach that KafkaConsumerManager uses to execute backoff RunnableReadTask is:
- Each task has a fix backoff (in millis) and timeout (in millis)
- The [first run](https://github.com/confluentinc/kafka-rest/blob/6ad01a571a106f539cbfc8ed84ea900db3f367b0/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L336) is submitted in readRecords(...) function
- If the task is not done, then then task is [resubmitted into a DelayQueue](https://github.com/confluentinc/kafka-rest/blob/6ad01a571a106f539cbfc8ed84ea900db3f367b0/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L403) with [new calculated time to be executed](https://github.com/confluentinc/kafka-rest/blob/6ad01a571a106f539cbfc8ed84ea900db3f367b0/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L402)
- The DelayQueue is [polled](https://github.com/confluentinc/kafka-rest/blob/23130bbaa8b61e09c89559d68eb93723ba07067d/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L717) to get the task to be executed based on getDelay of the task.
- And so on until the timeout of the task has reach (timeout)


However, the implementation has flaws:
- First, it is in the [getDelay calculation](https://github.com/confluentinc/kafka-rest/blob/23130bbaa8b61e09c89559d68eb93723ba07067d/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L435), we want the task to be executed on `waitExpiration` instant, however Duration.between exclude the end instant, therefore, the task might be executed 1 millisecond earlier than expected
- Second, it is in the logic of calculating [the next time to be executed](https://github.com/confluentinc/kafka-rest/blob/23130bbaa8b61e09c89559d68eb93723ba07067d/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java#L402), basically, at the last retries, the value will always be set to requestExpiration. 

Combining the two flaws above, we can now explain why the test is flaky (to be fair, the test is correct, it is implementation's issue)
- On the last retry of the task, waitExpiration set to requestExpiration, due to the first flaw, the task would be executed 1 millisecond early.
- This task would do the polling, and other steps, as there is nothing to read, the task would finish those steps very quick (in less than 1 millisecond), and due to the second flaw, it would then be executed in the exact millisecond that the previous one ran. You can now notice the cycle will continue until that exact millisecond passes. 
- Hence, that is why we will get many retries at the last retry.

This PR fixes the above flaws by ensuring that:
- the task will be executed in the right time for the first flaw
- and it checks for the last retry condition for the second flaw


