### PR TITLE
[KNET-5703] remove is_internal field

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -2343,7 +2343,6 @@ components:
           required:
             - cluster_id
             - topic_name
-            - is_internal
             - replication_factor
             - partitions_count
             - partitions
@@ -2354,8 +2353,6 @@ components:
               type: string
             topic_name:
               type: string
-            is_internal:
-              type: boolean
             replication_factor:
               type: integer
             partitions_count:
@@ -2591,7 +2588,6 @@ components:
               resource_name: 'crn:///kafka=cluster-1/topic=topic-X'
             cluster_id: 'cluster-1'
             topic_name: 'topic-X'
-            is_internal: false
             replication_factor: 3
             partitions_count: 1
             partitions:
@@ -2953,7 +2949,6 @@ components:
               resource_name: 'crn:///kafka=cluster-1/topic=topic-1'
             cluster_id: 'cluster-1'
             topic_name: 'topic-1'
-            is_internal: false
             replication_factor: 3
             partitions_count: 1
             partitions:
@@ -3582,7 +3577,6 @@ components:
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-1'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-1'
-                is_internal: false
                 replication_factor: 3
                 partitions_count: 1
                 partitions:
@@ -3597,7 +3591,6 @@ components:
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-2'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-2'
-                is_internal: true
                 replication_factor: 4
                 partitions_count: 1
                 partitions:
@@ -3612,7 +3605,6 @@ components:
                   resource_name: 'crn:///kafka=cluster-1/topic=topic-3'
                 cluster_id: 'cluster-1'
                 topic_name: 'topic-3'
-                is_internal: false
                 replication_factor: 5
                 partitions_count: 1
                 partitions:

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/entities/v3/TopicData.java
@@ -35,9 +35,6 @@ public abstract class TopicData extends Resource {
   @JsonProperty("topic_name")
   public abstract String getTopicName();
 
-  @JsonProperty("is_internal")
-  public abstract boolean isInternal();
-
   @JsonProperty("replication_factor")
   public abstract int getReplicationFactor();
 
@@ -64,7 +61,6 @@ public abstract class TopicData extends Resource {
     return builder()
         .setClusterId(topic.getClusterId())
         .setTopicName(topic.getName())
-        .setInternal(topic.isInternal())
         .setReplicationFactor(topic.getReplicationFactor())
         .setPartitionsCount(topic.getPartitions().size())
         .setAuthorizedOperations(topic.getAuthorizedOperations());
@@ -76,7 +72,6 @@ public abstract class TopicData extends Resource {
       @JsonProperty("metadata") Metadata metadata,
       @JsonProperty("cluster_id") String clusterId,
       @JsonProperty("topic_name") String topicName,
-      @JsonProperty("is_internal") boolean isInternal,
       @JsonProperty("replication_factor") int replicationFactor,
       @JsonProperty("partitions_count") int partitionsCount,
       @JsonProperty("partitions") Relationship partitions,
@@ -88,7 +83,6 @@ public abstract class TopicData extends Resource {
         .setMetadata(metadata)
         .setClusterId(clusterId)
         .setTopicName(topicName)
-        .setInternal(isInternal)
         .setReplicationFactor(replicationFactor)
         .setPartitionsCount(partitionsCount)
         .setPartitions(partitions)
@@ -106,8 +100,6 @@ public abstract class TopicData extends Resource {
     public abstract Builder setClusterId(String clusterId);
 
     public abstract Builder setTopicName(String topicName);
-
-    public abstract Builder setInternal(boolean isInternal);
 
     public abstract Builder setReplicationFactor(int replicationFactor);
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/TopicsResourceIntegrationTest.java
@@ -97,7 +97,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                     .build())
                             .setClusterId(clusterId)
                             .setTopicName(TOPIC_1)
-                            .setInternal(false)
                             .setReplicationFactor(1)
                             .setPartitionsCount(1)
                             .setPartitions(
@@ -140,7 +139,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                     .build())
                             .setClusterId(clusterId)
                             .setTopicName(TOPIC_2)
-                            .setInternal(false)
                             .setReplicationFactor(1)
                             .setPartitionsCount(1)
                             .setPartitions(
@@ -183,7 +181,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                                     .build())
                             .setClusterId(clusterId)
                             .setTopicName(TOPIC_3)
-                            .setInternal(false)
                             .setReplicationFactor(1)
                             .setPartitionsCount(1)
                             .setPartitions(
@@ -250,7 +247,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         .build())
                 .setClusterId(clusterId)
                 .setTopicName(TOPIC_1)
-                .setInternal(false)
                 .setReplicationFactor(1)
                 .setPartitionsCount(1)
                 .setPartitions(
@@ -321,7 +317,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         .build())
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
-                .setInternal(false)
                 .setReplicationFactor(1)
                 .setPartitionsCount(0)
                 .setPartitions(
@@ -389,7 +384,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         .build())
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
-                .setInternal(false)
                 .setReplicationFactor(2) // As determined by the actual replicas asignments below.
                 .setPartitionsCount(0)
                 .setPartitions(
@@ -534,7 +528,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         .build())
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
-                .setInternal(false)
                 .setReplicationFactor(0)
                 .setPartitionsCount(0)
                 .setPartitions(
@@ -596,7 +589,6 @@ public class TopicsResourceIntegrationTest extends ClusterTestHarness {
                         .build())
                 .setClusterId(clusterId)
                 .setTopicName(topicName)
-                .setInternal(false)
                 .setReplicationFactor(2)
                 .setPartitionsCount(1)
                 .setPartitions(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/TopicsResourceTest.java
@@ -339,7 +339,6 @@ public class TopicsResourceTest {
                 .build())
         .setClusterId("cluster-1")
         .setTopicName(topicName)
-        .setInternal(isInternal)
         .setReplicationFactor(replicationFactor)
         .setPartitions(
             Resource.Relationship.create(


### PR DESCRIPTION
For CCloud, internal topics are not exposed. Thus `is_internal` will always be false. It should be removed for (List|Get|Create) api calls.

This code change is covered by local test and integration tests:
```
curl -X GET http://localhost:8082/v3/clusters/5L6g3nShT-eMCtK--X86sw/topics

{"kind":"KafkaTopicList","metadata":{"self":"http://localhost:8082/v3/clusters/5L6g3nShT-eMCtK--X86sw/topics","next":null},
"data":[{"kind":"KafkaTopic","metadata":{"self":"http://localhost:8082/v3/clusters/5L6g3nShT-eMCtK--X86sw/topics/quickstart-events","resource_name":"crn:///kafka=5L6g3nShT-eMCtK--X86sw/topic=quickstart-events"},"cluster_id":"5L6g3nShT-eMCtK--X86sw","topic_name":"quickstart-events","replication_factor":1,"partitions_count":1,"partitions":{"related":"http://localhost:8082/v3/clusters/5L6g3nShT-eMCtK--X86sw/topics/quickstart-events/partitions"},"configs":{"related":"http://localhost:8082/v3/clusters/5L6g3nShT-eMCtK--X86sw/topics/quickstart-events/configs"},"partition_reassignments":{"related":"http://localhost:8082/v3/clusters/5L6g3nShT-eMCtK--X86sw/topics/quickstart-events/partitions/-/reassignment"},"authorized_operations":[]}]}
```