### PR TITLE
Remove zk and replace jetty DOSFilter with Confluent fork

### DIFF
--- a/checkstyle/import_control.xml
+++ b/checkstyle/import_control.xml
@@ -148,7 +148,6 @@
   <allow class="kafka.server.QuorumTestHarness" />
   <allow class="kafka.utils.CoreUtils" />
   <allow class="kafka.utils.TestUtils" />
-  <allow class="kafka.utils.TestInfoUtils" />
   <allow class="kafka.zk.EmbeddedZookeeper" />
 
 </import-control>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
@@ -16,10 +16,8 @@
 package io.confluent.kafkarest.requestlog;
 
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException.ErrorCodes;
+import io.confluent.rest.jetty.DoSFilter;
 import javax.servlet.http.HttpServletRequest;
-import org.eclipse.jetty.servlets.DoSFilter;
-import org.eclipse.jetty.servlets.DoSFilter.Action;
-import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
 
 /**
  * This class is a Jetty DosFilter.Listener, for the global-dos filter. This on 429s will populate
@@ -28,12 +26,12 @@ import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
 public class GlobalDosFilterListener extends DoSFilter.Listener {
 
   @Override
-  public Action onRequestOverLimit(
-      HttpServletRequest request, OverLimit overlimit, DoSFilter dosFilter) {
+  public DoSFilter.Action onRequestOverLimit(
+      HttpServletRequest request, DoSFilter.OverLimit overlimit, DoSFilter dosFilter) {
     // KREST-10418: we don't use super function to get action object because
     // it will log a WARN line, in order to reduce verbosity
-    Action action = Action.fromDelay(dosFilter.getDelayMs());
-    if (action.equals(Action.REJECT)) {
+    DoSFilter.Action action = DoSFilter.Action.fromDelay(dosFilter.getDelayMs());
+    if (action.equals(DoSFilter.Action.REJECT)) {
       request.setAttribute(
           CustomLogRequestAttributes.REST_ERROR_CODE,
           ErrorCodes.DOS_FILTER_MAX_REQUEST_LIMIT_EXCEEDED);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
@@ -17,6 +17,8 @@ package io.confluent.kafkarest.requestlog;
 
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException.ErrorCodes;
 import io.confluent.rest.jetty.DoSFilter;
+import io.confluent.rest.jetty.DoSFilter.Action;
+import io.confluent.rest.jetty.DoSFilter.OverLimit;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -26,12 +28,12 @@ import javax.servlet.http.HttpServletRequest;
 public class GlobalDosFilterListener extends DoSFilter.Listener {
 
   @Override
-  public DoSFilter.Action onRequestOverLimit(
-      HttpServletRequest request, DoSFilter.OverLimit overlimit, DoSFilter dosFilter) {
+  public Action onRequestOverLimit(
+      HttpServletRequest request, OverLimit overlimit, DoSFilter dosFilter) {
     // KREST-10418: we don't use super function to get action object because
     // it will log a WARN line, in order to reduce verbosity
-    DoSFilter.Action action = DoSFilter.Action.fromDelay(dosFilter.getDelayMs());
-    if (action.equals(DoSFilter.Action.REJECT)) {
+    Action action = Action.fromDelay(dosFilter.getDelayMs());
+    if (action.equals(Action.REJECT)) {
       request.setAttribute(
           CustomLogRequestAttributes.REST_ERROR_CODE,
           ErrorCodes.DOS_FILTER_MAX_REQUEST_LIMIT_EXCEEDED);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
@@ -16,10 +16,8 @@
 package io.confluent.kafkarest.requestlog;
 
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException.ErrorCodes;
+import io.confluent.rest.jetty.DoSFilter;
 import javax.servlet.http.HttpServletRequest;
-import org.eclipse.jetty.servlets.DoSFilter;
-import org.eclipse.jetty.servlets.DoSFilter.Action;
-import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
 
 /**
  * This class is a Jetty DosFilter.Listener, for the per-connection-dos(aka per IP, or non-global)
@@ -29,12 +27,12 @@ import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
 public class PerConnectionDosFilterListener extends DoSFilter.Listener {
 
   @Override
-  public Action onRequestOverLimit(
-      HttpServletRequest request, OverLimit overlimit, DoSFilter dosFilter) {
+  public DoSFilter.Action onRequestOverLimit(
+      HttpServletRequest request, DoSFilter.OverLimit overlimit, DoSFilter dosFilter) {
     // KREST-10418: we don't use super function to get action object because
     // it will log a WARN line, in order to reduce verbosity
-    Action action = Action.fromDelay(dosFilter.getDelayMs());
-    if (action.equals(Action.REJECT)) {
+    DoSFilter.Action action = DoSFilter.Action.fromDelay(dosFilter.getDelayMs());
+    if (action.equals(DoSFilter.Action.REJECT)) {
       request.setAttribute(
           CustomLogRequestAttributes.REST_ERROR_CODE,
           ErrorCodes.DOS_FILTER_MAX_REQUEST_PER_CONNECTION_LIMIT_EXCEEDED);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
@@ -17,6 +17,8 @@ package io.confluent.kafkarest.requestlog;
 
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException.ErrorCodes;
 import io.confluent.rest.jetty.DoSFilter;
+import io.confluent.rest.jetty.DoSFilter.Action;
+import io.confluent.rest.jetty.DoSFilter.OverLimit;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -27,12 +29,12 @@ import javax.servlet.http.HttpServletRequest;
 public class PerConnectionDosFilterListener extends DoSFilter.Listener {
 
   @Override
-  public DoSFilter.Action onRequestOverLimit(
-      HttpServletRequest request, DoSFilter.OverLimit overlimit, DoSFilter dosFilter) {
+  public Action onRequestOverLimit(
+      HttpServletRequest request, OverLimit overlimit, DoSFilter dosFilter) {
     // KREST-10418: we don't use super function to get action object because
     // it will log a WARN line, in order to reduce verbosity
-    DoSFilter.Action action = DoSFilter.Action.fromDelay(dosFilter.getDelayMs());
-    if (action.equals(DoSFilter.Action.REJECT)) {
+    Action action = Action.fromDelay(dosFilter.getDelayMs());
+    if (action.equals(Action.REJECT)) {
       request.setAttribute(
           CustomLogRequestAttributes.REST_ERROR_CODE,
           ErrorCodes.DOS_FILTER_MAX_REQUEST_PER_CONNECTION_LIMIT_EXCEEDED);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -150,6 +150,7 @@ public class AuthorizationErrorTest
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
   @ValueSource(strings = {"zk"})
+  @Disabled("KNET-16782")
   public void testConsumerRequest(String quorum) {
     // test without acls
     verifySubscribeToTopic(true);
@@ -178,6 +179,7 @@ public class AuthorizationErrorTest
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
   @ValueSource(strings = {"zk"})
+  @Disabled("KNET-16782")
   public void testProducerAuthorization(String quorum) {
     BinaryTopicProduceRequest request = BinaryTopicProduceRequest.create(topicRecords);
     // test without any acls

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AvroProducerTest.java
@@ -158,7 +158,7 @@ public class AvroProducerTest extends ClusterTestHarness {
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"kraft", "zk"})
+  @ValueSource(strings = {"kraft"})
   public void testProduceToTopicWithPartitionsAndKeys(String quorum) {
     testProduceToTopic(topicRecordsWithPartitionsAndKeys, partitionOffsetsWithPartitionsAndKeys);
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -211,7 +211,6 @@ public abstract class ClusterTestHarness {
         new DefaultQuorumTestHarness(
             overrideKraftControllerSecurityProtocol(), overrideKraftControllerConfig());
     quorumTestHarness.setUp(testInfo);
-    // zkConnect = quorumTestHarness.zkConnectOrNull();
 
     // start brokers concurrently
     startBrokersConcurrently(numBrokers);

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/AclsResourceIntegrationTest.java
@@ -97,11 +97,7 @@ public class AclsResourceIntegrationTest extends ClusterTestHarness {
 
   @Override
   public Properties overrideBrokerProperties(int i, Properties props) {
-    if (isKraftTest()) {
-      props.put("authorizer.class.name", StandardAuthorizer.class.getName());
-    } else {
-      props.put("authorizer.class.name", "kafka.security.authorizer.AclAuthorizer");
-    }
+    props.put("authorizer.class.name", StandardAuthorizer.class.getName());
     props.put(
         "listener.name.sasl_plaintext.plain.sasl.jaas.config",
         "org.apache.kafka.common.security.plain.PlainLoginModule required "

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -29,6 +29,7 @@ import io.confluent.kafkarest.integration.ClusterTestHarness;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -41,6 +42,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
   /** Only applicable for Zk because getControllerID() is non-deterministic in Kraft */
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
   @ValueSource(strings = {"zk"})
+  @Disabled("KNET-16782")
   public void listClusters_returnsArrayWithOwnCluster(String quorum) {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
@@ -101,6 +103,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
   /** Only applicable for Zk because getControllerID() is non-deterministic in Kraft */
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
   @ValueSource(strings = {"zk"})
+  @Disabled("KNET-16782")
   public void getCluster_ownCluster_returnsOwnCluster(String quorum) {
     String baseUrl = restConnect;
     String clusterId = getClusterId();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import kafka.server.KafkaBroker;
 import kafka.server.KafkaConfig;
-import kafka.utils.TestInfoUtils;
 import kafka.utils.TestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.network.ListenerName;
@@ -101,18 +100,15 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
     logDir = Files.createTempDirectory(String.format("kafka-%d-", brokerId));
     broker =
         quorumController.createBroker(
-            KafkaConfig.fromProps(getBrokerConfigs(TestInfoUtils.isKRaft(testInfo))),
-            Time.SYSTEM,
-            true,
-            Option.empty());
+            KafkaConfig.fromProps(getBrokerConfigs()), Time.SYSTEM, true, Option.empty());
   }
 
-  private Properties getBrokerConfigs(boolean isKraftTest) {
+  private Properties getBrokerConfigs() {
     checkState(logDir != null);
     Properties properties =
         TestUtils.createBrokerConfig(
             brokerId,
-            quorumController.zkConnectOrNull(),
+            null,
             false,
             false,
             TestUtils.RandomPort(),
@@ -135,18 +131,15 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
     properties.putAll(CONFIG_TEMPLATE);
     properties.setProperty("broker.id", String.valueOf(brokerId));
     properties.setProperty("log.dir", logDir.toString());
-    properties.putAll(getBrokerSecurityConfigs(isKraftTest));
+    properties.putAll(getBrokerSecurityConfigs());
     properties.putAll(getBrokerSslConfigs());
     properties.putAll(configs);
     return properties;
   }
 
-  private Properties getBrokerSecurityConfigs(boolean isKraftTest) {
+  private Properties getBrokerSecurityConfigs() {
     Properties properties = new Properties();
-    String listenerSecurityProtocolMapTempl = "EXTERNAL:%s,INTERNAL:%s";
-    if (isKraftTest) {
-      listenerSecurityProtocolMapTempl += ",CONTROLLER:PLAINTEXT";
-    }
+    String listenerSecurityProtocolMapTempl = "EXTERNAL:%s,INTERNAL:%s,CONTROLLER:PLAINTEXT";
     properties.setProperty(
         "listener.security.protocol.map",
         String.format(listenerSecurityProtocolMapTempl, securityProtocol, securityProtocol));
@@ -157,12 +150,8 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
           "listener.name.internal.plain.sasl.jaas.config", getBrokerPlainSaslJaasConfig());
       properties.setProperty("sasl.enabled.mechanisms", "PLAIN");
       properties.setProperty("sasl.mechanism.inter.broker.protocol", "PLAIN");
-      if (isKraftTest) {
-        properties.setProperty(
-            "authorizer.class.name", "org.apache.kafka.metadata.authorizer.StandardAuthorizer");
-      } else {
-        properties.setProperty("authorizer.class.name", "kafka.security.authorizer.AclAuthorizer");
-      }
+      properties.setProperty(
+          "authorizer.class.name", "org.apache.kafka.metadata.authorizer.StandardAuthorizer");
     }
     properties.setProperty("super.users", getSuperUsers());
     return properties;


### PR DESCRIPTION
Remove all zk dependencies, make sure tests are running with KRaft.

This PR replaces the default jetty DOSFilter with our fork.