### PR TITLE
perf: add singleton to Schema Record Serializers

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -76,6 +76,7 @@ public final class ControllersModule extends AbstractBinder {
     }
 
     @Override
+    @Singleton
     public SchemaRecordSerializer provide() {
       if (schemaRegistryClient.isPresent()) {
         return new SchemaRecordSerializerImpl(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.controllers;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafkarest.config.ConfigModule.AvroSerializerConfigs;
@@ -55,16 +56,19 @@ public final class ControllersModule extends AbstractBinder {
     bindFactory(SchemaRecordSerializerFactory.class).to(SchemaRecordSerializer.class);
   }
 
-  private static final class SchemaRecordSerializerFactory
+  @VisibleForTesting
+  protected static final class SchemaRecordSerializerFactory
       implements Factory<SchemaRecordSerializer> {
 
+    private static volatile SchemaRecordSerializer schemaRecordSerializer;
     private final Optional<SchemaRegistryClient> schemaRegistryClient;
     private final Map<String, Object> avroSerializerConfigs;
     private final Map<String, Object> jsonschemaSerializerConfigs;
     private final Map<String, Object> protobufSerializerConfigs;
 
+    @VisibleForTesting
     @Inject
-    private SchemaRecordSerializerFactory(
+    protected SchemaRecordSerializerFactory(
         Optional<SchemaRegistryClient> schemaRegistryClient,
         @AvroSerializerConfigs Map<String, Object> avroSerializerConfigs,
         @JsonschemaSerializerConfigs Map<String, Object> jsonschemaSerializerConfigs,
@@ -78,15 +82,22 @@ public final class ControllersModule extends AbstractBinder {
     @Override
     @Singleton
     public SchemaRecordSerializer provide() {
-      if (schemaRegistryClient.isPresent()) {
-        return new SchemaRecordSerializerImpl(
-            schemaRegistryClient.get(),
-            avroSerializerConfigs,
-            jsonschemaSerializerConfigs,
-            protobufSerializerConfigs);
-      } else {
-        return new SchemaRecordSerializerThrowing();
+      if (schemaRecordSerializer == null) {
+        synchronized (SchemaRecordSerializer.class) {
+          if (schemaRegistryClient.isPresent()) {
+            schemaRecordSerializer =
+                new SchemaRecordSerializerImpl(
+                    schemaRegistryClient.get(),
+                    avroSerializerConfigs,
+                    jsonschemaSerializerConfigs,
+                    protobufSerializerConfigs);
+            return schemaRecordSerializer;
+          } else {
+            return new SchemaRecordSerializerThrowing();
+          }
+        }
       }
+      return schemaRecordSerializer;
     }
 
     @Override

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
@@ -41,6 +41,7 @@ import io.confluent.kafkarest.exceptions.BadRequestException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import javax.inject.Singleton;
 import org.apache.avro.AvroTypeException;
 import org.everit.json.schema.ValidationException;
 
@@ -56,10 +57,11 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
       @JsonschemaSerializerConfigs Map<String, Object> jsonschemaSerializerConfigs,
       @ProtobufSerializerConfigs Map<String, Object> protobufSerializerConfigs) {
     requireNonNull(schemaRegistryClient);
-    avroSerializer = new AvroSerializer(schemaRegistryClient, avroSerializerConfigs);
+    avroSerializer = AvroSerializer.getInstance(schemaRegistryClient, avroSerializerConfigs);
     jsonschemaSerializer =
-        new JsonSchemaSerializer(schemaRegistryClient, jsonschemaSerializerConfigs);
-    protobufSerializer = new ProtobufSerializer(schemaRegistryClient, protobufSerializerConfigs);
+        JsonSchemaSerializer.getInstance(schemaRegistryClient, jsonschemaSerializerConfigs);
+    protobufSerializer =
+        ProtobufSerializer.getInstance(schemaRegistryClient, protobufSerializerConfigs);
   }
 
   @Override
@@ -128,11 +130,22 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
         protobufSerializer.serialize(subject, topicName, protobufSchema, record, isKey));
   }
 
+  @Singleton
   private static final class AvroSerializer extends AbstractKafkaAvroSerializer {
+
+    private static volatile AvroSerializer instance;
 
     private AvroSerializer(SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
       this.schemaRegistry = requireNonNull(schemaRegistryClient);
       configure(serializerConfig(configs));
+    }
+
+    private static AvroSerializer getInstance(
+        SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
+      if (instance == null) {
+        instance = new AvroSerializer(schemaRegistryClient, configs);
+      }
+      return instance;
     }
 
     private byte[] serialize(String subject, AvroSchema schema, Object data) {
@@ -140,8 +153,11 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
     }
   }
 
+  @Singleton
   private static final class JsonSchemaSerializer
       extends AbstractKafkaJsonSchemaSerializer<Object> {
+
+    private static volatile JsonSchemaSerializer instance;
 
     private JsonSchemaSerializer(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
@@ -149,17 +165,36 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
       configure(serializerConfig(configs));
     }
 
+    private static JsonSchemaSerializer getInstance(
+        SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
+      if (instance == null) {
+        instance = new JsonSchemaSerializer(schemaRegistryClient, configs);
+      }
+      return instance;
+    }
+
     private byte[] serialize(String subject, JsonSchema schema, Object data) {
       return serializeImpl(subject, JsonSchemaUtils.getValue(data), schema);
     }
   }
 
+  @Singleton
   private static final class ProtobufSerializer extends KafkaProtobufSerializer<Message> {
+
+    private static volatile ProtobufSerializer instance;
 
     private ProtobufSerializer(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
       this.schemaRegistry = requireNonNull(schemaRegistryClient);
       configure(serializerConfig(configs));
+    }
+
+    private static ProtobufSerializer getInstance(
+        SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
+      if (instance == null) {
+        instance = new ProtobufSerializer(schemaRegistryClient, configs);
+      }
+      return instance;
     }
 
     private byte[] serialize(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
@@ -142,12 +142,14 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
     private static AvroSerializer getInstance(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
-      synchronized (AvroSerializer.class) {
-        if (instance == null) {
-          instance = new AvroSerializer(schemaRegistryClient, configs);
+      if (instance == null) {
+        synchronized (AvroSerializer.class) {
+          if (instance == null) {
+            instance = new AvroSerializer(schemaRegistryClient, configs);
+          }
         }
-        return instance;
       }
+      return instance;
     }
 
     private byte[] serialize(String subject, AvroSchema schema, Object data) {
@@ -169,12 +171,14 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
     private static JsonSchemaSerializer getInstance(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
-      synchronized (JsonSchemaSerializer.class) {
-        if (instance == null) {
-          instance = new JsonSchemaSerializer(schemaRegistryClient, configs);
+      if (instance == null) {
+        synchronized (JsonSchemaSerializer.class) {
+          if (instance == null) {
+            instance = new JsonSchemaSerializer(schemaRegistryClient, configs);
+          }
         }
-        return instance;
       }
+      return instance;
     }
 
     private byte[] serialize(String subject, JsonSchema schema, Object data) {
@@ -195,12 +199,14 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
     private static ProtobufSerializer getInstance(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
-      synchronized (ProtobufSerializer.class) {
-        if (instance == null) {
-          instance = new ProtobufSerializer(schemaRegistryClient, configs);
+      if (instance == null) {
+        synchronized (ProtobufSerializer.class) {
+          if (instance == null) {
+            instance = new ProtobufSerializer(schemaRegistryClient, configs);
+          }
         }
-        return instance;
       }
+      return instance;
     }
 
     private byte[] serialize(

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
@@ -142,10 +142,12 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
     private static AvroSerializer getInstance(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
-      if (instance == null) {
-        instance = new AvroSerializer(schemaRegistryClient, configs);
+      synchronized (AvroSerializer.class) {
+        if (instance == null) {
+          instance = new AvroSerializer(schemaRegistryClient, configs);
+        }
+        return instance;
       }
-      return instance;
     }
 
     private byte[] serialize(String subject, AvroSchema schema, Object data) {
@@ -167,10 +169,12 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
     private static JsonSchemaSerializer getInstance(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
-      if (instance == null) {
-        instance = new JsonSchemaSerializer(schemaRegistryClient, configs);
+      synchronized (JsonSchemaSerializer.class) {
+        if (instance == null) {
+          instance = new JsonSchemaSerializer(schemaRegistryClient, configs);
+        }
+        return instance;
       }
-      return instance;
     }
 
     private byte[] serialize(String subject, JsonSchema schema, Object data) {
@@ -191,10 +195,12 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
     private static ProtobufSerializer getInstance(
         SchemaRegistryClient schemaRegistryClient, Map<String, Object> configs) {
-      if (instance == null) {
-        instance = new ProtobufSerializer(schemaRegistryClient, configs);
+      synchronized (ProtobufSerializer.class) {
+        if (instance == null) {
+          instance = new ProtobufSerializer(schemaRegistryClient, configs);
+        }
+        return instance;
       }
-      return instance;
     }
 
     private byte[] serialize(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ControllersModuleTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ControllersModuleTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafkarest.controllers.ControllersModule.SchemaRecordSerializerFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.easymock.EasyMockExtension;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(EasyMockExtension.class)
+class ControllersModuleTest extends EasyMockSupport {
+
+  @Test
+  void testSchemaRecordSerializerSingleton() {
+    SchemaRegistryClient mockSchemaRegistryClient = mock(SchemaRegistryClient.class);
+    replayAll();
+
+    Map<String, Object> commonConfig = new HashMap<>();
+    commonConfig.put("schema.registry.url", "http://dummy-schema-registry-url");
+
+    SchemaRecordSerializerFactory schemaRecordSerializerFactory =
+        new SchemaRecordSerializerFactory(
+            Optional.ofNullable(mockSchemaRegistryClient),
+            commonConfig,
+            commonConfig,
+            commonConfig);
+
+    SchemaRecordSerializer serializerInstanceOne = schemaRecordSerializerFactory.provide();
+    SchemaRecordSerializer serializerInstanceTwo = schemaRecordSerializerFactory.provide();
+
+    assertSame(
+        serializerInstanceOne, serializerInstanceTwo, "Expected both instances to be the same");
+    verifyAll();
+  }
+}


### PR DESCRIPTION
Closing this PR in lieu of https://github.com/confluentinc/kafka-rest/pull/1356

Update -
The integ tests are failing on this PR, for reasons I couldn't find. Here's an alternative PR - https://github.com/confluentinc/kafka-rest/pull/1356

JIRA: KNET-16476

For each produce request, serializers for JSON, Avro, Protobuf were being initialized as they were always being constructed (with `new`).  I have changed them to `@Singleton` so that their instances are reused with future invocations. This has led to a stark reduction in CPU time taken. 
The controller Module will now have a singleton implementation of the SchemaRecordSerializer. 

Without Singleton - 
<img width="1492" alt="Screenshot 2025-03-14 at 17 47 35" src="https://github.com/user-attachments/assets/d50035f7-a6f7-4cb6-a3fe-d95b8bcfd78c" />
Without Singleton Profiler - https://drive.google.com/file/d/1wfZ7t5-EeBeenUVUzHy_FBVJ5jA_VJWH/view?usp=sharing
With Singleton - 
<img width="1467" alt="Screenshot 2025-03-14 at 17 47 41" src="https://github.com/user-attachments/assets/bedecf7b-3068-424b-bc78-fc6e8f8013f3" />
With Singleton Profiler - https://drive.google.com/file/d/1PM9pyF986P_hd3vZ3i73ShoJFcuXDNuT/view?usp=sharing
