### PR TITLE
Fix SystemTime and revert pin ak version

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
-            <version>7.8.0-100122-ccs</version>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>7.8.0-100122-ccs</version>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -119,21 +119,21 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
-            <version>7.8.0-100122-ccs</version>
+            <version>${kafka.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>7.8.0-100122-ccs</version>
+            <version>${kafka.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-server-common</artifactId>
-            <version>7.8.0-100122-ccs</version>
+            <version>${kafka.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/SystemTime.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/SystemTime.java
@@ -15,10 +15,30 @@
 
 package io.confluent.kafkarest;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.function.Supplier;
 
-@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
-public class SystemTime extends org.apache.kafka.common.utils.SystemTime implements Time {
+public class SystemTime implements Time {
+  private final org.apache.kafka.common.utils.Time delegate = Time.SYSTEM;
+
+  @Override
+  public long milliseconds() {
+    return delegate.milliseconds();
+  }
+
+  @Override
+  public long nanoseconds() {
+    return delegate.nanoseconds();
+  }
+
+  @Override
+  public void sleep(long ms) {
+    delegate.sleep(ms);
+  }
+
+  @Override
+  public void waitObject(Object o, Supplier<Boolean> supplier, long l) throws InterruptedException {
+    delegate.waitObject(o, supplier, l);
+  }
 
   @Override
   public void waitOn(Object on, long ms) throws InterruptedException {


### PR DESCRIPTION
SystemTime is using a class that is now package private, so using delegate to fix that.

And using kafka nano version so that it will load with the latest ak build that fix _ issue.