### PR TITLE
KREST-NNN disable flakey test

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -70,7 +70,6 @@ import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.rest.RestConfigException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.runner.RunWith;
 
 /**

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -70,6 +70,7 @@ import io.confluent.kafkarest.entities.ConsumerInstanceConfig;
 import io.confluent.kafkarest.entities.EmbeddedFormat;
 import io.confluent.kafkarest.entities.TopicPartitionOffset;
 import io.confluent.rest.RestConfigException;
+import org.junit.jupiter.api.Disabled;
 import org.junit.runner.RunWith;
 
 /**
@@ -401,6 +402,7 @@ public class KafkaConsumerManagerTest {
         consumerManager.deleteConsumer(groupName, consumer.cid());
     }
 
+  @Ignore
   @Test
   public void testBackoffMsControlsPollCalls() throws Exception {
     long timeoutMillis = 5000L;


### PR DESCRIPTION
See https://confluent.slack.com/archives/C06CFQNK2BF/p1704845102888579 for details.  This test continues to flake, and is disabled in master.  Matching that behaviour back in the 6.2.x branch