### PR TITLE
CPBR-1311: Removing /tmp/confluent as the DSTDIR check in Makefile

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -71,8 +71,6 @@ INSTALL=install -D -m 644
 INSTALL_X=install -D -m 755
 
 install: build
-	# Safety precatuion to avoid removing of root dir when DESTDIR or PREFIX is not set, for wathever reason
-	if [[ $(DESTDIR)$(PREFIX) != /tmp/confluent/* ]]; then echo "DESTDIR=$(DESTDIR) or PREFIX=$(PREFIX) is weird" ; exit 1 ; fi
 	rm -rf $(DESTDIR)$(PREFIX)
 	mkdir -p $(DESTDIR)$(PREFIX)
 	mkdir -p $(DESTDIR)$(BINPATH)


### PR DESCRIPTION
We are using different directory structure in SemaphoreCI in [packaging](https://github.com/confluentinc/packaging) repo and this leads to failure when building deb because of the check that is present in Makefile. This check is being removed as part of this PR.