### PR TITLE
KNET-18123: Do not overcheck the custom request log

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/CustomLogIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/CustomLogIntegrationTest.java
@@ -587,7 +587,7 @@ public class CustomLogIntegrationTest extends ClusterTestHarness {
     }
     int rateLimitedRequests = 0;
     int totalRequests = 0;
-    while (true) {
+    while (totalRequests < expectedNumOfEntries) {
       String entry = logEntries.poll();
       if (entry == null) {
         break;


### PR DESCRIPTION
We saw a test failure for `test_whenGlobalProduceBytesRateLimitTriggered_ThenRequestLogHasRelevantInfo` in which we saw the 400 error code that we weren't expected. However, it seems the test is only supposed to send 100 requests (logs 0 to 99). Log 100 and 101 are unknown, and could be caused by a separate thing since they happen much later than the requests our test sends. We can fix some of this flakiness by making sure we just check the request log for the exact number of requests we know we send.

Example logs for failure:
```
...
[2025-04-07 18:43:55,840] INFO Log #98:200 429003 Codes=429:1 (io.confluent.kafkarest.integration.CustomLogIntegrationTest:486)
[2025-04-07 18:43:55,840] INFO Log #99:200 429003 Codes=429:1 (io.confluent.kafkarest.integration.CustomLogIntegrationTest:486)
[2025-04-07 18:43:56,017] INFO Log #100:400 - - (io.confluent.kafkarest.integration.CustomLogIntegrationTest:486)
[2025-04-07 18:43:57,848] INFO Stopping REST. (io.confluent.kafkarest.integration.ClusterTestHarness:345)
[2025-04-07 18:43:57,850] INFO Shutdown icr.ApplicationServer@1b243dad{STOPPING}[12.0.16,sto=5000] (io.confluent.rest.ApplicationServer:141)
[2025-04-07 18:43:57,850] DEBUG Graceful NetworkTrafficServerConnector@588af8b3{HTTP/1.1, (http/1.1, h2c)}{localhost:38227} (io.confluent.rest.ApplicationServer:150)
[2025-04-07 18:43:57,850] DEBUG Graceful HTTP2SessionContainer@1debb68d[size=0] (io.confluent.rest.ApplicationServer:150)
[2025-04-07 18:43:57,850] DEBUG Graceful oeje10wjc.SessionTracker@2278ff63{STARTED} (io.confluent.rest.ApplicationServer:150)
[2025-04-07 18:43:57,888] INFO Log #101:400 - - (io.confluent.kafkarest.integration.CustomLogIntegrationTest:486)
```