### PR TITLE
Allow to set KafkaAvroSerializerConfig in KafkaRestConfig (#1229)

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -32,6 +32,7 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.confluent.kafka.serializers.KafkaJsonSerializerConfig;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
@@ -45,6 +46,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -984,7 +987,14 @@ public class KafkaRestConfig extends RestConfig {
   }
 
   public final Map<String, Object> getAvroSerializerConfigs() {
-    Set<String> mask = AbstractKafkaSchemaSerDeConfig.baseConfigDef().names();
+    Set<String> mask = new HashSet<>();
+    mask.addAll(AbstractKafkaSchemaSerDeConfig.baseConfigDef().names());
+    mask.addAll(
+        // these configs are specific to KafkaAvroSerializerConfig
+        ImmutableSet.of(
+            KafkaAvroSerializerConfig.AVRO_REFLECTION_ALLOW_NULL_CONFIG,
+            KafkaAvroSerializerConfig.AVRO_USE_LOGICAL_TYPE_CONVERTERS_CONFIG,
+            KafkaAvroSerializerConfig.AVRO_REMOVE_JAVA_PROPS_CONFIG));
     HashMap<String, Object> configs =
         new HashMap<>(
             new ConfigsBuilder(mask).addConfigs("client.").addConfigs("producer.").build());

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -47,7 +47,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -256,13 +256,16 @@ public class KafkaRestConfigTest {
     Properties properties = new Properties();
     properties.put("schema.registry.url", "foobar");
     properties.put("producer.acks", 1);
+    // this is one of specific avro configs, added by stripping "producer." prefix
+    properties.put("producer.avro.use.logical.type.converters", true);
     KafkaRestConfig config = new KafkaRestConfig(properties);
 
     assertEquals(
         ImmutableMap.of(
             "schema.registry.url", "foobar",
             "auto.register.schemas", false,
-            "use.latest.version", false),
+            "use.latest.version", false,
+            "avro.use.logical.type.converters", true),
         config.getAvroSerializerConfigs());
   }
 


### PR DESCRIPTION
Cherry-picking to ensure avro serializer is more configurable. 
This is ` avro.use.logical.type.converters` config so that we are able to serialize logical type in avro message.