### PR TITLE
[KNET-17449] Implement hashCode for ConsumerGroup.State to satisfy equals contract

### DIFF
--- a/checkstyle/import_control.xml
+++ b/checkstyle/import_control.xml
@@ -160,5 +160,6 @@
   <allow class="kafka.utils.CoreUtils" />
   <allow class="kafka.utils.TestUtils" />
   <allow class="kafka.zk.EmbeddedZookeeper" />
-
+  <!-- For verifying equals contract -->
+  <allow class="nl.jqno.equalsverifier.EqualsVerifier" exact-match="true"/>
 </import-control>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -63,4 +63,7 @@
   <!-- AutoValue-generated classes can contain various violations which should be ignored. -->
   <suppress checks="[A-za-z]*" files="AutoValue[A-Za-z_]*" />
 
+  <!-- ClusterTestHarness contains many boiler plate code for setting up Kafka cluster with Kafka Rest -->
+  <suppress checks="CyclomaticComplexity|JavaNCSS|NPathComplexity|ParameterNumber" files="ClusterTestHarness" />
+
 </suppressions>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -188,6 +188,12 @@
             <artifactId>snappy-java</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier-nodep</artifactId>
+            <version>3.18.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
@@ -128,7 +129,7 @@ public abstract class ConsumerGroup {
     private final GroupState state;
 
     State(GroupState state) {
-      this.state = state;
+      this.state = Objects.requireNonNull(state);
     }
 
     public GroupState toGroupState() {
@@ -157,6 +158,11 @@ public abstract class ConsumerGroup {
       }
       State that = (State) obj;
       return state == that.state;
+    }
+
+    @Override
+    public int hashCode() {
+      return state.hashCode();
     }
   }
 }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/entities/ConsumerGroupTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/entities/ConsumerGroupTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.entities;
+
+import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class ConsumerGroupTest {
+
+  @Test
+  public void testStateEqualsContract() {
+    EqualsVerifier.simple().forClass(State.class).withNonnullFields("state").verify();
+  }
+}


### PR DESCRIPTION
This implement `hashCode` for ConsumerGroup.State since we need to override both equals and hashCode to ensure consistency of a class.