### PR TITLE
Implement getConsumer in DefaultKafkaRestContext

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/DefaultKafkaRestContext.java
@@ -24,9 +24,12 @@ import io.confluent.kafkarest.config.SchemaRegistryConfig;
 import io.confluent.kafkarest.v2.KafkaConsumerManager;
 import java.net.URI;
 import java.util.List;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -73,6 +76,14 @@ public class DefaultKafkaRestContext implements KafkaRestContext {
   public Producer<byte[], byte[]> getProducer() {
     return new KafkaProducer<>(
         config.getProducerConfigs(), new ByteArraySerializer(), new ByteArraySerializer());
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getConsumer(Properties properties) {
+    Properties consumerProperties = config.getConsumerProperties();
+    consumerProperties.putAll(properties);
+    KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer(consumerProperties);
+    return consumer;
   }
 
   @Override


### PR DESCRIPTION
This PR provides the implementation for the `getConsumer` method in the DefaultKafkaRestContext class. This follows the addition of the default `getConsumer` interface method in a previous PR https://github.com/confluentinc/kafka-rest/pull/1289