### PR TITLE
KNET-17072: Remove zk support for kafka-rest integration tests

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -31,8 +31,12 @@ import io.confluent.kafkarest.entities.v2.BinaryTopicProduceRequest.BinaryTopicP
 import io.confluent.kafkarest.entities.v2.CreateConsumerInstanceRequest;
 import io.confluent.kafkarest.entities.v2.CreateConsumerInstanceResponse;
 import io.confluent.kafkarest.entities.v2.PartitionOffset;
+import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -86,14 +90,21 @@ public class AuthorizationErrorTest
     Properties properties = restConfig.getAdminProperties();
     properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
     properties.put("sasl.jaas.config", createPlainLoginModule("admin", "admin-secret"));
-    for (int i = 0; i < 10; i++) {
-      try {
-        createTopic(TOPIC_NAME, 1, (short) 1, properties);
-        break;
-      } catch (Exception ignored) {
-        Thread.sleep(1000);
-      }
-    }
+    String clusterId = getClusterId();
+    String topicUrl = "/v3/clusters/" + clusterId + "/topics";
+    Response respose =
+        request(topicUrl)
+            .post(
+                Entity.entity(
+                    CreateTopicRequest.builder()
+                        .setTopicName(TOPIC_NAME)
+                        .setPartitionsCount(1)
+                        .setReplicationFactor((short) 1)
+                        .setConfigs(new ArrayList<>())
+                        .build(),
+                    MediaType.APPLICATION_JSON));
+    System.out.println(respose);
+//    createTopic(TOPIC_NAME, 1, (short) 1, properties);
   }
 
   @Override
@@ -170,10 +181,10 @@ public class AuthorizationErrorTest
   @ValueSource(strings = {"kraft"})
   public void testConsumerRequest(String quorum) {
     // test without acls
-//    verifySubscribeToTopic(true);
+    verifySubscribeToTopic(true);
     // add acls
-//    setConsumerAcls();
-//    verifySubscribeToTopic(false);
+    setConsumerAcls();
+    verifySubscribeToTopic(false);
   }
 
   private void setConsumerAcls() {
@@ -195,8 +206,7 @@ public class AuthorizationErrorTest
   }
 
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"zk"})
-  @Disabled("KNET-16782")
+  @ValueSource(strings = {"kraft"})
   public void testProducerAuthorization(String quorum) {
     BinaryTopicProduceRequest request = BinaryTopicProduceRequest.create(topicRecords);
     // test without any acls
@@ -298,7 +308,7 @@ public class AuthorizationErrorTest
     Properties adminProperties = new Properties();
     adminProperties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
     adminProperties.put("security.protocol", "SASL_PLAINTEXT");
-    adminProperties.setProperty("sasl.mechanism", "PLAIN");
+    adminProperties.put("sasl.mechanism", "PLAIN");
     adminProperties.put("sasl.jaas.config", createPlainLoginModule("admin", "admin-secret"));
     return adminProperties;
   }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -18,6 +18,7 @@ package io.confluent.kafkarest.integration;
 import static io.confluent.kafkarest.TestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME;
 import static io.confluent.kafkarest.TestUtils.assertErrorResponse;
 import static io.confluent.kafkarest.TestUtils.assertOKResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -92,7 +93,7 @@ public class AuthorizationErrorTest
     properties.put("sasl.jaas.config", createPlainLoginModule("admin", "admin-secret"));
     String clusterId = getClusterId();
     String topicUrl = "/v3/clusters/" + clusterId + "/topics";
-    Response respose =
+    Response response =
         request(topicUrl)
             .post(
                 Entity.entity(
@@ -103,8 +104,7 @@ public class AuthorizationErrorTest
                         .setConfigs(new ArrayList<>())
                         .build(),
                     MediaType.APPLICATION_JSON));
-    System.out.println(respose);
-//    createTopic(TOPIC_NAME, 1, (short) 1, properties);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -136,7 +136,7 @@ public class AuthorizationErrorTest
             (short) 1,
             false);
     brokerProps.put("broker.id", Integer.toString(i));
-    brokerProps.put("authorizer.class.name", StandardAuthorizer.class.getName());
+    brokerProps.put(ServerConfigs.AUTHORIZER_CLASS_NAME_CONFIG, StandardAuthorizer.class.getName());
     brokerProps.setProperty("super.users", "User:admin");
     brokerProps.setProperty(
         "listener.name.sasl_plaintext.plain.sasl.jaas.config",

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -55,13 +55,11 @@ import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.apache.kafka.server.config.ServerConfigs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import scala.Option;
 
-@Disabled("Until we fix KNET-16472, this test should be disabled")
 public class AuthorizationErrorTest
     extends AbstractProducerTest<BinaryTopicProduceRequest, BinaryPartitionProduceRequest> {
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -36,7 +36,6 @@ import io.confluent.kafkarest.entities.v3.CreateTopicRequest;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -152,7 +151,7 @@ public class AuthorizationErrorTest
   @Override
   protected Properties overrideKraftControllerConfig() {
     Properties props = new Properties();
-    props.setProperty(ServerConfigs.AUTHORIZER_CLASS_NAME_CONFIG, StandardAuthorizer.class.getName());
+    props.put(ServerConfigs.AUTHORIZER_CLASS_NAME_CONFIG, StandardAuthorizer.class.getName());
     // this setting allows brokers to register to Kraft controller
     props.put(StandardAuthorizer.ALLOW_EVERYONE_IF_NO_ACL_IS_FOUND_CONFIG, true);
     return props;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/AuthorizationErrorTest.java
@@ -101,7 +101,7 @@ public class AuthorizationErrorTest
                         .setConfigs(new ArrayList<>())
                         .build(),
                     MediaType.APPLICATION_JSON));
-    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
   }
 
   @Override

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -47,7 +47,6 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
 
-
     Response response = request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
 
@@ -57,7 +56,8 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
     assertEquals(1, actualClusterData.size());
     Resource.Relationship relationship = actualClusterData.get(0).getController().orElse(null);
     assertNotNull(relationship);
-    assertTrue(relationship.getRelated().startsWith(baseUrl + "/v3/clusters/" + clusterId + "/brokers/"));
+    assertTrue(
+        relationship.getRelated().startsWith(baseUrl + "/v3/clusters/" + clusterId + "/brokers/"));
 
     ListClustersResponse expected =
         ListClustersResponse.create(
@@ -117,7 +117,8 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
     ClusterData actualClusterData = actual.getValue();
     Resource.Relationship relationship = actualClusterData.getController().orElse(null);
     assertNotNull(relationship);
-    assertTrue(relationship.getRelated().startsWith(baseUrl + "/v3/clusters/" + clusterId + "/brokers/"));
+    assertTrue(
+        relationship.getRelated().startsWith(baseUrl + "/v3/clusters/" + clusterId + "/brokers/"));
 
     GetClusterResponse expected =
         GetClusterResponse.create(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -18,7 +18,10 @@ package io.confluent.kafkarest.integration.v3;
 import static io.confluent.kafkarest.TestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.kafkarest.entities.v3.ClusterData;
 import io.confluent.kafkarest.entities.v3.ClusterDataList;
 import io.confluent.kafkarest.entities.v3.GetClusterResponse;
@@ -29,7 +32,6 @@ import io.confluent.kafkarest.integration.ClusterTestHarness;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -39,14 +41,23 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
     super(/* numBrokers= */ 3, /* withSchemaRegistry= */ false);
   }
 
-  /** Only applicable for Zk because getControllerID() is non-deterministic in Kraft */
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"zk"})
-  @Disabled("KNET-16782")
+  @ValueSource(strings = {"kraft"})
   public void listClusters_returnsArrayWithOwnCluster(String quorum) {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
-    int controllerId = getControllerID();
+
+
+    Response response = request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+    ListClustersResponse actual = response.readEntity(ListClustersResponse.class);
+
+    ImmutableList<ClusterData> actualClusterData = actual.getValue().getData();
+    assertEquals(1, actualClusterData.size());
+    Resource.Relationship relationship = actualClusterData.get(0).getController().orElse(null);
+    assertNotNull(relationship);
+    assertTrue(relationship.getRelated().startsWith(baseUrl + "/v3/clusters/" + clusterId + "/brokers/"));
 
     ListClustersResponse expected =
         ListClustersResponse.create(
@@ -62,13 +73,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                                     .setResourceName("crn:///kafka=" + clusterId)
                                     .build())
                             .setClusterId(clusterId)
-                            .setController(
-                                Resource.Relationship.create(
-                                    baseUrl
-                                        + "/v3/clusters/"
-                                        + clusterId
-                                        + "/brokers/"
-                                        + controllerId))
+                            .setController(relationship)
                             .setAcls(
                                 Resource.Relationship.create(
                                     baseUrl + "/v3/clusters/" + clusterId + "/acls"))
@@ -92,22 +97,27 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                                         + "/topics/-/partitions/-/reassignment"))
                             .build()))
                 .build());
-
-    Response response = request("/v3/clusters").accept(MediaType.APPLICATION_JSON).get();
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
-
-    ListClustersResponse actual = response.readEntity(ListClustersResponse.class);
     assertEquals(expected, actual);
   }
 
-  /** Only applicable for Zk because getControllerID() is non-deterministic in Kraft */
   @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
-  @ValueSource(strings = {"zk"})
-  @Disabled("KNET-16782")
+  @ValueSource(strings = {"kraft"})
   public void getCluster_ownCluster_returnsOwnCluster(String quorum) {
     String baseUrl = restConnect;
     String clusterId = getClusterId();
-    int controllerId = getControllerID();
+
+    Response response =
+        request(String.format("/v3/clusters/%s", clusterId))
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    assertEquals(Status.OK.getStatusCode(), response.getStatus());
+
+    GetClusterResponse actual = response.readEntity(GetClusterResponse.class);
+
+    ClusterData actualClusterData = actual.getValue();
+    Resource.Relationship relationship = actualClusterData.getController().orElse(null);
+    assertNotNull(relationship);
+    assertTrue(relationship.getRelated().startsWith(baseUrl + "/v3/clusters/" + clusterId + "/brokers/"));
 
     GetClusterResponse expected =
         GetClusterResponse.create(
@@ -118,9 +128,7 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                         .setResourceName("crn:///kafka=" + clusterId)
                         .build())
                 .setClusterId(clusterId)
-                .setController(
-                    Resource.Relationship.create(
-                        baseUrl + "/v3/clusters/" + clusterId + "/brokers/" + controllerId))
+                .setController(relationship)
                 .setAcls(
                     Resource.Relationship.create(baseUrl + "/v3/clusters/" + clusterId + "/acls"))
                 .setBrokers(
@@ -141,14 +149,6 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
                             + clusterId
                             + "/topics/-/partitions/-/reassignment"))
                 .build());
-
-    Response response =
-        request(String.format("/v3/clusters/%s", clusterId))
-            .accept(MediaType.APPLICATION_JSON)
-            .get();
-    assertEquals(Status.OK.getStatusCode(), response.getStatus());
-
-    GetClusterResponse actual = response.readEntity(GetClusterResponse.class);
     assertEquals(expected, actual);
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ClustersResourceIntegrationTest.java
@@ -54,6 +54,8 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
 
     ImmutableList<ClusterData> actualClusterData = actual.getValue().getData();
     assertEquals(1, actualClusterData.size());
+    // getControllerID() is non-deterministic in Kraft,
+    // so we're relying on the returned controller for building actual object
     Resource.Relationship relationship = actualClusterData.get(0).getController().orElse(null);
     assertNotNull(relationship);
     assertTrue(
@@ -115,6 +117,8 @@ public class ClustersResourceIntegrationTest extends ClusterTestHarness {
     GetClusterResponse actual = response.readEntity(GetClusterResponse.class);
 
     ClusterData actualClusterData = actual.getValue();
+    // getControllerID() is non-deterministic in Kraft,
+    // so we're relying on the returned controller for building actual object
     Resource.Relationship relationship = actualClusterData.getController().orElse(null);
     assertNotNull(relationship);
     assertTrue(


### PR DESCRIPTION
This PR fixed several zk only tests to kraft.