### PR TITLE
Exclude log4j2 deps from kafka

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -41,6 +41,24 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
             <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-1.2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
For context, kafka core [bring log4j2 dependencies](https://github.com/confluentinc/kafka/commit/b37b89c6686f5270b37d39cf3144bccb4f5bceb2#diff-a74b4a65ab1f4aed61344787bb9654ba7e835154730653848c88ca11f9965dc0R243) (particularly log4j-1.2-api) that is clashing with reload4j.

This fixes the issue by excluding log4j2 deps from kafka-rest