### PR TITLE
refactor: changing the config introduced in the commit d65a0b3

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestConfig.java
@@ -519,13 +519,16 @@ public class KafkaRestConfig extends RestConfig {
       "Whether to use custom-request-logging i.e. CustomLog.java. Instead of using"
           + "Jetty's request-logging.";
   private static final boolean USE_CUSTOM_REQUEST_LOGGING_DEFAULT = true;
-  public static final String NULL_NODE_ALWAYS_EMPTY_RECORD_CONFIG = "null.node.always.empty.record";
-  private static final String NULL_NODE_ALWAYS_EMPTY_RECORD_DOC =
-      "Null Nodes in either key or value will always be treated as empty records "
-          + "for formats that require schema"
-          + "This is useful when you want to treat null nodes as empty records. "
-          + "Default is false.";
-  private static final boolean NULL_NODE_ALWAYS_EMPTY_RECORD_DEFAULT = false;
+  public static final String NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_CONFIG =
+      "null.request.body.always.publishes.empty.record";
+  private static final String NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_DOC =
+      "Before commit d65a0b3, when a schema was specified, "
+          + "but the associated key or value request body was null, "
+          + "then the message was published with an empty key or value. "
+          + "If a schema does not allow a null value, then the message should be rejected. "
+          + "After commit d65a0b3, the new behaviour where the message is rejected in this "
+          + "scenario is the default. This configuration property enables the old behaviour.";
+  private static final boolean NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_DEFAULT = false;
 
   private static final ConfigDef config;
   private volatile Metrics metrics;
@@ -939,11 +942,11 @@ public class KafkaRestConfig extends RestConfig {
             Importance.LOW,
             USE_CUSTOM_REQUEST_LOGGING_DOC)
         .define(
-            NULL_NODE_ALWAYS_EMPTY_RECORD_CONFIG,
+            NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_CONFIG,
             Type.BOOLEAN,
-            NULL_NODE_ALWAYS_EMPTY_RECORD_DEFAULT,
+            NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_DEFAULT,
             Importance.LOW,
-            NULL_NODE_ALWAYS_EMPTY_RECORD_DOC);
+            NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_DOC);
   }
 
   private static Properties getPropsFromFile(String propsFile) throws RestConfigException {
@@ -1251,8 +1254,8 @@ public class KafkaRestConfig extends RestConfig {
     return getLong(PRODUCE_REQUEST_SIZE_LIMIT_MAX_BYTES_CONFIG);
   }
 
-  public final boolean isNullNodeAlwaysEmptyRecordEnabled() {
-    return getBoolean(NULL_NODE_ALWAYS_EMPTY_RECORD_CONFIG);
+  public final boolean isNullRequestBodyAlwaysPublishEmptyRecordEnabled() {
+    return getBoolean(NULL_REQUEST_BODY_ALWAYS_PUBLISH_EMPTY_RECORD_CONFIG);
   }
 
   public final ImmutableMap<String, Integer> getRateLimitCosts() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/config/ConfigModule.java
@@ -185,8 +185,8 @@ public final class ConfigModule extends AbstractBinder {
         .qualifiedBy(new SchemaRegistryConfigsImpl())
         .to(new TypeLiteral<Map<String, Object>>() {});
 
-    bind(config.isNullNodeAlwaysEmptyRecordEnabled())
-        .qualifiedBy(new NullNodeAlwaysEmptyEnabledConfigImpl())
+    bind(config.isNullRequestBodyAlwaysPublishEmptyRecordEnabled())
+        .qualifiedBy(new NullRequestBodyAlwaysPublishEmptyRecordEnabledConfigImpl())
         .to(Boolean.class);
 
     bind(schemaRegistryConfig.requestHeaders())
@@ -488,10 +488,10 @@ public final class ConfigModule extends AbstractBinder {
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
-  public @interface NullNodeAlwaysEmptyEnabledConfig {}
+  public @interface NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig {}
 
-  private static final class NullNodeAlwaysEmptyEnabledConfigImpl
-      extends AnnotationLiteral<NullNodeAlwaysEmptyEnabledConfig>
-      implements NullNodeAlwaysEmptyEnabledConfig {}
+  private static final class NullRequestBodyAlwaysPublishEmptyRecordEnabledConfigImpl
+      extends AnnotationLiteral<NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig>
+      implements NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig {}
 }
 // CHECKSTYLE:ON:ClassDataAbstractionCoupling

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ControllersModule.java
@@ -21,7 +21,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafkarest.config.ConfigModule.AvroSerializerConfigs;
 import io.confluent.kafkarest.config.ConfigModule.JsonschemaSerializerConfigs;
-import io.confluent.kafkarest.config.ConfigModule.NullNodeAlwaysEmptyEnabledConfig;
+import io.confluent.kafkarest.config.ConfigModule.NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig;
 import io.confluent.kafkarest.config.ConfigModule.ProtobufSerializerConfigs;
 import java.util.Map;
 import java.util.Optional;
@@ -67,7 +67,7 @@ public final class ControllersModule extends AbstractBinder {
     private final Map<String, Object> avroSerializerConfigs;
     private final Map<String, Object> jsonschemaSerializerConfigs;
     private final Map<String, Object> protobufSerializerConfigs;
-    private final boolean nullNodeAlwaysEmptyRecord;
+    private final boolean nullRequestBodyAlwaysPublishEmptyRecord;
 
     @Inject
     private SchemaRecordSerializerFactory(
@@ -75,12 +75,13 @@ public final class ControllersModule extends AbstractBinder {
         @AvroSerializerConfigs Map<String, Object> avroSerializerConfigs,
         @JsonschemaSerializerConfigs Map<String, Object> jsonschemaSerializerConfigs,
         @ProtobufSerializerConfigs Map<String, Object> protobufSerializerConfigs,
-        @NullNodeAlwaysEmptyEnabledConfig Boolean nullNodeAlwaysEmptyRecord) {
+        @NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig
+            Boolean nullRequestBodyAlwaysPublishEmptyRecord) {
       this.schemaRegistryClient = requireNonNull(schemaRegistryClient);
       this.avroSerializerConfigs = requireNonNull(avroSerializerConfigs);
       this.jsonschemaSerializerConfigs = requireNonNull(jsonschemaSerializerConfigs);
       this.protobufSerializerConfigs = requireNonNull(protobufSerializerConfigs);
-      this.nullNodeAlwaysEmptyRecord = nullNodeAlwaysEmptyRecord;
+      this.nullRequestBodyAlwaysPublishEmptyRecord = nullRequestBodyAlwaysPublishEmptyRecord;
     }
 
     @Override
@@ -92,7 +93,7 @@ public final class ControllersModule extends AbstractBinder {
             avroSerializerConfigs,
             jsonschemaSerializerConfigs,
             protobufSerializerConfigs,
-            nullNodeAlwaysEmptyRecord);
+            nullRequestBodyAlwaysPublishEmptyRecord);
       } else {
         return new SchemaRecordSerializerThrowing();
       }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/SchemaRecordSerializerImpl.java
@@ -46,7 +46,7 @@ import org.everit.json.schema.ValidationException;
 
 final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
 
-  private final boolean nullNodeAlwaysEmptyRecord;
+  private final boolean nullRequestBodyAlwaysPublishEmptyRecord;
   private final AvroSerializer avroSerializer;
   private final JsonSchemaSerializer jsonschemaSerializer;
   private final ProtobufSerializer protobufSerializer;
@@ -56,13 +56,13 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
       @AvroSerializerConfigs Map<String, Object> avroSerializerConfigs,
       @JsonschemaSerializerConfigs Map<String, Object> jsonschemaSerializerConfigs,
       @ProtobufSerializerConfigs Map<String, Object> protobufSerializerConfigs,
-      boolean nullNodeAlwaysEmptyRecord) {
+      boolean nullRequestBodyAlwaysPublishEmptyRecord) {
     requireNonNull(schemaRegistryClient);
     avroSerializer = new AvroSerializer(schemaRegistryClient, avroSerializerConfigs);
     jsonschemaSerializer =
         new JsonSchemaSerializer(schemaRegistryClient, jsonschemaSerializerConfigs);
     protobufSerializer = new ProtobufSerializer(schemaRegistryClient, protobufSerializerConfigs);
-    this.nullNodeAlwaysEmptyRecord = nullNodeAlwaysEmptyRecord;
+    this.nullRequestBodyAlwaysPublishEmptyRecord = nullRequestBodyAlwaysPublishEmptyRecord;
   }
 
   @Override
@@ -73,7 +73,7 @@ final class SchemaRecordSerializerImpl implements SchemaRecordSerializer {
       JsonNode data,
       boolean isKey) {
     checkArgument(format.requiresSchema());
-    if (nullNodeAlwaysEmptyRecord && data.isNull()) {
+    if (nullRequestBodyAlwaysPublishEmptyRecord && data.isNull()) {
       return Optional.empty();
     }
     if (data.isNull() && schema.isEmpty()) {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ControllersModuleTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/controllers/ControllersModuleTest.java
@@ -19,9 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafkarest.config.ConfigModule;
 import io.confluent.kafkarest.config.ConfigModule.AvroSerializerConfigs;
 import io.confluent.kafkarest.config.ConfigModule.JsonschemaSerializerConfigs;
+import io.confluent.kafkarest.config.ConfigModule.NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig;
 import io.confluent.kafkarest.config.ConfigModule.ProtobufSerializerConfigs;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,7 +63,7 @@ public class ControllersModuleTest {
                 .to(new TypeLiteral<Map<String, Object>>() {});
 
             bind(false)
-                .qualifiedBy(new TestNullNodeAlwaysEmptyEnabledConfigImpl())
+                .qualifiedBy(new TestNullRequestBodyAlwaysPublishEmptyRecordEnabledConfigImpl())
                 .to(Boolean.class);
             install(new ControllersModule());
           }
@@ -97,7 +97,7 @@ public class ControllersModuleTest {
   private static final class TestProtobufSerializerConfigsImpl
       extends AnnotationLiteral<ProtobufSerializerConfigs> implements ProtobufSerializerConfigs {}
 
-  private static final class TestNullNodeAlwaysEmptyEnabledConfigImpl
-      extends AnnotationLiteral<ConfigModule.NullNodeAlwaysEmptyEnabledConfig>
-      implements ConfigModule.NullNodeAlwaysEmptyEnabledConfig {}
+  private static final class TestNullRequestBodyAlwaysPublishEmptyRecordEnabledConfigImpl
+      extends AnnotationLiteral<NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig>
+      implements NullRequestBodyAlwaysPublishEmptyRecordEnabledConfig {}
 }


### PR DESCRIPTION
A follow up to this PR - https://github.com/confluentinc/kafka-rest/pull/1360, refactoring the config name and documentation for clarity.