### PR TITLE
Fix Release block on 7.6.x: drop pip install confluent-release-tools

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,7 +56,6 @@ blocks:
           commands:
             - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
             - git fetch --unshallow || true
-            - pip install -q confluent-release-tools
             - pint merge --check-all
             - . ci-tools ci-update-version
             - . ci-tools ci-push-tag


### PR DESCRIPTION
## Summary
- Drop `pip install -q confluent-release-tools` from the Release block in `.semaphore/semaphore.yml`.
- The Release block on 7.6.x fails because installing `confluent-release-tools` pulls `setuptools>=81`, which removed `pkg_resources`; `pint` imports `pkg_resources` and can't start, so `pint merge --check-all` exits before `mvn deploy`.
- `confluent-devtools` is pre-installed on the Semaphore AMI and already provides a working `pint`, per devprod guidance — so the `pip install` step is both unnecessary and the source of the regression.

## Context
- Same root cause as the 7.5.x failure (https://semaphore.ci.confluent.io/jobs/36096d32-4ade-4a96-9b86-9b4b6c7f81bc).
- 7.7.x and newer already don't do this `pip install` (they use `. sem-pint -c` from the toolbox), so only 7.5.x and 7.6.x are affected. Companion PR against 7.5.x: #1465.

## Test plan
- [ ] Merge and verify the Release block on 7.6.x reaches `mvn ... deploy` (i.e. `pint merge --check-all` passes on the pre-installed `confluent-devtools`).
- [ ] Confirm no downstream 7.6.x consumers are blocked after the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)