### PR TITLE
KNET-13992 Fix java.lang.ClassNotFoundException: org.xerial.snappy.SnappyInputStream

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -178,6 +178,11 @@
             <artifactId>jersey-apache-connector</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@
                 <artifactId>metrics-core</artifactId>
                 <version>4.1.12.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
As title said. Add snappy-java test dependency to fix the error of ClassNotFoundException