### PR TITLE
Bump rest-utils deps, update project version

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-rest-parent</artifactId>
-        <version>7.7.0-435</version>
+        <version>7.7.0-478</version>
     </parent>
 
     <artifactId>kafka-rest</artifactId>
@@ -20,7 +20,7 @@
     </description>
 
     <properties>
-        <io.confluent.schema-registry.version>7.7.0-375</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.7.0-423</io.confluent.schema-registry.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>7.7.0-369</version>
+        <version>7.7.0-422</version>
     </parent>
 
     <artifactId>kafka-rest-parent</artifactId>
     <packaging>pom</packaging>
     <name>kafka-rest-parent</name>
-    <version>7.7.0-435</version>
+    <version>7.7.0-478</version>
     <organization>
         <name>Confluent, Inc.</name>
         <url>http://confluent.io</url>
@@ -48,7 +48,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
-        <io.confluent.kafka-rest.version>7.7.0-435</io.confluent.kafka-rest.version>
+        <io.confluent.kafka-rest.version>7.7.0-478</io.confluent.kafka-rest.version>
         <!-- Allow enough heap space for integration tests with both Kraft and Zookeeper -->
         <argLine>-Xmx4g -Xms2g</argLine>
     </properties>


### PR DESCRIPTION
We need a more recent rest-utils for this build. This is based on 06b5d8854.