### PR TITLE
Fix NPE in test deserializers

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/testing/SchemaRegistryFixture.java
@@ -175,15 +175,15 @@ public final class SchemaRegistryFixture implements BeforeEachCallback, AfterEac
   }
 
   public KafkaAvroDeserializer createAvroDeserializer() {
-    return new KafkaAvroDeserializer(client);
+    return new KafkaAvroDeserializer(client, getClientConfigs());
   }
 
   public KafkaJsonSchemaDeserializer<Object> createJsonSchemaDeserializer() {
-    return new KafkaJsonSchemaDeserializer<>(client);
+    return new KafkaJsonSchemaDeserializer<>(client, getClientConfigs());
   }
 
   public KafkaProtobufDeserializer<Message> createProtobufDeserializer() {
-    return new KafkaProtobufDeserializer<>(client);
+    return new KafkaProtobufDeserializer<>(client, getClientConfigs());
   }
 
   public static Builder builder() {


### PR DESCRIPTION
## Summary
- Fix `NullPointerException` in `SchemaRegistrySaslInheritTest.produceAvroWithRawSchema` caused by uninitialized `subjectNameCache` in the schema serializer's subject name strategy
- Pass client configs to `KafkaAvroDeserializer`, `KafkaJsonSchemaDeserializer`, and `KafkaProtobufDeserializer` constructors in `SchemaRegistryFixture` so that `configure()` is called during construction
- After [this commit](https://github.com/confluentinc/schema-registry/pull/4225), the serializer library requires `configure()` to be invoked before a deserializer is used in a `KafkaConsumer`, otherwise the `ClusterResourceListener` metadata callback triggers an NPE

## Test plan
- [x] Verify `SchemaRegistrySaslInheritTest.produceAvroWithRawSchema` passes
- [x] Verify other integration tests using `createAvroDeserializer()`, `createJsonSchemaDeserializer()`, and `createProtobufDeserializer()` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)