### PR TITLE
Temporary Kafka-rest change for v1 testing

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/AclsResource.java
@@ -255,7 +255,7 @@ public final class AclsResource {
                                     .thenComparing(AclData::getPermission))
                             .collect(Collectors.toList())));
 
-    AsyncResponses.asyncResume(asyncResponse, response);
+    AsyncResponses.asyncResume(asyncResponse, response, true);
   }
 
   public AclData toAclData(Acl acl) {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>[8.1.0-0, 8.1.1-0)</version>
+        <version>8.1.0-0</version>
     </parent>
 
     <artifactId>kafka-rest-parent</artifactId>


### PR DESCRIPTION
This change is only for making a v1 image, it throws 500 error after the ACL delete call in the `asyncResponse.resume` method.
As a delete ACL call throws that error, we map it in the rest-utils repo with this hotfix here - https://github.com/confluentinc/rest-utils/pull/588/files