### PR TITLE
KNET-14986: Uncaught exception while closing input stream is causing …

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/response/StreamingResponse.java
@@ -255,7 +255,11 @@ public abstract class StreamingResponse<T> {
       try {
         inputStream.close();
       } catch (IOException e) {
-        log.error("Error when closing the request stream.", e);
+        log.error("Error when closing the request stream", e);
+      } catch (BadRequestException e) {
+        log.error("Error when closing the request stream", e.getCause() != null ? e.getCause() : e);
+      } catch (Throwable e) {
+        log.error("Unknown error when closing the request stream.", e);
       }
     }
 


### PR DESCRIPTION
…clean up failures.

InpuStream close just handles the IOException. But when the there are unused streams Jersey throws BadRequestException instead of IOException. This uncaught exception disrupts the outbound response closure leaving the producer thread behind.