### PR TITLE
[MINOR]DOCS-25908:remove incorrect doc link that is directing to cloud docs

### DIFF
--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -701,7 +701,7 @@ paths:
       summary: 'Get Consumer Group Lag Summary'
       operationId: getKafkaConsumerGroupLagSummary
       description: |-
-        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) 
 
         Return the maximum and total lag of the consumers belonging to the
         specified consumer group.


### PR DESCRIPTION
One of the sections in the CP docs is incorrectly pointing to the cloud. This PR fixes the issue.

Doc link: https://confluentinc.atlassian.net/browse/DOCS-25908

Issue doc link: https://docs.confluent.io/platform/current/kafka-rest/api.html#section/Versioning/API-Lifecycle-Policy:~:text=Get%20Consumer%20Group%20Lag%20Summary