### PR TITLE
Use backward compatible method to fix downstream build

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupManagerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ConsumerGroupManagerImpl.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
-import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 
 final class ConsumerGroupManagerImpl implements ConsumerGroupManager {
@@ -92,7 +92,7 @@ final class ConsumerGroupManagerImpl implements ConsumerGroupManager {
                         // TODO: Investigate a better way of detecting non-existent consumer-group.
                         description ->
                             !description.isSimpleConsumerGroup()
-                                || description.groupState() != GroupState.DEAD)
+                                || description.state() != ConsumerGroupState.DEAD)
                     .map(
                         description ->
                             ConsumerGroup.fromConsumerGroupDescription(clusterId, description))

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.GroupState;
 
 @AutoValue
@@ -111,11 +112,7 @@ public abstract class ConsumerGroup {
 
     DEAD,
 
-    EMPTY,
-
-    ASSIGNING,
-
-    RECONCILING;
+    EMPTY;
 
     public static State fromConsumerGroupState(GroupState state) {
       try {
@@ -125,11 +122,11 @@ public abstract class ConsumerGroup {
       }
     }
 
-    public GroupState toConsumerGroupState() {
+    public ConsumerGroupState toConsumerGroupState() {
       try {
-        return GroupState.valueOf(name());
+        return ConsumerGroupState.valueOf(name());
       } catch (IllegalArgumentException e) {
-        return GroupState.UNKNOWN;
+        return ConsumerGroupState.UNKNOWN;
       }
     }
   }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.common.ConsumerGroupState;
-import org.apache.kafka.common.GroupState;
 
 @AutoValue
 public abstract class ConsumerGroup {
@@ -68,7 +67,7 @@ public abstract class ConsumerGroup {
         .setPartitionAssignor(description.partitionAssignor())
         // I have only been able to see state=PREPARING_REBALANCE on all my tests.
         // TODO: Investigate how to get actual state of consumer group.
-        .setState(State.fromConsumerGroupState(description.groupState()))
+        .setState(State.fromConsumerGroupState(description.state()))
         .setCoordinator(Broker.fromNode(clusterId, description.coordinator()))
         .setConsumers(
             description.members().stream()
@@ -114,7 +113,7 @@ public abstract class ConsumerGroup {
 
     EMPTY;
 
-    public static State fromConsumerGroupState(GroupState state) {
+    public static State fromConsumerGroupState(ConsumerGroupState state) {
       try {
         return State.valueOf(state.name());
       } catch (IllegalArgumentException e) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupManagerImplTest.java
@@ -337,7 +337,7 @@ public class ConsumerGroupManagerImplTest {
           .andStubReturn(CONSUMER_GROUPS[i].isSimple());
       expect(consumerGroupDescriptions[i].partitionAssignor())
           .andStubReturn(CONSUMER_GROUPS[i].getPartitionAssignor());
-      expect(consumerGroupDescriptions[i].groupState())
+      expect(consumerGroupDescriptions[i].state())
           .andStubReturn(CONSUMER_GROUPS[i].getState().toConsumerGroupState());
       expect(consumerGroupDescriptions[i].coordinator())
           .andStubReturn(CONSUMER_GROUPS[i].getCoordinator().toNode());
@@ -400,7 +400,7 @@ public class ConsumerGroupManagerImplTest {
         .andStubReturn(CONSUMER_GROUPS[0].isSimple());
     expect(consumerGroupDescriptions[0].partitionAssignor())
         .andStubReturn(CONSUMER_GROUPS[0].getPartitionAssignor());
-    expect(consumerGroupDescriptions[0].groupState())
+    expect(consumerGroupDescriptions[0].state())
         .andStubReturn(CONSUMER_GROUPS[0].getState().toConsumerGroupState());
     expect(consumerGroupDescriptions[0].coordinator())
         .andStubReturn(CONSUMER_GROUPS[0].getCoordinator().toNode());


### PR DESCRIPTION
Revert changes made by 0b6b7b6ffdf17cf80a3a2ce0fcebd3a7df532309 and use `.state()` where needed.