### PR TITLE
Modify codeowners for kafka-rest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @confluentinc/kafka-rest-eng
+* @confluentinc/kafka-rest-eng @confluentinc/kora-networking


### PR DESCRIPTION
Adding @confluentinc/kora-networking team as codeowners