### PR TITLE
MINOR: align with kafka-clients package and classifier changes

### DIFF
--- a/checkstyle/import_control.xml
+++ b/checkstyle/import_control.xml
@@ -69,7 +69,7 @@
   <allow class="org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo" />
   <allow class="org.apache.kafka.common.requests.DescribeLogDirsResponse.ReplicaInfo" />
   <!-- Non-public APIs that are better imported than reimplemented -->
-  <allow class="org.apache.kafka.common.utils.AppInfoParser" />
+  <allow class="org.apache.kafka.common.utils.internals.AppInfoParser" />
   <allow class="org.apache.kafka.common.internals.KafkaFutureImpl" />
   <allow class="org.apache.kafka.common.header.internals.RecordHeader" />
 

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -138,6 +138,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-server-common</artifactId>
             <version>${kafka.version}</version>
             <classifier>test</classifier>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -151,6 +151,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry</artifactId>
             <version>${io.confluent.schema-registry.version}</version>

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/KafkaRestMetricsContext.java
@@ -17,7 +17,7 @@ package io.confluent.kafkarest;
 
 import io.confluent.rest.metrics.RestMetricsContext;
 import java.util.Map;
-import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
 
 public final class KafkaRestMetricsContext {
   /** MetricsContext Label's for use by Confluent's TelemetryReporter */

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/KafkaRestConfigTest.java
@@ -39,7 +39,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
## Summary
Align with breaking changes in the latest `kafka.version` (`8.4.0-114-ccs`):
- `AppInfoParser` moved from `org.apache.kafka.common.utils` to `org.apache.kafka.common.utils.internals`. Update the two imports and the checkstyle `import_control.xml` allow rule.
- `TestSslUtils` (used by `SslFixture`) moved from the `test` classifier of `kafka-clients` into the new `test-fixtures` classifier. Add the corresponding test dependency in `kafka-rest/pom.xml`.
- `MockFaultHandler` (pulled in transitively via `kafka.server.QuorumTestHarness`) moved from the `test` classifier of `kafka-server-common` into the new `test-fixtures` classifier. Without it, integration tests fail at setup with `NoClassDefFoundError: org/apache/kafka/server/fault/MockFaultHandler`. Add the test-fixtures dependency.

## Test plan
- [x] `mvn install -DskipTests` succeeds locally
- [x] `mvn verify -pl kafka-rest -Dit.test=ProduceActionNoSchemaIntegrationTest` passes (27/27)
- [ ] CI build is green