### PR TITLE
Correct field name in ConsumerGroupData, consumer -> consumers to mach code/examples

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -2147,7 +2147,7 @@ components:
               $ref: '#/components/schemas/ConsumerGroupState'
             coordinator:
               $ref: '#/components/schemas/Relationship'
-            consumer:
+            consumers:
               $ref: '#/components/schemas/Relationship'
             lag_summary:
               $ref: '#/components/schemas/Relationship'


### PR DESCRIPTION
`consumers` as field name is used in `ConsumerGroupData.java`, further [required](https://github.com/confluentinc/kafka-rest/pull/1324/files#diff-15612e27820603f2efe1f27c21963e53492df05773f3c9b4489fc575582ced9cR2135) also lists field name as `consumers`