### PR TITLE
KNET-15501 work around jackson databind string length limit

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -243,7 +243,8 @@ public class KafkaRestConfig extends RestConfig {
           + "Due to the produce request size counting algorithm's limitation, it is recommended "
           + "to add 8192 (8KiB) buffer to the intended number that you want to set for the limit "
           + "to avoid rejecting legitimate produce requests."
-          + "If this limit is set to a non-positive number, no limit is applied. Default is 0.";
+          + "If this limit is set to 0 or a negative number, no limit is applied. Default is "
+          + "0.";
   public static final String PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_DEFAULT = "0";
   public static final ConfigDef.Range PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_VALIDATOR =
       ConfigDef.Range.atLeast(0);


### PR DESCRIPTION
Implement the change from https://github.com/FasterXML/jackson-core/issues/1001#issuecomment-1527216221

I'm using maxint for the value, as we do length checks of the stream elsewhere, and this seems safest to avoid a regression (see the code comment for more details)