### PR TITLE
Fix build due to upstream change

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -99,7 +99,6 @@ public class AuthorizationErrorTest
     Properties brokerProps =
         kafka.utils.TestUtils.createBrokerConfig(
             0,
-            "",
             false,
             false,
             kafka.utils.TestUtils.RandomPort(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -398,7 +398,6 @@ public abstract class ClusterTestHarness {
     Properties props =
         TestUtils.createBrokerConfig(
             i,
-            null,
             false,
             false,
             TestUtils.RandomPort(),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/KafkaBrokerFixture.java
@@ -108,7 +108,6 @@ public final class KafkaBrokerFixture implements BeforeEachCallback, AfterEachCa
     Properties properties =
         TestUtils.createBrokerConfig(
             brokerId,
-            null,
             false,
             false,
             TestUtils.RandomPort(),


### PR DESCRIPTION
Change in upstream https://github.com/confluentinc/kafka/commit/d874aa42f3d54f1474f2e617c792e48ed01f6a77 has removed a param (zkConnect) from `TestUtils.createBrokerConfig` function, this is to fixes it to make kafka-rest build pass.