### PR TITLE
KCOORD-966: Add protocol related fields to list consumer groups api

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -2172,6 +2172,8 @@ components:
             - is_simple
             - partition_assignor
             - state
+            - type
+            - is_mixed_consumer_group
             - coordinator
             - consumers
             - lag_summary
@@ -2186,6 +2188,10 @@ components:
               type: string
             state:
               $ref: '#/components/schemas/ConsumerGroupState'
+            type:
+              $ref: '#/components/schemas/ConsumerGroupType'
+            is_mixed_consumer_group:
+              type: boolean
             coordinator:
               $ref: '#/components/schemas/Relationship'
             consumers:
@@ -2211,9 +2217,19 @@ components:
         - UNKNOWN
         - PREPARING_REBALANCE
         - COMPLETING_REBALANCE
+        - ASSIGNING
+        - RECONCILING
         - STABLE
         - DEAD
         - EMPTY
+    
+    ConsumerGroupType:
+      type: string
+      x-extensible-enum:
+        - UNKNOWN
+        - CLASSIC
+        - CONSUMER
+        - SHARE
 
     ConsumerLagData:
       allOf:
@@ -3296,6 +3312,8 @@ components:
             is_simple: false
             partition_assignor: 'org.apache.kafka.clients.consumer.RoundRobinAssignor'
             state: 'STABLE'
+            type: 'CLASSIC'
+            is_mixed_consumer_group: false
             coordinator:
               related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
             consumers:
@@ -3793,6 +3811,8 @@ components:
                 is_simple: false
                 partition_assignor: 'org.apache.kafka.clients.consumer.RoundRobinAssignor'
                 state: 'STABLE'
+                type: 'CLASSIC'
+                is_mixed_consumer_group: false
                 coordinator:
                   related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1'
                 consumers:
@@ -3808,6 +3828,8 @@ components:
                 is_simple: false
                 partition_assignor: 'org.apache.kafka.clients.consumer.StickyAssignor'
                 state: 'PREPARING_REBALANCE'
+                type: 'CLASSIC'
+                is_mixed_consumer_group: false
                 coordinator:
                   related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2'
                 consumers:
@@ -3823,6 +3845,8 @@ components:
                 is_simple: false
                 partition_assignor: 'org.apache.kafka.clients.consumer.RangeAssignor'
                 state: 'DEAD'
+                type: 'CLASSIC'
+                is_mixed_consumer_group: false
                 coordinator:
                   related: 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3'
                 consumers:

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/ConsumerGroup.java
@@ -150,7 +150,7 @@ public abstract class ConsumerGroup {
     public static final State ASSIGNING = new State(GroupState.ASSIGNING);
     public static final State RECONCILING = new State(GroupState.RECONCILING);
 
-    // States that only apply to both group types.
+    // States that apply to both group types.
     public static final State STABLE = new State(GroupState.STABLE);
     public static final State DEAD = new State(GroupState.DEAD);
     public static final State EMPTY = new State(GroupState.EMPTY);

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/ConsumerGroupData.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 
 @AutoValue
 public abstract class ConsumerGroupData extends Resource {
@@ -41,6 +42,12 @@ public abstract class ConsumerGroupData extends Resource {
   @JsonProperty("state")
   public abstract State getState();
 
+  @JsonProperty("type")
+  public abstract Type getType();
+
+  @JsonProperty("is_mixed_consumer_group")
+  public abstract boolean isMixedConsumerGroup();
+
   @JsonProperty("coordinator")
   public abstract Relationship getCoordinator();
 
@@ -60,9 +67,12 @@ public abstract class ConsumerGroupData extends Resource {
         .setConsumerGroupId(consumerGroup.getConsumerGroupId())
         .setSimple(consumerGroup.isSimple())
         .setPartitionAssignor(consumerGroup.getPartitionAssignor())
-        .setState(consumerGroup.getState());
+        .setState(consumerGroup.getState())
+        .setType(consumerGroup.getType())
+        .setMixedConsumerGroup(consumerGroup.isMixedConsumerGroup());
   }
 
+  // CHECKSTYLE:OFF:ParameterNumber
   @JsonCreator
   static ConsumerGroupData fromJson(
       @JsonProperty("kind") String kind,
@@ -72,6 +82,8 @@ public abstract class ConsumerGroupData extends Resource {
       @JsonProperty("is_simple") boolean isSimple,
       @JsonProperty("partition_assignor") String partitionAssignor,
       @JsonProperty("state") State state,
+      @JsonProperty("type") Type type,
+      @JsonProperty("is_mixed_consumer_group") boolean isMixedConsumerGroup,
       @JsonProperty("coordinator") Relationship coordinator,
       @JsonProperty("consumers") Relationship consumers,
       @JsonProperty("lag_summary") Relationship lagSummary) {
@@ -83,11 +95,14 @@ public abstract class ConsumerGroupData extends Resource {
         .setSimple(isSimple)
         .setPartitionAssignor(partitionAssignor)
         .setState(state)
+        .setType(type)
+        .setMixedConsumerGroup(isMixedConsumerGroup)
         .setCoordinator(coordinator)
         .setConsumers(consumers)
         .setLagSummary(lagSummary)
         .build();
   }
+  // CHECKSTYLE:ON:ParameterNumber
 
   @AutoValue.Builder
   public abstract static class Builder extends Resource.Builder<Builder> {
@@ -103,6 +118,10 @@ public abstract class ConsumerGroupData extends Resource {
     public abstract Builder setPartitionAssignor(String partitionAssignor);
 
     public abstract Builder setState(State state);
+
+    public abstract Builder setType(Type type);
+
+    public abstract Builder setMixedConsumerGroup(boolean isMixedConsumerGroup);
 
     public abstract Builder setCoordinator(Relationship coordinator);
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupLagSummaryManagerImplTest.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.ConsumerGroupLagSummary;
 import io.confluent.kafkarest.entities.Partition;
 import java.util.Arrays;
@@ -114,6 +115,8 @@ public class ConsumerGroupLagSummaryManagerImplTest {
           .setSimple(true)
           .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
           .setState(State.STABLE)
+          .setType(Type.CLASSIC)
+          .setMixedConsumerGroup(false)
           .setCoordinator(BROKER_1)
           .setConsumers(Arrays.asList(CONSUMER_1, CONSUMER_2))
           .build();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerGroupManagerImplTest.java
@@ -32,8 +32,10 @@ import io.confluent.kafkarest.entities.Cluster;
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.Partition;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -223,6 +225,160 @@ public class ConsumerGroupManagerImplTest {
                       /* partitionId= */ 9,
                       /* replicas= */ emptyList())))
           .build()
+    },
+    {
+      Consumer.builder()
+          .setClusterId(CLUSTER_ID)
+          .setConsumerGroupId("consumer-group-3")
+          .setConsumerId("consumer-7")
+          .setClientId("client-7")
+          .setInstanceId("instance-7")
+          .setHost("71.72.73.74")
+          .setAssignedPartitions(
+              Arrays.asList(
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-4",
+                      /* partitionId= */ 1,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-5",
+                      /* partitionId= */ 2,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-6",
+                      /* partitionId= */ 3,
+                      /* replicas= */ emptyList())))
+          .build(),
+      Consumer.builder()
+          .setClusterId(CLUSTER_ID)
+          .setConsumerGroupId("consumer-group-3")
+          .setConsumerId("consumer-8")
+          .setClientId("client-8")
+          .setInstanceId("instance-8")
+          .setHost("81.82.83.84")
+          .setAssignedPartitions(
+              Arrays.asList(
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-4",
+                      /* partitionId= */ 4,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-5",
+                      /* partitionId= */ 5,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-6",
+                      /* partitionId= */ 6,
+                      /* replicas= */ emptyList())))
+          .build(),
+      Consumer.builder()
+          .setClusterId(CLUSTER_ID)
+          .setConsumerGroupId("consumer-group-3")
+          .setConsumerId("consumer-9")
+          .setClientId("client-9")
+          .setInstanceId("instance-9")
+          .setHost("91.92.93.94")
+          .setAssignedPartitions(
+              Arrays.asList(
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-7",
+                      /* partitionId= */ 7,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-8",
+                      /* partitionId= */ 8,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-9",
+                      /* partitionId= */ 9,
+                      /* replicas= */ emptyList())))
+          .build()
+    },
+    {
+      Consumer.builder()
+          .setClusterId(CLUSTER_ID)
+          .setConsumerGroupId("consumer-group-4")
+          .setConsumerId("consumer-10")
+          .setClientId("client-10")
+          .setInstanceId("instance-10")
+          .setHost("101.102.103.104")
+          .setAssignedPartitions(
+              Arrays.asList(
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-4",
+                      /* partitionId= */ 1,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-5",
+                      /* partitionId= */ 2,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-6",
+                      /* partitionId= */ 3,
+                      /* replicas= */ emptyList())))
+          .build(),
+      Consumer.builder()
+          .setClusterId(CLUSTER_ID)
+          .setConsumerGroupId("consumer-group-4")
+          .setConsumerId("consumer-11")
+          .setClientId("client-11")
+          .setInstanceId("instance-11")
+          .setHost("111.112.113.114")
+          .setAssignedPartitions(
+              Arrays.asList(
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-4",
+                      /* partitionId= */ 4,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-5",
+                      /* partitionId= */ 5,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-6",
+                      /* partitionId= */ 6,
+                      /* replicas= */ emptyList())))
+          .build(),
+      Consumer.builder()
+          .setClusterId(CLUSTER_ID)
+          .setConsumerGroupId("consumer-group-4")
+          .setConsumerId("consumer-12")
+          .setClientId("client-12")
+          .setInstanceId("instance-12")
+          .setHost("121.122.123.124")
+          .setAssignedPartitions(
+              Arrays.asList(
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-7",
+                      /* partitionId= */ 7,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-8",
+                      /* partitionId= */ 8,
+                      /* replicas= */ emptyList()),
+                  Partition.create(
+                      CLUSTER_ID,
+                      /* topicName= */ "topic-9",
+                      /* partitionId= */ 9,
+                      /* replicas= */ emptyList())))
+          .build()
     }
   };
 
@@ -233,6 +389,8 @@ public class ConsumerGroupManagerImplTest {
         .setSimple(true)
         .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
         .setState(State.STABLE)
+        .setType(Type.CLASSIC)
+        .setMixedConsumerGroup(false)
         .setCoordinator(BROKER_1)
         .setConsumers(Arrays.asList(CONSUMERS[0]))
         .build(),
@@ -242,8 +400,32 @@ public class ConsumerGroupManagerImplTest {
         .setSimple(false)
         .setPartitionAssignor("org.apache.kafka.clients.consumer.RoundRobinAssignor")
         .setState(State.COMPLETING_REBALANCE)
+        .setType(Type.CLASSIC)
+        .setMixedConsumerGroup(false)
         .setCoordinator(BROKER_2)
         .setConsumers(Arrays.asList(CONSUMERS[1]))
+        .build(),
+    ConsumerGroup.builder()
+        .setClusterId(CLUSTER_ID)
+        .setConsumerGroupId("consumer-group-3")
+        .setSimple(false)
+        .setPartitionAssignor("org.apache.kafka.clients.consumer.StickyAssignor")
+        .setState(State.RECONCILING)
+        .setType(Type.CONSUMER)
+        .setMixedConsumerGroup(true)
+        .setCoordinator(BROKER_2)
+        .setConsumers(Arrays.asList(CONSUMERS[2]))
+        .build(),
+    ConsumerGroup.builder()
+        .setClusterId(CLUSTER_ID)
+        .setConsumerGroupId("consumer-group-4")
+        .setSimple(false)
+        .setPartitionAssignor("org.apache.kafka.clients.consumer.CooperativeStickyAssignor")
+        .setState(State.STABLE)
+        .setType(Type.CONSUMER)
+        .setMixedConsumerGroup(false)
+        .setCoordinator(BROKER_2)
+        .setConsumers(Arrays.asList(CONSUMERS[3]))
         .build()
   };
 
@@ -268,39 +450,32 @@ public class ConsumerGroupManagerImplTest {
   @BeforeEach
   public void setUp() {
     consumerGroupListings =
-        new ConsumerGroupListing[] {
-          createMock(ConsumerGroupListing.class), createMock(ConsumerGroupListing.class)
-        };
+        IntStream.range(0, CONSUMER_GROUPS.length)
+            .mapToObj(i -> createMock(ConsumerGroupListing.class))
+            .toArray(ConsumerGroupListing[]::new);
+
     consumerGroupDescriptions =
-        new ConsumerGroupDescription[] {
-          createMock(ConsumerGroupDescription.class), createMock(ConsumerGroupDescription.class)
-        };
+        IntStream.range(0, CONSUMER_GROUPS.length)
+            .mapToObj(i -> createMock(ConsumerGroupDescription.class))
+            .toArray(ConsumerGroupDescription[]::new);
+
     memberDescriptions =
-        new MemberDescription[][] {
-          {
-            createMock(MemberDescription.class),
-            createMock(MemberDescription.class),
-            createMock(MemberDescription.class)
-          },
-          {
-            createMock(MemberDescription.class),
-            createMock(MemberDescription.class),
-            createMock(MemberDescription.class)
-          }
-        };
+        Arrays.stream(CONSUMERS)
+            .map(
+                consumerArray ->
+                    Arrays.stream(consumerArray)
+                        .map(consumer -> createMock(MemberDescription.class))
+                        .toArray(MemberDescription[]::new))
+            .toArray(MemberDescription[][]::new);
+
     memberAssignments =
-        new MemberAssignment[][] {
-          {
-            createMock(MemberAssignment.class),
-            createMock(MemberAssignment.class),
-            createMock(MemberAssignment.class)
-          },
-          {
-            createMock(MemberAssignment.class),
-            createMock(MemberAssignment.class),
-            createMock(MemberAssignment.class)
-          }
-        };
+        Arrays.stream(CONSUMERS)
+            .map(
+                consumerArray ->
+                    Arrays.stream(consumerArray)
+                        .map(consumer -> createMock(MemberAssignment.class))
+                        .toArray(MemberAssignment[]::new))
+            .toArray(MemberAssignment[][]::new);
 
     consumerGroupManager = new ConsumerGroupManagerImpl(adminClient, clusterManager);
   }
@@ -339,6 +514,8 @@ public class ConsumerGroupManagerImplTest {
           .andStubReturn(CONSUMER_GROUPS[i].getPartitionAssignor());
       expect(consumerGroupDescriptions[i].groupState())
           .andStubReturn(CONSUMER_GROUPS[i].getState().toGroupState());
+      expect(consumerGroupDescriptions[i].type())
+          .andStubReturn(CONSUMER_GROUPS[i].getType().toGroupType());
       expect(consumerGroupDescriptions[i].coordinator())
           .andStubReturn(CONSUMER_GROUPS[i].getCoordinator().toNode());
       expect(consumerGroupDescriptions[i].members())
@@ -353,6 +530,7 @@ public class ConsumerGroupManagerImplTest {
             .andStubReturn(CONSUMERS[i][j].getInstanceId());
         expect(memberDescriptions[i][j].clientId()).andStubReturn(CONSUMERS[i][j].getClientId());
         expect(memberDescriptions[i][j].host()).andStubReturn(CONSUMERS[i][j].getHost());
+        expect(memberDescriptions[i][j].upgraded()).andStubReturn(Optional.of(3 * i + j > 6));
         expect(memberDescriptions[i][j].assignment()).andStubReturn(memberAssignments[i][j]);
         expect(memberAssignments[i][j].topicPartitions())
             .andStubReturn(
@@ -366,7 +544,7 @@ public class ConsumerGroupManagerImplTest {
 
     List<ConsumerGroup> consumerGroups = consumerGroupManager.listConsumerGroups(CLUSTER_ID).get();
 
-    assertEquals(Arrays.asList(CONSUMER_GROUPS), consumerGroups);
+    assertEquals(new HashSet<>(Arrays.asList(CONSUMER_GROUPS)), new HashSet<>(consumerGroups));
   }
 
   @Test
@@ -402,6 +580,8 @@ public class ConsumerGroupManagerImplTest {
         .andStubReturn(CONSUMER_GROUPS[0].getPartitionAssignor());
     expect(consumerGroupDescriptions[0].groupState())
         .andStubReturn(CONSUMER_GROUPS[0].getState().toGroupState());
+    expect(consumerGroupDescriptions[0].type())
+        .andStubReturn(CONSUMER_GROUPS[0].getType().toGroupType());
     expect(consumerGroupDescriptions[0].coordinator())
         .andStubReturn(CONSUMER_GROUPS[0].getCoordinator().toNode());
     expect(consumerGroupDescriptions[0].members())

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerLagManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerLagManagerImplTest.java
@@ -30,6 +30,7 @@ import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.ConsumerLag;
 import io.confluent.kafkarest.entities.Partition;
 import java.util.Arrays;
@@ -115,6 +116,8 @@ public class ConsumerLagManagerImplTest {
           .setSimple(true)
           .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
           .setState(State.STABLE)
+          .setType(Type.CLASSIC)
+          .setMixedConsumerGroup(false)
           .setCoordinator(BROKER_1)
           .setConsumers(Arrays.asList(CONSUMER_1, CONSUMER_2))
           .build();
@@ -287,6 +290,8 @@ public class ConsumerLagManagerImplTest {
             .setSimple(true)
             .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
             .setState(State.STABLE)
+            .setType(Type.CLASSIC)
+            .setMixedConsumerGroup(false)
             .setCoordinator(BROKER_1)
             .setConsumers(Collections.singletonList(consumer))
             .build();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerManagerImplTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ConsumerManagerImplTest.java
@@ -27,6 +27,7 @@ import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.Partition;
 import java.util.Arrays;
 import java.util.List;
@@ -133,6 +134,8 @@ public class ConsumerManagerImplTest {
           .setSimple(true)
           .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
           .setState(State.STABLE)
+          .setType(Type.CLASSIC)
+          .setMixedConsumerGroup(false)
           .setCoordinator(BROKER_1)
           .setConsumers(Arrays.asList(CONSUMERS))
           .build();

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -791,7 +791,7 @@ public abstract class ClusterTestHarness {
       TestUtils.createTopicWithAdmin(
           admin,
           topicName,
-          JavaConverters.asScalaBuffer(servers).toSeq(),
+          JavaConverters.asScalaBuffer(servers),
           quorumTestHarness.controllerServers(),
           numPartitions.orElse(1),
           replicationFactor.orElse((short) 1),

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ConsumerGroupsResourceIntegrationTest.java
@@ -16,13 +16,11 @@
 package io.confluent.kafkarest.integration.v3;
 
 import static io.confluent.kafkarest.TestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME;
-import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.AnyOf.anyOf;
+import static io.confluent.kafkarest.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.v3.ConsumerGroupData;
 import io.confluent.kafkarest.entities.v3.ConsumerGroupDataList;
 import io.confluent.kafkarest.entities.v3.GetConsumerGroupResponse;
@@ -33,7 +31,11 @@ import io.confluent.kafkarest.entities.v3.ResourceCollection;
 import io.confluent.kafkarest.integration.ClusterTestHarness;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.stream.IntStream;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -51,37 +53,59 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
   @ValueSource(strings = {"kraft"})
-  public void listConsumerGroups_returnsConsumerGroups(String quorum) {
+  public void listConsumerGroups_returnsConsumerGroups(String quorum) throws InterruptedException {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
     createTopic("topic-1", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-2", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-3", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
-    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1");
-    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2");
-    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3");
+
+    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1", "classic");
+    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2", "classic");
+    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3", "classic");
     consumer1.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer2.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer3.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
-    consumer1.poll(Duration.ofSeconds(1));
-    consumer2.poll(Duration.ofSeconds(1));
-    consumer3.poll(Duration.ofSeconds(1));
 
-    ListConsumerGroupsResponse expectedPreparingRebalance =
-        getExpectedListResponse(baseUrl, clusterId, "", State.PREPARING_REBALANCE);
+    KafkaConsumer<?, ?> consumer4 = createConsumer("consumer-group-2", "client-1", "consumer");
+    KafkaConsumer<?, ?> consumer5 = createConsumer("consumer-group-2", "client-2", "consumer");
+    KafkaConsumer<?, ?> consumer6 = createConsumer("consumer-group-2", "client-3", "consumer");
+    consumer4.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
+    consumer5.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
+    consumer6.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
 
-    ListConsumerGroupsResponse expectedStable =
-        getExpectedListResponse(baseUrl, clusterId, "range", State.STABLE);
+    KafkaConsumer<?, ?> consumer7 = createConsumer("consumer-group-3", "client-1", "classic");
+    KafkaConsumer<?, ?> consumer8 = createConsumer("consumer-group-3", "client-2", "consumer");
+    KafkaConsumer<?, ?> consumer9 = createConsumer("consumer-group-3", "client-3", "classic");
+    consumer7.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
+    consumer8.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
+    consumer9.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
 
-    Response response =
-        request("/v3/clusters/" + clusterId + "/consumer-groups")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    assertThat(
-        response.readEntity(ListConsumerGroupsResponse.class),
-        anyOf(is(expectedPreparingRebalance), is(expectedStable)));
+    List<KafkaConsumer<?, ?>> consumers =
+        Arrays.asList(
+            consumer1, consumer2, consumer3, consumer4, consumer5, consumer6, consumer7, consumer8,
+            consumer9);
+
+    ListConsumerGroupsResponse expected =
+        getExpectedListResponse(
+            baseUrl,
+            clusterId,
+            new String[] {"range", "uniform", "uniform"},
+            new State[] {State.STABLE, State.STABLE, State.STABLE},
+            new Type[] {Type.CLASSIC, Type.CONSUMER, Type.CONSUMER},
+            new boolean[] {false, false, true});
+
+    pollUntilTrue(
+        consumers,
+        () -> {
+          Response response =
+              request("/v3/clusters/" + clusterId + "/consumer-groups")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          return Status.OK.getStatusCode() == response.getStatus()
+              && unorderedEquals(expected, response.readEntity(ListConsumerGroupsResponse.class));
+        });
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
@@ -90,9 +114,9 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     createTopic("topic-1", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-2", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-3", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
-    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1");
-    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2");
-    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3");
+    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1", "classic");
+    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2", "classic");
+    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3", "classic");
     consumer1.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer2.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer3.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
@@ -114,30 +138,26 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     createTopic("topic-1", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-2", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-3", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
-    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1");
-    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2");
-    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3");
+    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1", "classic");
+    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2", "classic");
+    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3", "classic");
     consumer1.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer2.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer3.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
-    consumer1.poll(Duration.ofSeconds(1));
-    consumer2.poll(Duration.ofSeconds(1));
-    consumer3.poll(Duration.ofSeconds(1));
 
-    GetConsumerGroupResponse expectedStable =
-        getExpectedGroupResponse(baseUrl, clusterId, "range", State.STABLE);
+    GetConsumerGroupResponse expected =
+        getExpectedGroupResponse(baseUrl, clusterId, "range", State.STABLE, Type.CLASSIC, false);
 
-    GetConsumerGroupResponse expectedRebalance =
-        getExpectedGroupResponse(baseUrl, clusterId, "", State.PREPARING_REBALANCE);
-
-    Response response =
-        request("/v3/clusters/" + clusterId + "/consumer-groups/consumer-group-1")
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    assertThat(
-        response.readEntity(GetConsumerGroupResponse.class),
-        anyOf(is(expectedStable), is(expectedRebalance)));
+    pollUntilTrue(
+        Arrays.asList(consumer1, consumer2, consumer3),
+        () -> {
+          Response response =
+              request("/v3/clusters/" + clusterId + "/consumer-groups/consumer-group-1")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .get();
+          return Status.OK.getStatusCode() == response.getStatus()
+              && response.readEntity(GetConsumerGroupResponse.class).equals(expected);
+        });
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
@@ -146,9 +166,9 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     createTopic("topic-1", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-2", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-3", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
-    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1");
-    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2");
-    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3");
+    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1", "classic");
+    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2", "classic");
+    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3", "classic");
     consumer1.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer2.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer3.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
@@ -170,9 +190,9 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     createTopic("topic-1", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-2", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
     createTopic("topic-3", /* numPartitions= */ 3, /* replicationFactor= */ (short) 1);
-    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1");
-    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2");
-    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3");
+    KafkaConsumer<?, ?> consumer1 = createConsumer("consumer-group-1", "client-1", "classic");
+    KafkaConsumer<?, ?> consumer2 = createConsumer("consumer-group-1", "client-2", "classic");
+    KafkaConsumer<?, ?> consumer3 = createConsumer("consumer-group-1", "client-3", "classic");
     consumer1.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer2.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
     consumer3.subscribe(Arrays.asList("topic-1", "topic-2", "topic-3"));
@@ -187,16 +207,42 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
 
-  private KafkaConsumer<?, ?> createConsumer(String consumerGroup, String clientId) {
+  private void pollUntilTrue(List<KafkaConsumer<?, ?>> consumers, Callable<Boolean> condition) {
+    waitForCondition(
+        () -> {
+          for (KafkaConsumer<?, ?> consumer : consumers) {
+            consumer.poll(Duration.ofSeconds(1));
+          }
+          return condition.call();
+        },
+        "Condition is not met within the timeout.");
+  }
+
+  private boolean unorderedEquals(
+      ListConsumerGroupsResponse expected, ListConsumerGroupsResponse actual) {
+    return (expected.getValue().getKind().equals(actual.getValue().getKind()))
+        && (expected.getValue().getMetadata().equals(actual.getValue().getMetadata()))
+        && (new HashSet<>(expected.getValue().getData())
+            .equals(new HashSet<>(actual.getValue().getData())));
+  }
+
+  private KafkaConsumer<?, ?> createConsumer(
+      String consumerGroup, String clientId, String groupProtocol) {
     Properties properties = restConfig.getConsumerProperties();
     properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
     properties.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
     properties.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+    properties.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, groupProtocol);
     return new KafkaConsumer<>(properties, new BytesDeserializer(), new BytesDeserializer());
   }
 
   private ListConsumerGroupsResponse getExpectedListResponse(
-      String baseUrl, String clusterId, String partitionAssignor, State state) {
+      String baseUrl,
+      String clusterId,
+      String[] partitionAssignors,
+      State[] states,
+      Type[] types,
+      boolean[] isMixed) {
     return ListConsumerGroupsResponse.create(
         ConsumerGroupDataList.builder()
             .setMetadata(
@@ -204,46 +250,69 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
                     .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups")
                     .build())
             .setData(
-                singletonList(
-                    ConsumerGroupData.builder()
-                        .setMetadata(
-                            Resource.Metadata.builder()
-                                .setSelf(
-                                    baseUrl
-                                        + "/v3/clusters/"
-                                        + clusterId
-                                        + "/consumer-groups/consumer-group-1")
-                                .setResourceName(
-                                    "crn:///kafka="
-                                        + clusterId
-                                        + "/consumer-group=consumer-group-1")
-                                .build())
-                        .setClusterId(clusterId)
-                        .setConsumerGroupId("consumer-group-1")
-                        .setSimple(false)
-                        .setPartitionAssignor(partitionAssignor)
-                        .setState(state)
-                        .setCoordinator(
-                            Relationship.create(
-                                baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
-                        .setConsumers(
-                            Relationship.create(
-                                baseUrl
-                                    + "/v3/clusters/"
-                                    + clusterId
-                                    + "/consumer-groups/consumer-group-1/consumers"))
-                        .setLagSummary(
-                            Relationship.create(
-                                baseUrl
-                                    + "/v3/clusters/"
-                                    + clusterId
-                                    + "/consumer-groups/consumer-group-1/lag-summary"))
-                        .build()))
+                IntStream.range(0, states.length)
+                    .mapToObj(
+                        i ->
+                            getListedConsumerGroupData(
+                                baseUrl,
+                                clusterId,
+                                "consumer-group-" + (i + 1),
+                                partitionAssignors[i],
+                                states[i],
+                                types[i],
+                                isMixed[i]))
+                    .collect(java.util.stream.Collectors.toList()))
             .build());
   }
 
+  private ConsumerGroupData getListedConsumerGroupData(
+      String baseUrl,
+      String clusterId,
+      String groupId,
+      String partitionAssignor,
+      State state,
+      Type type,
+      boolean isMixed) {
+    return ConsumerGroupData.builder()
+        .setMetadata(
+            Resource.Metadata.builder()
+                .setSelf(baseUrl + "/v3/clusters/" + clusterId + "/consumer-groups/" + groupId)
+                .setResourceName("crn:///kafka=" + clusterId + "/consumer-group=" + groupId)
+                .build())
+        .setClusterId(clusterId)
+        .setConsumerGroupId(groupId)
+        .setSimple(false)
+        .setPartitionAssignor(partitionAssignor)
+        .setState(state)
+        .setType(type)
+        .setMixedConsumerGroup(isMixed)
+        .setCoordinator(Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
+        .setConsumers(
+            Relationship.create(
+                baseUrl
+                    + "/v3/clusters/"
+                    + clusterId
+                    + "/consumer-groups/"
+                    + groupId
+                    + "/consumers"))
+        .setLagSummary(
+            Relationship.create(
+                baseUrl
+                    + "/v3/clusters/"
+                    + clusterId
+                    + "/consumer-groups/"
+                    + groupId
+                    + "/lag-summary"))
+        .build();
+  }
+
   private GetConsumerGroupResponse getExpectedGroupResponse(
-      String baseUrl, String clusterId, String partitionAssignor, State state) {
+      String baseUrl,
+      String clusterId,
+      String partitionAssignor,
+      State state,
+      Type type,
+      boolean isMixed) {
     return GetConsumerGroupResponse.create(
         ConsumerGroupData.builder()
             .setMetadata(
@@ -258,6 +327,8 @@ public class ConsumerGroupsResourceIntegrationTest extends ClusterTestHarness {
             .setSimple(false)
             .setPartitionAssignor(partitionAssignor)
             .setState(state)
+            .setType(type)
+            .setMixedConsumerGroup(isMixed)
             .setCoordinator(
                 Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/brokers/0"))
             .setConsumers(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumerGroupsResourceTest.java
@@ -26,6 +26,7 @@ import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.v3.ConsumerGroupData;
 import io.confluent.kafkarest.entities.v3.ConsumerGroupDataList;
@@ -222,6 +223,8 @@ public class ConsumerGroupsResourceTest {
         .setSimple(true)
         .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
         .setState(State.STABLE)
+        .setType(Type.CLASSIC)
+        .setMixedConsumerGroup(false)
         .setCoordinator(BROKER_1)
         .setConsumers(Arrays.asList(CONSUMERS[0]))
         .build(),
@@ -231,6 +234,8 @@ public class ConsumerGroupsResourceTest {
         .setSimple(false)
         .setPartitionAssignor("org.apache.kafka.clients.consumer.RoundRobinAssignor")
         .setState(State.COMPLETING_REBALANCE)
+        .setType(Type.CLASSIC)
+        .setMixedConsumerGroup(false)
         .setCoordinator(BROKER_2)
         .setConsumers(Arrays.asList(CONSUMERS[1]))
         .build()

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumersResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ConsumersResourceTest.java
@@ -26,6 +26,7 @@ import io.confluent.kafkarest.entities.Broker;
 import io.confluent.kafkarest.entities.Consumer;
 import io.confluent.kafkarest.entities.ConsumerGroup;
 import io.confluent.kafkarest.entities.ConsumerGroup.State;
+import io.confluent.kafkarest.entities.ConsumerGroup.Type;
 import io.confluent.kafkarest.entities.Partition;
 import io.confluent.kafkarest.entities.v3.ConsumerData;
 import io.confluent.kafkarest.entities.v3.ConsumerDataList;
@@ -140,6 +141,8 @@ public class ConsumersResourceTest {
           .setSimple(true)
           .setPartitionAssignor("org.apache.kafka.clients.consumer.RangeAssignor")
           .setState(State.STABLE)
+          .setType(Type.CLASSIC)
+          .setMixedConsumerGroup(false)
           .setCoordinator(BROKER_1)
           .setConsumers(Arrays.asList(CONSUMERS))
           .build();


### PR DESCRIPTION
This patch adds two protocol related fields to `ListConsumerGroups` api.

- Group protocol (CLASSIC, CONSUMER, SHARE, UNKNOWN)

- New field to indicate whether a group with the consumer protocol does/does not have all its assigned consumers on the new protocol. The boolean is set to be false for groups using protocols other than CONSUMER.

Beside, it also updates the `state` field to have the new states of the new protocol ASSIGNING and RECONCILING.