### PR TITLE
Remove/Disable ZK specific tests in Kafka Rest

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Properties;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
-import kafka.security.authorizer.AclAuthorizer;
+
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -48,14 +48,18 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import scala.Option;
 
-/** This integration test uses AclAuthorizer class which is Zk specific. */
+// Until we fix KNET-16472, this test should be disabled.
+
+@Disabled
 public class AuthorizationErrorTest
     extends AbstractProducerTest<BinaryTopicProduceRequest, BinaryPartitionProduceRequest> {
 
@@ -121,8 +125,7 @@ public class AuthorizationErrorTest
             (short) 1,
             false);
     brokerProps.put("broker.id", Integer.toString(i));
-    brokerProps.put(ZOOKEEPER_CONNECT_CONFIG, zkConnect);
-    brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
+    //    brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");
     brokerProps.setProperty(
         "listener.name.sasl_plaintext.plain.sasl.jaas.config",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafkarest.integration;
 
-import static io.confluent.kafkarest.KafkaRestConfig.ZOOKEEPER_CONNECT_CONFIG;
 import static io.confluent.kafkarest.TestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME;
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
@@ -37,7 +36,6 @@ import java.util.List;
 import java.util.Properties;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
-
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -48,7 +46,6 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -54,9 +54,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import scala.Option;
 
-// Until we fix KNET-16472, this test should be disabled.
-
-@Disabled
+@Disabled("Until we fix KNET-16472, this test should be disabled")
 public class AuthorizationErrorTest
     extends AbstractProducerTest<BinaryTopicProduceRequest, BinaryPartitionProduceRequest> {
 
@@ -122,7 +120,6 @@ public class AuthorizationErrorTest
             (short) 1,
             false);
     brokerProps.put("broker.id", Integer.toString(i));
-    //    brokerProps.setProperty("authorizer.class.name", AclAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");
     brokerProps.setProperty(
         "listener.name.sasl_plaintext.plain.sasl.jaas.config",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/SchemaRegistrySaslInheritTest.java
@@ -102,7 +102,7 @@ public class SchemaRegistrySaslInheritTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void produceAvroWithRawSchema(String quorum) throws Exception {
     String clusterId = kafkaCluster.getClusterId();
     String key = "foo";

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
@@ -260,7 +260,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testCreateSearchAndSeparateDelete(String quorum) {
     createAliceAndBobAcls();
 
@@ -319,7 +319,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testCreateSearchAndMultiDelete(String quorum) {
     createAliceAndBobAcls();
 
@@ -358,7 +358,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testMultiDeleteBadQueryParameter(String quorum) {
     createAliceAndBobAcls();
 
@@ -398,7 +398,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testBatchAclCreate(String quorum) {
 
     SearchAclsResponse expectedPreCreateSearchResponse =
@@ -491,7 +491,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testBatchAclCreateWithNoRequestBody(String quorum) {
 
     Response nullRequestBodyResponse =
@@ -523,7 +523,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testBatchAclCreateRequestWithBodyAndNoContent(String quorum) {
 
     Response emptyRequestBodyResponse =
@@ -555,7 +555,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testBatchAclCreateWithBodyAndEmptyData(String quorum) {
 
     List<CreateAclRequest> acls = Arrays.asList();
@@ -593,7 +593,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testBatchAclCreateInvalidEntry(String quorum) {
 
     CreateAclRequest bob =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionRateLimitIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionRateLimitIntegrationTest.java
@@ -138,7 +138,7 @@ public class ProduceActionRateLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("test_whenGlobalByteLimitReached_thenCallerIsRateLimited")
   public void test_whenGlobalByteLimitReached_thenCallerIsRateLimited(String quorum)
       throws Exception {
@@ -146,7 +146,7 @@ public class ProduceActionRateLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("test_whenClusterByteLimitReached_thenCallerIsRateLimited")
   public void test_whenClusterByteLimitReached_thenCallerIsRateLimited(String quorum)
       throws Exception {
@@ -200,7 +200,7 @@ public class ProduceActionRateLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("test_whenGlobalRequestCountLimitReached_thenCallerIsRateLimited")
   public void test_whenGlobalRequestCountLimitReached_thenCallerIsRateLimited(String quorum)
       throws Exception {
@@ -208,7 +208,7 @@ public class ProduceActionRateLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("test_whenClusterRequestCountLimitReached_thenCallerIsRateLimited")
   public void test_whenClusterRequestCountLimitReached_thenCallerIsRateLimited(String quorum)
       throws Exception {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionRequestSizeLimitIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionRequestSizeLimitIntegrationTest.java
@@ -99,7 +99,7 @@ public class ProduceActionRequestSizeLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("testStreaming_ProduceRequestSizeNoLimit")
   public void testStreaming_ProduceRequestSizeNoLimit(String quorum) throws Exception {
     String clusterId = testEnv.kafkaCluster().getClusterId();
@@ -160,7 +160,7 @@ public class ProduceActionRequestSizeLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("testStreaming_ProduceRequestSizeWithLimit_withinLimit")
   public void testStreaming_ProduceRequestSizeWithLimit_withinLimit(String quorum)
       throws Exception {
@@ -223,7 +223,7 @@ public class ProduceActionRequestSizeLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("testStreaming_ProduceRequestSizeWithLimit_violateLimitFirstMessage")
   public void testStreaming_ProduceRequestSizeWithLimit_violateLimitFirstMessage(String quorum)
       throws Exception {
@@ -289,7 +289,7 @@ public class ProduceActionRequestSizeLimitIntegrationTest {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   @DisplayName("testStreaming_ProduceRequestSizeWithLimit_violateLimitSecondMessage")
   public void testStreaming_ProduceRequestSizeWithLimit_violateLimitSecondMessage(String quorum)
       throws Exception {


### PR DESCRIPTION
### What

- `AclAuthorizer` is deprecated. Removing ZK tests using `AclAuthorizer`

- `AuthorizationErrorTest` is ZK specific. Disabling the test temporarily. `StandardAuthorizer` to be used instead to support Kraft case. 