### PR TITLE
Retire Jenkins CI for release branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/env groovy
-common {
-  slackChannel = '#kafka-rest-warn'
-  downStreamRepos = ["ce-kafka-rest"]
-  nanoVersion = true
-  mvnSkipDeploy = true
-}


### PR DESCRIPTION
As in [announcement](https://confluent.slack.com/archives/C06N5PM0W0G/p1709590990771839), we migrate this repo off Jenkins, this is for release branches