### PR TITLE
Revert to old DosFilter

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.servlets.DoSFilter;
 import org.eclipse.jetty.servlets.DoSFilter.Action;
 import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
 
-
 /**
  * This class is a Jetty DosFilter.Listener, for the global-dos filter. This on 429s will populate
  * relevant metadata as attributed on the request, that later-on can be logged.

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/GlobalDosFilterListener.java
@@ -16,10 +16,11 @@
 package io.confluent.kafkarest.requestlog;
 
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException.ErrorCodes;
-import io.confluent.rest.jetty.DoSFilter;
-import io.confluent.rest.jetty.DoSFilter.Action;
-import io.confluent.rest.jetty.DoSFilter.OverLimit;
 import javax.servlet.http.HttpServletRequest;
+import org.eclipse.jetty.servlets.DoSFilter;
+import org.eclipse.jetty.servlets.DoSFilter.Action;
+import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
+
 
 /**
  * This class is a Jetty DosFilter.Listener, for the global-dos filter. This on 429s will populate

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
@@ -16,10 +16,11 @@
 package io.confluent.kafkarest.requestlog;
 
 import io.confluent.kafkarest.ratelimit.RateLimitExceededException.ErrorCodes;
-import io.confluent.rest.jetty.DoSFilter;
-import io.confluent.rest.jetty.DoSFilter.Action;
-import io.confluent.rest.jetty.DoSFilter.OverLimit;
 import javax.servlet.http.HttpServletRequest;
+import org.eclipse.jetty.servlets.DoSFilter;
+import org.eclipse.jetty.servlets.DoSFilter.Action;
+import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
+
 
 /**
  * This class is a Jetty DosFilter.Listener, for the per-connection-dos(aka per IP, or non-global)

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/requestlog/PerConnectionDosFilterListener.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.servlets.DoSFilter;
 import org.eclipse.jetty.servlets.DoSFilter.Action;
 import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
 
-
 /**
  * This class is a Jetty DosFilter.Listener, for the per-connection-dos(aka per IP, or non-global)
  * filter. This on 429s will populate relevant metadata as attributed on the request, that later-on

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>8.0.0-501</version>
+        <version>8.0.0-274</version>
     </parent>
 
     <artifactId>kafka-rest-parent</artifactId>


### PR DESCRIPTION
Use `org.eclipse.jetty.servlets.DoSFilter` in release branch for green image build.