### PR TITLE
KNET-14854 Fix for ZkConnectProp that is moved in https://github.com/apache/kafka/pull/15075

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -38,7 +38,6 @@ import java.util.Properties;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import kafka.security.authorizer.AclAuthorizer;
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -115,7 +114,7 @@ public class AuthorizationErrorTest
             1,
             (short) 1,
             false);
-    brokerProps.put(KafkaConfig.BrokerIdProp(), Integer.toString(i));
+    brokerProps.put("broker.id", Integer.toString(i));
     brokerProps.put(ZOOKEEPER_CONNECT_CONFIG, zkConnect);
     brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafkarest.integration;
 
+import static io.confluent.kafkarest.KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG;
 import static io.confluent.kafkarest.TestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME;
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
@@ -115,7 +116,7 @@ public class AuthorizationErrorTest
             (short) 1,
             false);
     brokerProps.put(KafkaConfig.BrokerIdProp(), Integer.toString(i));
-    brokerProps.put(KafkaConfig.ZkConnectProp(), zkConnect);
+    brokerProps.put(ZOOKEEPER_CONNECT_CONFIG, zkConnect);
     brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");
     brokerProps.setProperty(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/QuorumControllerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/QuorumControllerFixture.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import kafka.server.KafkaConfig;
 import kafka.server.QuorumTestHarness;
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.junit.jupiter.api.TestInfo;
@@ -54,7 +53,7 @@ public final class QuorumControllerFixture extends QuorumTestHarness
   @Override
   public Seq<Properties> kraftControllerConfigs() {
     Properties props = new Properties();
-    props.put(KafkaConfig.AuthorizerClassNameProp(), StandardAuthorizer.class.getName());
+    props.put("authorizer.class.name", StandardAuthorizer.class.getName());
     // this setting allows brokers to register to Kraft controller
     props.put(StandardAuthorizer.ALLOW_EVERYONE_IF_NO_ACL_IS_FOUND_CONFIG, true);
     return JavaConverters.asScalaBuffer(Collections.singletonList(props));


### PR DESCRIPTION
ZkConnectProp is internal to server KafkaConfig, moving it to our public constant.