### PR TITLE
Upscale Semaphore CI instance to avoid occasionally crash

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu20-04-amd64-2
 
 fail_fast:
   cancel:

--- a/service.yml
+++ b/service.yml
@@ -8,6 +8,8 @@ semaphore:
   pipeline_type: cp
   nano_version: true
   downstream_projects: ["confluent-security-plugins", "ce-kafka-rest", "confluent-cloud-plugins"]
+  # kafka-rest has many tests, so we need to run on a bigger machine
+  machine_type: s1-prod-ubuntu20-04-amd64-2
 git:
   enable: true
 code_artifact:


### PR DESCRIPTION
Update semaphore instance to a bigger machine type to avoid occasionally crashes in nightly builds.