### PR TITLE
INC-10321: Disable javaType resolution in JSONSCHEMA consumer

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -271,6 +271,7 @@ public class KafkaConsumerManager {
         props.put(
             "value.deserializer",
             "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer");
+        props.put("json.type.allowed.packages", "");
         break;
       case PROTOBUF:
         props.put(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -176,6 +176,46 @@ public class KafkaConsumerManagerTest {
     EasyMock.verify(consumerFactory);
   }
 
+  @Test
+  public void createConsumer_jsonSchemaFormat_disablesJavaTypeResolution() {
+    // INC-10321 / KSECURITY-2716: the JSONSCHEMA consumer must be created with
+    // json.type.allowed.packages="" so KafkaJsonSchemaDeserializer refuses to resolve
+    // arbitrary classes from the schema's javaType property.
+    final Capture<Properties> consumerConfig = Capture.newInstance();
+    EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
+        .andReturn(consumer);
+    EasyMock.replay(consumerFactory);
+
+    consumerManager.createConsumer(
+        groupName, ConsumerInstanceConfig.create(EmbeddedFormat.JSONSCHEMA));
+
+    Properties props = consumerConfig.getValue();
+    assertEquals("", props.get("json.type.allowed.packages"));
+    assertEquals(
+        "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        props.get("key.deserializer"));
+    assertEquals(
+        "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        props.get("value.deserializer"));
+
+    EasyMock.verify(consumerFactory);
+  }
+
+  @Test
+  public void createConsumer_nonJsonSchemaFormat_doesNotSetJavaTypeAllowedPackages() {
+    // The new config is scoped to JSONSCHEMA only; other formats should be unaffected.
+    final Capture<Properties> consumerConfig = Capture.newInstance();
+    EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
+        .andReturn(consumer);
+    EasyMock.replay(consumerFactory);
+
+    consumerManager.createConsumer(groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
+
+    assertNull(consumerConfig.getValue().get("json.type.allowed.packages"));
+
+    EasyMock.verify(consumerFactory);
+  }
+
   /** Response should return no sooner than KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG */
   @Test
   public void testConsumerRequestTimeoutms() throws Exception {


### PR DESCRIPTION
## Summary

- Sets `json.type.allowed.packages=""` on the V2 consumer when format is `JSONSCHEMA`, so `KafkaJsonSchemaDeserializer` refuses to resolve arbitrary classes from the schema's `javaType` property (the INC-10321 / KSECURITY-2716 RCE).
- This is the permanent source-side equivalent of the build-time patch landed in `confluentinc/packaging` for the Q2 emergency CP release (packaging PRs #2400–#2407 + #2410–#2419). Once this is merged across all `.x` branches that feed CP patch releases, those `kafka-rest-build.patch` files on the `7.4.15`/`7.5.14`/…/`8.2.1` packaging branches can be removed.

Note: the empty-string value only enforces anything once the matching `schema-registry` change is released for each CP version (DGS-24199 — adds `TYPE_ALLOWED_PACKAGES` config + `checkTypeAllowed` to `AbstractKafkaJsonSchemaDeserializer`). Coordinate timing with @rayokota before declaring the fix complete for a given CP line.

Refs:
- Jira: KSECURITY-2716
- Incident: INC-10321
- Temp packaging patch (8.2.1): https://github.com/confluentinc/packaging/blob/8.2.1/cp_packaging/resources/patches/kafka-rest-build.patch

## Test plan

- [ ] Unit/integration tests pass in CI
- [ ] Manually verify: produce a JSON Schema record with a `javaType` pointing at an arbitrary class and consume via V2; deserialization should fail with "javaType resolution is disabled" rather than instantiating the class
- [ ] Confirm with @rayokota that the SR-side enforcement (DGS-24199) ships in the same CP version where this is included, otherwise the config is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)