### PR TITLE
Change to manageRest to make the name consistent for all release branch

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -120,7 +120,7 @@ public abstract class ClusterTestHarness {
     return choosePorts(1)[0];
   }
 
-  private final boolean startRest;
+  private final boolean manageRest;
   private final int numBrokers;
   private final boolean withSchemaRegistry;
   // ZK Config
@@ -159,10 +159,11 @@ public abstract class ClusterTestHarness {
     this(numBrokers, withSchemaRegistry, true);
   }
 
-  public ClusterTestHarness(int numBrokers, boolean withSchemaRegistry, boolean startRest) {
+  /** @param manageRest If false, child-class is expected to create and start/stop REST-app. */
+  public ClusterTestHarness(int numBrokers, boolean withSchemaRegistry, boolean manageRest) {
+    this.manageRest = manageRest;
     this.numBrokers = numBrokers;
     this.withSchemaRegistry = withSchemaRegistry;
-    this.startRest = startRest;
 
     schemaRegProperties = new Properties();
     restProperties = new Properties();
@@ -195,7 +196,7 @@ public abstract class ClusterTestHarness {
     if (withSchemaRegistry) {
       doStartSchemaRegistry();
     }
-    if (startRest) {
+    if (manageRest) {
       startRest(brokerList);
     }
     log.info("Completed setup of {}", getClass().getSimpleName());
@@ -229,6 +230,7 @@ public abstract class ClusterTestHarness {
       log.warn("Rest server already started, skipping start");
       return;
     }
+    log.info("Setting up REST.");
     restProperties.put(KafkaRestConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     overrideKafkaRestConfigs(restProperties);
     if (withSchemaRegistry && schemaRegConnect != null) {
@@ -286,6 +288,7 @@ public abstract class ClusterTestHarness {
   }
 
   private void stopRest() throws Exception {
+    log.info("Stopping REST.");
     if (restApp != null) {
       restApp.stop();
       restApp.getMetrics().close();
@@ -370,8 +373,9 @@ public abstract class ClusterTestHarness {
   @After
   public void tearDown() throws Exception {
     log.info("Starting teardown of {}", getClass().getSimpleName());
-    stopRest();
-
+    if (manageRest) {
+      stopRest();
+    }
     if (schemaRegServer != null) {
       schemaRegServer.stop();
       schemaRegServer.join();


### PR DESCRIPTION
From branch 7.6.x, we already have property name `manageRest`, so this change is to make it consistent for all branches, also fix the missing check in tearDown.