### PR TITLE
Change visibility of testInfo and quorumTestHarness to protected so they can be used by subclasses

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -119,8 +119,8 @@ public abstract class ClusterTestHarness {
   private final boolean manageRest;
 
   // Quorum controller
-  private TestInfo testInfo;
-  private QuorumTestHarness quorumTestHarness;
+  protected TestInfo testInfo;
+  protected QuorumTestHarness quorumTestHarness;
 
   // Kafka Config
   protected List<KafkaConfig> configs = null;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -119,8 +119,8 @@ public abstract class ClusterTestHarness {
   private final boolean manageRest;
 
   // Quorum controller
-  protected TestInfo testInfo;
-  protected QuorumTestHarness quorumTestHarness;
+  private TestInfo testInfo;
+  private QuorumTestHarness quorumTestHarness;
 
   // Kafka Config
   protected List<KafkaConfig> configs = null;
@@ -823,6 +823,14 @@ public abstract class ClusterTestHarness {
           new TopicPartition(topicName, i), Optional.of(new NewPartitionReassignment(replicaIds)));
     }
     return reassignmentMap;
+  }
+
+  protected TestInfo getTestInfo() {
+    return testInfo;
+  }
+
+  protected QuorumTestHarness getQuorumTestHarness() {
+    return quorumTestHarness;
   }
 
   /** A concrete class of QuorumTestHarness so that we can customize for testing purposes */


### PR DESCRIPTION
Change visibility of testInfo and quorumTestHarness to protected so they can be used by subclasses.

This will help with customising subclasses for ce-kafka-rest to fix issue regarding deprecating zk.