### PR TITLE
 Fix build breaks due to upstream changes

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -825,7 +825,7 @@ public abstract class ClusterTestHarness {
     }
 
     @Override
-    public Seq<Properties> kraftControllerConfigs() {
+    public Seq<Properties> kraftControllerConfigs(TestInfo testInfo) {
       // only one Kraft controller is supported in QuorumTestHarness
       return JavaConverters.asScalaBuffer(Collections.singletonList(kraftControllerConfig));
     }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceAvroProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceAvroProduceTest.java
@@ -94,8 +94,8 @@ public class TopicsResourceAvroProduceTest
   private static final TopicPartition PARTITION = new TopicPartition(TOPIC_NAME, 0);
   private static final List<RecordMetadata> PRODUCE_RESULTS =
       Arrays.asList(
-          new RecordMetadata(PARTITION, 0L, 0L, 0L, 0L, 1, 1),
-          new RecordMetadata(PARTITION, 0L, 1L, 0L, 0L, 1, 1));
+          new RecordMetadata(PARTITION, 0L, 0, 0L, 1, 1),
+          new RecordMetadata(PARTITION, 0L, 1, 0L, 1, 1));
   private static final List<PartitionOffset> OFFSETS =
       Arrays.asList(new PartitionOffset(0, 0L, null, null), new PartitionOffset(0, 1L, null, null));
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v2/TopicsResourceBinaryProduceTest.java
@@ -97,8 +97,8 @@ public class TopicsResourceBinaryProduceTest
   private static final TopicPartition PARTITION = new TopicPartition(TOPIC_NAME, 0);
   private static final List<CompletableFuture<RecordMetadata>> PRODUCE_RESULTS =
       Arrays.asList(
-          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 0L, 0L, 0L, 1, 1)),
-          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 1L, 0L, 0L, 1, 1)));
+          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 0, 0L, 1, 1)),
+          CompletableFuture.completedFuture(new RecordMetadata(PARTITION, 0L, 1, 0L, 1, 1)));
   private static final List<PartitionOffset> OFFSETS =
       Arrays.asList(new PartitionOffset(0, 0L, null, null), new PartitionOffset(0, 1L, null, null));
   private static final List<ProduceRecord> PRODUCE_EXCEPTION_DATA =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/QuorumControllerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/QuorumControllerFixture.java
@@ -51,7 +51,7 @@ public final class QuorumControllerFixture extends QuorumTestHarness
   }
 
   @Override
-  public Seq<Properties> kraftControllerConfigs() {
+  public Seq<Properties> kraftControllerConfigs(TestInfo testInfo) {
     Properties props = new Properties();
     props.put("authorizer.class.name", StandardAuthorizer.class.getName());
     // this setting allows brokers to register to Kraft controller


### PR DESCRIPTION
https://github.com/apache/kafka/pull/16979/files remove the RecordMetadata constructor kafka rest was using

    Old method signature was

    TopicPartition topicPartition, long baseOffset, long batchIndex, long timestamp,
                              Long checksum, int serializedKeySize, int serializedValueSize

    new is

    TopicPartition topicPartition, long baseOffset, int batchIndex, long timestamp,
                              int serializedKeySize, int serializedValueSize

    So I've turned batch index from a long to an int, and removed the checksum.

    AND

    https://github.com/apache/kafka/pull/16866 updated the method signature on QuorumTestHarness.kraftContorllerConfigs, so I've updated our overriding method to match