### PR TITLE
CONMON-9817: protobuf-java

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-rest-parent</artifactId>
-        <version>7.9.0-228</version>
+        <version>7.9.0-323</version>
     </parent>
 
     <artifactId>kafka-rest</artifactId>
@@ -20,7 +20,7 @@
     </description>
 
     <properties>
-        <io.confluent.schema-registry.version>7.9.0-139</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.9.0-201</io.confluent.schema-registry.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>7.9.0-250</version>
+        <version>7.9.0-323</version>
     </parent>
 
     <artifactId>kafka-rest-parent</artifactId>
     <packaging>pom</packaging>
     <name>kafka-rest-parent</name>
-    <version>7.9.0-228</version>
+    <version>7.9.0-323</version>
     <organization>
         <name>Confluent, Inc.</name>
         <url>http://confluent.io</url>
@@ -48,7 +48,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
-        <io.confluent.kafka-rest.version>7.9.0-228</io.confluent.kafka-rest.version>
+        <io.confluent.kafka-rest.version>7.9.0-323</io.confluent.kafka-rest.version>
         <!-- Allow enough heap space for integration tests with both Kraft and Zookeeper -->
         <argLine>-Xmx4g -Xms2g</argLine>
     </properties>


### PR DESCRIPTION
Protobuf-java is bumped from 3.25.4 to 3.25.5 by bumping up all the dependencies of kafka-rest indirectly.
This has been tested by scanning the bom files produced by Maven using trivy, and make sure no vulnerabilities are found.