### PR TITLE
cherry pick fa71840

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-rest-parent</artifactId>
-        <version>8.0.0-0</version>
+        <version>8.1.0-0</version>
     </parent>
 
     <artifactId>kafka-rest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>[8.0.0-0, 8.0.1-0)</version>
+        <version>[8.1.0-0, 8.1.1-0)</version>
     </parent>
 
     <artifactId>kafka-rest-parent</artifactId>
     <packaging>pom</packaging>
     <name>kafka-rest-parent</name>
-    <version>8.0.0-0</version>
+    <version>8.1.0-0</version>
     <organization>
         <name>Confluent, Inc.</name>
         <url>http://confluent.io</url>
@@ -48,7 +48,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
-        <io.confluent.kafka-rest.version>8.0.0-0</io.confluent.kafka-rest.version>
+        <io.confluent.kafka-rest.version>8.1.0-0</io.confluent.kafka-rest.version>
         <!-- Allow enough heap space for integration tests with Kraft -->
         <argLine>-Xmx4g -Xms2g</argLine>
     </properties>


### PR DESCRIPTION
Version is bumped by bot via [fa71840](https://github.com/confluentinc/kafka-rest/commit/fa7184019572b6a97b681b23b6372cc28a105820). We need to merge this commit to `8.0.x` to avoid merge conflicts