### PR TITLE
Retire Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,0 @@
-#!/usr/bin/env groovy
-common {
-  slackChannel = '#kafka-rest-warn'
-  downStreamRepos = ["ce-kafka-rest"]
-  nanoVersion = true
-  mavenProfiles = ''
-  mvnSkipDeploy = true
-}


### PR DESCRIPTION
As in [announcement](https://confluent.slack.com/archives/C06N5PM0W0G/p1709590990771839), we migrate this repo off Jenkins