### PR TITLE
Pin kafka version to 7.8.0-100122-ccs to fix SystemTime cannot be accessed from outside package

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
-            <version>${kafka.version}</version>
+            <version>7.8.0-100122-ccs</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
+            <version>7.8.0-100122-ccs</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -119,21 +119,21 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
-            <version>${kafka.version}</version>
+            <version>7.8.0-100122-ccs</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
+            <version>7.8.0-100122-ccs</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-server-common</artifactId>
-            <version>${kafka.version}</version>
+            <version>7.8.0-100122-ccs</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
org.apache.kafka.common.utils.SystemTime qualifier has been changed from public to default https://github.com/apache/kafka/pull/16266 . This is causing compilation failure for `io/confluent/kafkarest/SystemTime.java` . We will pin 7.8.0-100122-ccs as kafka-clients version so that we don't hit the compilation failure and unblock the release.
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.0:compile (default-compile) on project kafka-rest: Compilation failure
[ERROR] /home/semaphore/ce-kafka-images/.src/kafka-rest/kafka-rest/src/main/java/io/confluent/kafkarest/SystemTime.java:[21,62] org.apache.kafka.common.utils.SystemTime is not public in org.apache.kafka.common.utils; cannot be accessed from outside package
```

discussion : https://confluent.slack.com/archives/CM6PEBEGM/p1718345803878219?thread_ts=1718271424.003559&cid=CM6PEBEGM