### PR TITLE
Fix visibility for stopRest function

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -287,7 +287,7 @@ public abstract class ClusterTestHarness {
     restServer.start();
   }
 
-  private void stopRest() throws Exception {
+  protected void stopRest() throws Exception {
     log.info("Stopping REST.");
     if (restApp != null) {
       restApp.stop();


### PR DESCRIPTION
`stopRest` needs to be `protected` visibility so that it can be used by subclasses.