### PR TITLE
Handle null payload in POST requests

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/Errors.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.config.ConfigException;
 
 public class Errors {
 
+  public static final String NULL_PAYLOAD_ERROR_MESSAGE = "Null input provided. Data is required.";
+
   public static final int KAFKA_AUTHENTICATION_ERROR_CODE =
       KafkaExceptionMapper.KAFKA_AUTHENTICATION_ERROR_CODE;
   public static final int KAFKA_AUTHORIZATION_ERROR_CODE =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
@@ -162,7 +162,7 @@ public final class AclsResource {
       @Valid CreateAclRequest request) {
 
     if (request == null) {
-      throw Errors.invalidPayloadException("Null input provided. Data is required.");
+      throw Errors.invalidPayloadException(Errors.NULL_PAYLOAD_ERROR_MESSAGE);
     }
 
     CompletableFuture<Void> response =

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchAction.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.BrokerConfigManager;
 import io.confluent.kafkarest.entities.v3.AlterBrokerConfigBatchRequest;
 import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
@@ -58,6 +59,10 @@ public final class AlterBrokerConfigBatchAction {
       @PathParam("clusterId") String clusterId,
       @PathParam("brokerId") int brokerId,
       @Valid AlterBrokerConfigBatchRequest request) {
+    if (request == null) {
+      throw Errors.invalidPayloadException(Errors.NULL_PAYLOAD_ERROR_MESSAGE);
+    }
+
     CompletableFuture<Void> response =
         brokerConfigManager
             .get()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchAction.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.ClusterConfigManager;
 import io.confluent.kafkarest.entities.ClusterConfig;
 import io.confluent.kafkarest.entities.v3.AlterClusterConfigBatchRequest;
@@ -59,6 +60,10 @@ public final class AlterClusterConfigBatchAction {
       @PathParam("clusterId") String clusterId,
       @PathParam("config_type") ClusterConfig.Type configType,
       @Valid AlterClusterConfigBatchRequest request) {
+    if (request == null) {
+      throw Errors.invalidPayloadException(Errors.NULL_PAYLOAD_ERROR_MESSAGE);
+    }
+
     CompletableFuture<Void> response =
         clusterConfigManager
             .get()

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchAction.java
@@ -17,6 +17,7 @@ package io.confluent.kafkarest.resources.v3;
 
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.TopicConfigManager;
 import io.confluent.kafkarest.entities.v3.AlterTopicConfigBatchRequest;
 import io.confluent.kafkarest.extension.ResourceAccesslistFeature.ResourceName;
@@ -58,6 +59,10 @@ public final class AlterTopicConfigBatchAction {
       @PathParam("clusterId") String clusterId,
       @PathParam("topicName") String topicName,
       @Valid AlterTopicConfigBatchRequest request) {
+    if (request == null) {
+      throw Errors.invalidPayloadException(Errors.NULL_PAYLOAD_ERROR_MESSAGE);
+    }
+
     boolean validateOnly = request.getValue().getValidateOnly().orElse(false);
     CompletableFuture<Void> response =
         validateOnly

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/CreateAclBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/CreateAclBatchAction.java
@@ -61,7 +61,7 @@ public final class CreateAclBatchAction {
       @Valid CreateAclBatchRequest request) {
 
     if (request == null) {
-      throw Errors.invalidPayloadException("Null input provided. Data is required.");
+      throw Errors.invalidPayloadException(Errors.NULL_PAYLOAD_ERROR_MESSAGE);
     }
 
     CompletableFuture<Void> response =

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterBrokerConfigBatchActionTest.java
@@ -22,8 +22,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.BrokerConfigManager;
 import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.BrokerConfig;
@@ -33,6 +35,7 @@ import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData;
 import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterEntry;
 import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterOperation;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
 import java.util.Arrays;
 import javax.ws.rs.NotFoundException;
 import org.easymock.EasyMockExtension;
@@ -77,6 +80,17 @@ public final class AlterBrokerConfigBatchActionTest {
   @BeforeEach
   public void setUp() {
     alterBrokerConfigBatchAction = new AlterBrokerConfigBatchAction(() -> brokerConfigManager);
+  }
+
+  @Test
+  public void alterBrokerConfigs_nullPayload() {
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                alterBrokerConfigBatchAction.alterBrokerConfigBatch(
+                    new FakeAsyncResponse(), CLUSTER_ID, BROKER_ID, null));
+    assertTrue(e.getMessage().contains(Errors.NULL_PAYLOAD_ERROR_MESSAGE));
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterClusterConfigBatchActionTest.java
@@ -22,8 +22,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.ClusterConfigManager;
 import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.ClusterConfig;
@@ -33,6 +35,7 @@ import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData;
 import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterEntry;
 import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterOperation;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
 import java.util.Arrays;
 import javax.ws.rs.NotFoundException;
 import org.easymock.EasyMockExtension;
@@ -76,6 +79,17 @@ public final class AlterClusterConfigBatchActionTest {
   @BeforeEach
   public void setUp() {
     alterClusterConfigBatchAction = new AlterClusterConfigBatchAction(() -> clusterConfigManager);
+  }
+
+  @Test
+  public void alterClusterConfigBatch_nullPayload() {
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                alterClusterConfigBatchAction.alterClusterConfigBatch(
+                    new FakeAsyncResponse(), CLUSTER_ID, ClusterConfig.Type.BROKER, null));
+    assertTrue(e.getMessage().contains(Errors.NULL_PAYLOAD_ERROR_MESSAGE));
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/AlterTopicConfigBatchActionTest.java
@@ -22,8 +22,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.TopicConfigManager;
 import io.confluent.kafkarest.entities.AlterConfigCommand;
 import io.confluent.kafkarest.entities.ConfigSource;
@@ -33,6 +35,7 @@ import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterEntry
 import io.confluent.kafkarest.entities.v3.AlterConfigBatchRequestData.AlterOperation;
 import io.confluent.kafkarest.entities.v3.AlterTopicConfigBatchRequest;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
 import java.util.Arrays;
 import javax.ws.rs.NotFoundException;
 import org.easymock.EasyMockExtension;
@@ -77,6 +80,17 @@ public class AlterTopicConfigBatchActionTest {
   @BeforeEach
   public void setUp() {
     alterTopicConfigBatchAction = new AlterTopicConfigBatchAction(() -> topicConfigManager);
+  }
+
+  @Test
+  public void alterTopicConfigBatch_nullPayload() {
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () ->
+                alterTopicConfigBatchAction.alterTopicConfigBatch(
+                    new FakeAsyncResponse(), CLUSTER_ID, TOPIC_NAME, null));
+    assertTrue(e.getMessage().contains(Errors.NULL_PAYLOAD_ERROR_MESSAGE));
   }
 
   @Test

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/CreateAclBatchActionTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/CreateAclBatchActionTest.java
@@ -20,13 +20,17 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.confluent.kafkarest.Errors;
 import io.confluent.kafkarest.controllers.AclManager;
 import io.confluent.kafkarest.entities.Acl;
 import io.confluent.kafkarest.entities.v3.CreateAclBatchRequest;
 import io.confluent.kafkarest.entities.v3.CreateAclBatchRequestData;
 import io.confluent.kafkarest.entities.v3.CreateAclRequest;
 import io.confluent.kafkarest.response.FakeAsyncResponse;
+import io.confluent.rest.exceptions.RestConstraintViolationException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -72,6 +76,15 @@ public class CreateAclBatchActionTest {
   @BeforeEach
   public void setUp() {
     aclsResource = new CreateAclBatchAction(() -> aclManager);
+  }
+
+  @Test
+  public void createAcls_nullPayload() {
+    RestConstraintViolationException e =
+        assertThrows(
+            RestConstraintViolationException.class,
+            () -> aclsResource.createAcls(new FakeAsyncResponse(), CLUSTER_ID, null));
+    assertTrue(e.getMessage().contains(Errors.NULL_PAYLOAD_ERROR_MESSAGE));
   }
 
   @Test


### PR DESCRIPTION
Even though we annotate the payload with `@Valid` annotation, we might still receive null payload, this will cause the endpoint to return 500 due to NPE of the payload, this PR fixes the issue by checking the nullability of the payload and return 422 if that is the case.

The fix in this PR is for v3 resources.