### PR TITLE
Make KafkaRestContext consistent wrt Producer & Consumer 

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestContext.java
@@ -15,9 +15,11 @@
 
 package io.confluent.kafkarest;
 
+import java.util.Properties;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafkarest.v2.KafkaConsumerManager;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 
 public interface KafkaRestContext {
@@ -32,6 +34,10 @@ public interface KafkaRestContext {
 
   default SchemaRegistryClient getSchemaRegistryClient() {
     return null;
+  }
+
+  default Consumer<byte[], byte[]> getConsumer(Properties properties) {
+    throw new UnsupportedOperationException();
   }
 
   void shutdown();


### PR DESCRIPTION
This PR adds `getConsumer()` method in KafkaRestContext which makes it consistent wrt Producer & Consumer.

Adding `getConsumer()` method will help in fetching the consumer if it is needed from any of the implementations of KafaRestContext.

By default consumer is not expected from some of the implementations of KafkaRestContext so for such cases we just throw `UnsupportedOperationException`