### PR TITLE
Disable ZK based AuthorizationErrorTest - AclAuthorizer is deprecated 

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Properties;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
-import kafka.security.authorizer.AclAuthorizer;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -50,12 +49,16 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import scala.Option;
 
 /** This integration test uses AclAuthorizer class which is Zk specific. */
+// Until we fix KNET-16472, this test should be disabled.
+
+@Disabled
 public class AuthorizationErrorTest
     extends AbstractProducerTest<BinaryTopicProduceRequest, BinaryPartitionProduceRequest> {
 
@@ -122,7 +125,7 @@ public class AuthorizationErrorTest
             false);
     brokerProps.put("broker.id", Integer.toString(i));
     brokerProps.put(ZOOKEEPER_CONNECT_CONFIG, zkConnect);
-    brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
+    //    brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");
     brokerProps.setProperty(
         "listener.name.sasl_plaintext.plain.sasl.jaas.config",


### PR DESCRIPTION
### What
`AclAuthorizer` is  deprecated and `AuthorizationErrorTest` is ZK specific. Disabling the test temporarily. 
 `StandardAuthorizer` to be used instead to support Kraft case. 