### PR TITLE
CPBR-2141: Enabling cp jar build by adding cc-service-bot config

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -6,6 +6,10 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
+  pr_ci_gating:
+    enable: true
+    project_name: kafka-rest
+  status_level: block
   nano_version: true
   downstream_projects: ["confluent-security-plugins", "ce-kafka-rest", "confluent-cloud-plugins"]
   # kafka-rest has many tests, so we need to run on a bigger machine


### PR DESCRIPTION
This change will allow adding non blocking cp jar build addition to master branch. Only in master branch, if [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) fails, developers will still be able to merge their changes. For all the branches, [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) will be required to pass before merging changes in any CP development branch.
More details can be found in https://confluentinc.atlassian.net/wiki/spaces/ENV/pages/2871296194/Add+SemaphoreCI#Configuration and https://docs.semaphoreci.com/using-semaphore/projects#edit-status-checks