### PR TITLE
Add dependency on log4j-1.2-api for logredactor

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -72,6 +72,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>logredactor</artifactId>
         </dependency>


### PR DESCRIPTION
logredactor library is using log4j 1 APIs so we need to add it as a dependency