### PR TITLE
remove bc dependency that is being merged in bc-prov

### DIFF
--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -152,11 +152,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>org.bouncycastle</groupId>
-           <artifactId>bcprov-ext-jdk18on</artifactId>
-           <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
@@ -256,7 +251,7 @@
                             <skip>true</skip>
                         </configuration>
                     </plugin>
-    
+
                     <!-- skip integration tests because they do not include smoke tests (other components have smoke tests) -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,6 @@
                 <version>${bouncycastle.jdk18.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-ext-jdk18on</artifactId>
-                <version>${bouncycastle.jdk18.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>$(hamcrest.version)</version>
@@ -196,7 +191,7 @@
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Remove deprecated library ( bcprov-ext is migrated to bcprov)
see:
https://mvnrepository.com/artifact/org.bouncycastle/bcprov-ext-jdk18on
