### PR TITLE
KNET-19593: tag produce_api error and rate-limited metrics with http_status_code

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -42,6 +42,7 @@ import io.confluent.kafkarest.requestlog.CustomLog.ProduceRecordErrorCounter;
 import io.confluent.kafkarest.requestlog.CustomLogRequestAttributes;
 import io.confluent.kafkarest.resources.v3.V3ResourcesModule.ProduceResponseThreadPool;
 import io.confluent.kafkarest.response.JsonStream;
+import io.confluent.kafkarest.response.StreamingResponse;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
 import jakarta.inject.Inject;
@@ -59,6 +60,7 @@ import jakarta.ws.rs.core.MediaType;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -226,7 +228,7 @@ public final class ProduceAction {
             (result, error) -> {
               if (error != null) {
                 long latency = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestStartNs);
-                recordErrorMetrics(metrics, latency);
+                recordErrorMetrics(metrics, latency, httpStatusCodeFromError(error));
                 throw new StacklessCompletionException(error);
               }
               return result;
@@ -329,8 +331,8 @@ public final class ProduceAction {
     metrics.recordRequestLatency(latencyMs);
   }
 
-  private void recordErrorMetrics(ProducerMetrics metrics, long latencyMs) {
-    metrics.recordError();
+  private void recordErrorMetrics(ProducerMetrics metrics, long latencyMs, int httpStatusCode) {
+    metrics.recordError(httpStatusCode);
     metrics.recordRequestLatency(latencyMs);
   }
 
@@ -342,5 +344,15 @@ public final class ProduceAction {
     metrics.recordRequest();
     // record request size
     metrics.recordRequestSize(size);
+  }
+
+  // Resolve an HTTP status code for the throwable in the same way StreamingResponse does for
+  // the response — keeps the metric's http_status_code tag consistent with what the client sees.
+  private static int httpStatusCodeFromError(Throwable error) {
+    Throwable cause = error;
+    if (error instanceof CompletionException && error.getCause() != null) {
+      cause = error.getCause();
+    }
+    return StreamingResponse.toErrorResponse(cause).getErrorCode();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceAction.java
@@ -42,7 +42,6 @@ import io.confluent.kafkarest.requestlog.CustomLog.ProduceRecordErrorCounter;
 import io.confluent.kafkarest.requestlog.CustomLogRequestAttributes;
 import io.confluent.kafkarest.resources.v3.V3ResourcesModule.ProduceResponseThreadPool;
 import io.confluent.kafkarest.response.JsonStream;
-import io.confluent.kafkarest.response.StreamingResponse;
 import io.confluent.kafkarest.response.StreamingResponseFactory;
 import io.confluent.rest.annotations.PerformanceMetric;
 import jakarta.inject.Inject;
@@ -60,7 +59,6 @@ import jakarta.ws.rs.core.MediaType;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -228,7 +226,8 @@ public final class ProduceAction {
             (result, error) -> {
               if (error != null) {
                 long latency = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestStartNs);
-                recordErrorMetrics(metrics, latency, httpStatusCodeFromError(error));
+                recordErrorMetrics(
+                    metrics, latency, ProduceMetricErrorCodes.httpStatusCodeFromError(error));
                 throw new StacklessCompletionException(error);
               }
               return result;
@@ -344,15 +343,5 @@ public final class ProduceAction {
     metrics.recordRequest();
     // record request size
     metrics.recordRequestSize(size);
-  }
-
-  // Resolve an HTTP status code for the throwable in the same way StreamingResponse does for
-  // the response — keeps the metric's http_status_code tag consistent with what the client sees.
-  private static int httpStatusCodeFromError(Throwable error) {
-    Throwable cause = error;
-    if (error instanceof CompletionException && error.getCause() != null) {
-      cause = error.getCause();
-    }
-    return StreamingResponse.toErrorResponse(cause).getErrorCode();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceBatchAction.java
@@ -261,7 +261,7 @@ public final class ProduceBatchAction {
               (result, error) -> {
                 if (error != null) {
                   long latency = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestStartNs);
-                  recordErrorMetrics(metrics, latency);
+                  recordErrorMetrics(metrics, latency, httpStatusCodeFromError(error));
                   throw new StacklessCompletionException(error);
                 }
                 return result;
@@ -392,8 +392,8 @@ public final class ProduceBatchAction {
     metrics.recordRequestLatency(latencyMs);
   }
 
-  private void recordErrorMetrics(ProducerMetrics metrics, long latencyMs) {
-    metrics.recordError();
+  private void recordErrorMetrics(ProducerMetrics metrics, long latencyMs, int httpStatusCode) {
+    metrics.recordError(httpStatusCode);
     metrics.recordRequestLatency(latencyMs);
   }
 
@@ -405,5 +405,15 @@ public final class ProduceBatchAction {
     metrics.recordRequest();
     // record request size
     metrics.recordRequestSize(size);
+  }
+
+  // Resolve an HTTP status code for the throwable in the same way StreamingResponse does for
+  // the response — keeps the metric's http_status_code tag consistent with what the client sees.
+  private static int httpStatusCodeFromError(Throwable error) {
+    Throwable cause = error;
+    if (error instanceof CompletionException && error.getCause() != null) {
+      cause = error.getCause();
+    }
+    return StreamingResponse.toErrorResponse(cause).getErrorCode();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceBatchAction.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceBatchAction.java
@@ -261,7 +261,8 @@ public final class ProduceBatchAction {
               (result, error) -> {
                 if (error != null) {
                   long latency = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestStartNs);
-                  recordErrorMetrics(metrics, latency, httpStatusCodeFromError(error));
+                  recordErrorMetrics(
+                      metrics, latency, ProduceMetricErrorCodes.httpStatusCodeFromError(error));
                   throw new StacklessCompletionException(error);
                 }
                 return result;
@@ -405,15 +406,5 @@ public final class ProduceBatchAction {
     metrics.recordRequest();
     // record request size
     metrics.recordRequestSize(size);
-  }
-
-  // Resolve an HTTP status code for the throwable in the same way StreamingResponse does for
-  // the response — keeps the metric's http_status_code tag consistent with what the client sees.
-  private static int httpStatusCodeFromError(Throwable error) {
-    Throwable cause = error;
-    if (error instanceof CompletionException && error.getCause() != null) {
-      cause = error.getCause();
-    }
-    return StreamingResponse.toErrorResponse(cause).getErrorCode();
   }
 }

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceMetricErrorCodes.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProduceMetricErrorCodes.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafkarest.resources.v3;
+
+import io.confluent.kafkarest.response.StreamingResponse;
+import java.util.concurrent.CompletionException;
+
+final class ProduceMetricErrorCodes {
+
+  private ProduceMetricErrorCodes() {}
+
+  /**
+   * Resolve an HTTP status code for the throwable in the same way StreamingResponse does for the
+   * response, so the produce-api metric's http_status_code tag stays consistent with what the
+   * client actually sees. Unwraps a single layer of CompletionException to match how
+   * StreamingResponse itself handles errors handed off from the CompletableFuture chain.
+   */
+  static int httpStatusCodeFromError(Throwable error) {
+    Throwable cause = error;
+    if (error instanceof CompletionException && error.getCause() != null) {
+      cause = error.getCause();
+    }
+    return StreamingResponse.toErrorResponse(cause).getErrorCode();
+  }
+}

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
@@ -18,8 +18,11 @@ package io.confluent.kafkarest.resources.v3;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafkarest.KafkaRestConfig;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -43,6 +46,19 @@ final class ProducerMetrics {
 
   private static final String GROUP_NAME = "produce-api-metrics";
   public static final long EXPIRY_SECONDS = TimeUnit.HOURS.toSeconds(1);
+
+  // KNET-19593: the produce_request_error 5xx and request_error_rate 429 monitors filter on
+  // http_status_code, but the error and rate-limited metrics never carried that tag, so the
+  // queries never matched any series. Tag both metrics with bucketed status codes so the
+  // existing monitor queries (http_status_code=~"5xx|unknown", http_status_code="429") work.
+  @VisibleForTesting static final String HTTP_STATUS_CODE_TAG = "http_status_code";
+  @VisibleForTesting static final String STATUS_CODE_BUCKET_4XX = "4xx";
+  @VisibleForTesting static final String STATUS_CODE_BUCKET_5XX = "5xx";
+  @VisibleForTesting static final String STATUS_CODE_BUCKET_UNKNOWN = "unknown";
+  @VisibleForTesting static final String STATUS_CODE_BUCKET_429 = "429";
+
+  private static final List<String> ERROR_STATUS_CODE_BUCKETS =
+      ImmutableList.of(STATUS_CODE_BUCKET_4XX, STATUS_CODE_BUCKET_5XX, STATUS_CODE_BUCKET_UNKNOWN);
 
   /*
    * Rate, Average and Percentile metrics use underlying SampledStat and are therefore over a window
@@ -108,7 +124,9 @@ final class ProducerMetrics {
   private final String requestSensorName;
   private final String requestSizeSensorName;
   private final String responseSensorName;
-  private final String recordErrorSensorName;
+  // Per-status-code-bucket sensor names. Each entry is keyed by an entry of
+  // ERROR_STATUS_CODE_BUCKETS and points at a sensor tagged with that http_status_code value.
+  private final Map<String, String> recordErrorSensorNames;
   private final String recordRateLimitedSensorName;
   private final String requestLatencySensorName;
 
@@ -128,15 +146,48 @@ final class ProducerMetrics {
     this.metrics = requireNonNull(config.getMetrics());
     this.jmxPrefix = config.getString(KafkaRestConfig.METRICS_JMX_PREFIX_CONFIG);
     String sensorNamePrefix = jmxPrefix + ":" + GROUP_NAME + ":";
-    this.recordErrorSensorName = sensorNamePrefix + RECORD_ERROR_SENSOR_NAME + sensorTags;
+    this.recordErrorSensorNames = new HashMap<>();
+    for (String bucket : ERROR_STATUS_CODE_BUCKETS) {
+      this.recordErrorSensorNames.put(
+          bucket,
+          sensorNamePrefix + RECORD_ERROR_SENSOR_NAME + bucketSensorTagSuffix(sensorTags, bucket));
+    }
     this.recordRateLimitedSensorName =
-        sensorNamePrefix + RECORD_RATE_LIMITED_SENSOR_NAME + sensorTags;
+        sensorNamePrefix
+            + RECORD_RATE_LIMITED_SENSOR_NAME
+            + bucketSensorTagSuffix(sensorTags, STATUS_CODE_BUCKET_429);
     this.requestSensorName = sensorNamePrefix + REQUEST_SENSOR_NAME + sensorTags;
     this.requestLatencySensorName = sensorNamePrefix + REQUEST_LATENCY_SENSOR_NAME + sensorTags;
     this.requestSizeSensorName = sensorNamePrefix + REQUEST_SIZE_SENSOR_NAME + sensorTags;
     this.responseSensorName = sensorNamePrefix + RESPONSE_SENSOR_NAME + sensorTags;
 
     setupSensors(sortedMetricsTags, sensorTags);
+  }
+
+  // Build the sensor-tag suffix for a given http_status_code bucket. http_status_code sorts
+  // before "tenant" alphabetically, so the bucket value goes first to match how MetricName
+  // tags are ordered downstream.
+  private static String bucketSensorTagSuffix(String baseSensorTags, String bucket) {
+    return ":" + bucket + baseSensorTags;
+  }
+
+  private static Map<String, String> tagsWithStatusCode(
+      Map<String, String> metricsTags, String bucket) {
+    Map<String, String> tagsWithStatus = new TreeMap<>(metricsTags);
+    tagsWithStatus.put(HTTP_STATUS_CODE_TAG, bucket);
+    return tagsWithStatus;
+  }
+
+  // Map an HTTP status code to one of the buckets used in monitor queries.
+  @VisibleForTesting
+  static String httpStatusCodeBucket(int httpStatusCode) {
+    if (httpStatusCode >= 500 && httpStatusCode < 600) {
+      return STATUS_CODE_BUCKET_5XX;
+    }
+    if (httpStatusCode >= 400 && httpStatusCode < 500) {
+      return STATUS_CODE_BUCKET_4XX;
+    }
+    return STATUS_CODE_BUCKET_UNKNOWN;
   }
 
   private void setupSensors(Map<String, String> metricsTags, String sensorTags) {
@@ -194,31 +245,39 @@ final class ProducerMetrics {
   }
 
   private void setupRecordErrorSensor(Map<String, String> metricsTags, String sensorTags) {
-    Sensor recordErrorSensor = createSensor(RECORD_ERROR_SENSOR_NAME, sensorTags);
-    addRate(
-        recordErrorSensor,
-        RECORD_ERROR_RATE_METRIC_NAME,
-        RECORD_ERROR_RATE_METRIC_DOC,
-        metricsTags);
-    addWindowedCount(
-        recordErrorSensor,
-        RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME,
-        RECORD_ERROR_COUNT_WINDOWED_METRIC_DOC,
-        metricsTags);
+    for (String bucket : ERROR_STATUS_CODE_BUCKETS) {
+      Sensor recordErrorSensor =
+          createSensor(RECORD_ERROR_SENSOR_NAME, bucketSensorTagSuffix(sensorTags, bucket));
+      Map<String, String> bucketTags = tagsWithStatusCode(metricsTags, bucket);
+      addRate(
+          recordErrorSensor,
+          RECORD_ERROR_RATE_METRIC_NAME,
+          RECORD_ERROR_RATE_METRIC_DOC,
+          bucketTags);
+      addWindowedCount(
+          recordErrorSensor,
+          RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME,
+          RECORD_ERROR_COUNT_WINDOWED_METRIC_DOC,
+          bucketTags);
+    }
   }
 
   private void setupRecordRateLimitedSensor(Map<String, String> metricsTags, String sensorTags) {
-    Sensor recordRateLimitedSensor = createSensor(RECORD_RATE_LIMITED_SENSOR_NAME, sensorTags);
+    Sensor recordRateLimitedSensor =
+        createSensor(
+            RECORD_RATE_LIMITED_SENSOR_NAME,
+            bucketSensorTagSuffix(sensorTags, STATUS_CODE_BUCKET_429));
+    Map<String, String> rateLimitedTags = tagsWithStatusCode(metricsTags, STATUS_CODE_BUCKET_429);
     addRate(
         recordRateLimitedSensor,
         RECORD_RATE_LIMITED_RATE_METRIC_NAME,
         RECORD_RATE_LIMITED_RATE_METRIC_DOC,
-        metricsTags);
+        rateLimitedTags);
     addWindowedCount(
         recordRateLimitedSensor,
         RECORD_RATE_LIMITED_COUNT_WINDOWED_METRIC_NAME,
         RECORD_RATE_LIMITED_COUNT_WINDOWED_METRIC_DOC,
-        metricsTags);
+        rateLimitedTags);
   }
 
   private void setupRequestLatencySensor(Map<String, String> metricsTags, String sensorTags) {
@@ -301,8 +360,11 @@ final class ProducerMetrics {
     recordMetric(requestLatencySensorName, valueMs);
   }
 
-  void recordError() {
-    recordMetric(recordErrorSensorName, 1.0);
+  void recordError(int httpStatusCode) {
+    String sensorName = recordErrorSensorNames.get(httpStatusCodeBucket(httpStatusCode));
+    if (sensorName != null) {
+      recordMetric(sensorName, 1.0);
+    }
   }
 
   void recordRateLimited() {

--- a/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/resources/v3/ProducerMetrics.java
@@ -361,10 +361,12 @@ final class ProducerMetrics {
   }
 
   void recordError(int httpStatusCode) {
-    String sensorName = recordErrorSensorNames.get(httpStatusCodeBucket(httpStatusCode));
-    if (sensorName != null) {
-      recordMetric(sensorName, 1.0);
-    }
+    String bucket = httpStatusCodeBucket(httpStatusCode);
+    String sensorName =
+        requireNonNull(
+            recordErrorSensorNames.get(bucket),
+            () -> "No error sensor registered for http_status_code bucket " + bucket);
+    recordMetric(sensorName, 1.0);
   }
 
   void recordRateLimited() {

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
@@ -27,8 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafkarest.KafkaRestConfig;
 import io.confluent.rest.RestConfig;
 import java.lang.management.ManagementFactory;
-import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -99,43 +97,53 @@ public class ProducerMetricsTest {
     LongStream.range(0L, 10L).forEach(producerMetrics::recordRequestLatency);
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
+    // Latency metrics live on the base MBean (no http_status_code tag).
+    ObjectName baseBean = new ObjectName("kafka.rest:type=produce-api-metrics,tag=value");
 
     for (String metric : avgMetrics) {
-      assertEquals(4.5, mBeanServer.getAttribute(beanNames.iterator().next(), metric));
+      assertEquals(4.5, mBeanServer.getAttribute(baseBean, metric));
     }
   }
 
   @Test
   public void testRateMetrics() throws Exception {
-    String[] rateMetrics =
-        new String[] {
-          ProducerMetrics.RECORD_ERROR_RATE_METRIC_NAME,
-          ProducerMetrics.REQUEST_RATE_METRIC_NAME,
-          ProducerMetrics.RESPONSE_RATE_METRIC_NAME
-        };
-
     IntStream.range(0, 30)
         .forEach(
             n -> {
-              producerMetrics.recordError();
+              producerMetrics.recordError(500);
               producerMetrics.recordRateLimited();
               producerMetrics.recordRequest();
               producerMetrics.recordResponse();
             });
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
 
-    // rate() uses the 30 second window we defined when creating the Metrics here so one per second
-    // is correct
-    for (String metric : rateMetrics) {
-      assertThat(
-          (Double) mBeanServer.getAttribute(beanNames.iterator().next(), metric),
-          closeTo(1.0, 0.01));
-    }
+    // request/response rate live on the base MBean (no http_status_code tag)
+    ObjectName baseBean = new ObjectName("kafka.rest:type=produce-api-metrics,tag=value");
+    assertThat(
+        (Double) mBeanServer.getAttribute(baseBean, ProducerMetrics.REQUEST_RATE_METRIC_NAME),
+        closeTo(1.0, 0.01));
+    assertThat(
+        (Double) mBeanServer.getAttribute(baseBean, ProducerMetrics.RESPONSE_RATE_METRIC_NAME),
+        closeTo(1.0, 0.01));
+
+    // error rate lives on the per-status-code MBean — we recorded 500s so only the 5xx bean gets
+    // increments; the 4xx and unknown beans should report ~0.
+    ObjectName error5xxBean =
+        new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=5xx,tag=value");
+    assertThat(
+        (Double)
+            mBeanServer.getAttribute(error5xxBean, ProducerMetrics.RECORD_ERROR_RATE_METRIC_NAME),
+        closeTo(1.0, 0.01));
+
+    // rate-limited rate lives on the 429 MBean
+    ObjectName rateLimited429Bean =
+        new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=429,tag=value");
+    assertThat(
+        (Double)
+            mBeanServer.getAttribute(
+                rateLimited429Bean, ProducerMetrics.RECORD_RATE_LIMITED_RATE_METRIC_NAME),
+        closeTo(1.0, 0.01));
   }
 
   @Test
@@ -145,11 +153,10 @@ public class ProducerMetricsTest {
     LongStream.range(0L, 10L).forEach(producerMetrics::recordRequestLatency);
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
+    ObjectName baseBean = new ObjectName("kafka.rest:type=produce-api-metrics,tag=value");
 
     for (String metric : maxMetrics) {
-      assertEquals(9.0, mBeanServer.getAttribute(beanNames.iterator().next(), metric));
+      assertEquals(9.0, mBeanServer.getAttribute(baseBean, metric));
     }
   }
 
@@ -165,39 +172,105 @@ public class ProducerMetricsTest {
     LongStream.range(0L, 1000L).forEach(producerMetrics::recordRequestLatency);
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
+    ObjectName baseBean = new ObjectName("kafka.rest:type=produce-api-metrics,tag=value");
 
     for (String metric : percentileMetrics) {
-      assertEquals(9.0, mBeanServer.getAttribute(beanNames.iterator().next(), metric));
+      assertEquals(9.0, mBeanServer.getAttribute(baseBean, metric));
     }
   }
 
   @Test
   public void testWindowedCountMetrics() throws Exception {
-    String[] maxMetrics =
-        new String[] {
-          ProducerMetrics.REQUEST_COUNT_WINDOWED_METRIC_NAME,
-          ProducerMetrics.RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME,
-          ProducerMetrics.RESPONSE_COUNT_WINDOWED_METRIC_NAME
-        };
-
     IntStream.range(0, 10)
         .forEach(
             n -> {
               producerMetrics.recordRequest();
-              producerMetrics.recordError();
+              producerMetrics.recordError(500);
               producerMetrics.recordRateLimited();
               producerMetrics.recordResponse();
             });
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
 
-    for (String metric : maxMetrics) {
-      assertEquals(10.0, mBeanServer.getAttribute(beanNames.iterator().next(), metric));
-    }
+    ObjectName baseBean = new ObjectName("kafka.rest:type=produce-api-metrics,tag=value");
+    assertEquals(
+        10.0,
+        mBeanServer.getAttribute(baseBean, ProducerMetrics.REQUEST_COUNT_WINDOWED_METRIC_NAME));
+    assertEquals(
+        10.0,
+        mBeanServer.getAttribute(baseBean, ProducerMetrics.RESPONSE_COUNT_WINDOWED_METRIC_NAME));
+
+    ObjectName error5xxBean =
+        new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=5xx,tag=value");
+    assertEquals(
+        10.0,
+        mBeanServer.getAttribute(
+            error5xxBean, ProducerMetrics.RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME));
+
+    // 4xx and unknown buckets exist but were not incremented in this test
+    ObjectName error4xxBean =
+        new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=4xx,tag=value");
+    assertEquals(
+        0.0,
+        mBeanServer.getAttribute(
+            error4xxBean, ProducerMetrics.RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME));
+
+    ObjectName rateLimited429Bean =
+        new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=429,tag=value");
+    assertEquals(
+        10.0,
+        mBeanServer.getAttribute(
+            rateLimited429Bean, ProducerMetrics.RECORD_RATE_LIMITED_COUNT_WINDOWED_METRIC_NAME));
+  }
+
+  @Test
+  public void testRecordErrorBucketing() throws Exception {
+    // 4xx (other than 429) routes to the 4xx bucket; 5xx routes to 5xx; codes outside 400-599
+    // (e.g. 0 = no response code) route to the "unknown" bucket.
+    producerMetrics.recordError(400);
+    producerMetrics.recordError(404);
+    producerMetrics.recordError(429);
+    producerMetrics.recordError(500);
+    producerMetrics.recordError(503);
+    producerMetrics.recordError(0);
+    producerMetrics.recordError(200);
+
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+    // 400, 404, 429 → 4xx bucket (3 increments)
+    assertEquals(
+        3.0,
+        mBeanServer.getAttribute(
+            new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=4xx,tag=value"),
+            ProducerMetrics.RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME));
+    // 500, 503 → 5xx bucket (2 increments)
+    assertEquals(
+        2.0,
+        mBeanServer.getAttribute(
+            new ObjectName("kafka.rest:type=produce-api-metrics,http_status_code=5xx,tag=value"),
+            ProducerMetrics.RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME));
+    // 0, 200 → unknown bucket (2 increments)
+    assertEquals(
+        2.0,
+        mBeanServer.getAttribute(
+            new ObjectName(
+                "kafka.rest:type=produce-api-metrics,http_status_code=unknown,tag=value"),
+            ProducerMetrics.RECORD_ERROR_COUNT_WINDOWED_METRIC_NAME));
+  }
+
+  @Test
+  public void testHttpStatusCodeBucketing() {
+    assertEquals(ProducerMetrics.STATUS_CODE_BUCKET_4XX, ProducerMetrics.httpStatusCodeBucket(400));
+    assertEquals(ProducerMetrics.STATUS_CODE_BUCKET_4XX, ProducerMetrics.httpStatusCodeBucket(429));
+    assertEquals(ProducerMetrics.STATUS_CODE_BUCKET_4XX, ProducerMetrics.httpStatusCodeBucket(499));
+    assertEquals(ProducerMetrics.STATUS_CODE_BUCKET_5XX, ProducerMetrics.httpStatusCodeBucket(500));
+    assertEquals(ProducerMetrics.STATUS_CODE_BUCKET_5XX, ProducerMetrics.httpStatusCodeBucket(599));
+    assertEquals(
+        ProducerMetrics.STATUS_CODE_BUCKET_UNKNOWN, ProducerMetrics.httpStatusCodeBucket(200));
+    assertEquals(
+        ProducerMetrics.STATUS_CODE_BUCKET_UNKNOWN, ProducerMetrics.httpStatusCodeBucket(600));
+    assertEquals(
+        ProducerMetrics.STATUS_CODE_BUCKET_UNKNOWN, ProducerMetrics.httpStatusCodeBucket(0));
   }
 
   @Test
@@ -205,23 +278,25 @@ public class ProducerMetricsTest {
     LongStream.iterate(1L, identity()).limit(30).forEach(producerMetrics::recordRequestSize);
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
+    ObjectName baseBean = new ObjectName("kafka.rest:type=produce-api-metrics,tag=value");
 
-    assertEquals(30.0, mBeanServer.getAttribute(beanNames.iterator().next(), "request-byte-total"));
+    assertEquals(30.0, mBeanServer.getAttribute(baseBean, "request-byte-total"));
     // Time window is 30000ms, so this is one request per second across the window.
     assertThat(
-        (Double) mBeanServer.getAttribute(beanNames.iterator().next(), "request-byte-rate"),
-        closeTo(1.0, 0.01));
+        (Double) mBeanServer.getAttribute(baseBean, "request-byte-rate"), closeTo(1.0, 0.01));
   }
 
   @Test
   public void testTenantTag() throws Exception {
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    // After KNET-19593 the producer metrics produce one base MBean (request/response/latency)
+    // plus per-status-code MBeans for error (4xx/5xx/unknown) and rate-limited (429). Every
+    // bean must carry the tenant tag.
     Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(1, beanNames.size());
-    String tenantId = beanNames.stream().iterator().next().getKeyPropertyList().get("tag");
-    assertEquals("value", tenantId);
+    assertEquals(5, beanNames.size());
+    for (ObjectName beanName : beanNames) {
+      assertEquals("value", beanName.getKeyPropertyList().get("tag"));
+    }
   }
 
   @Test
@@ -235,18 +310,6 @@ public class ProducerMetricsTest {
     producerMetrics2.recordRequest();
 
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> beanNames = mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null);
-    assertEquals(2, beanNames.size());
-    Iterator<ObjectName> i = beanNames.stream().iterator();
-    String tenantId = i.next().getKeyPropertyList().get("tag");
-
-    Hashtable<String, String> object2 = i.next().getKeyPropertyList();
-    String tenantId2 = object2.get("tag");
-    String otherValue2 = object2.get("otherTag");
-
-    assertEquals("value", tenantId);
-    assertEquals("value2", tenantId2);
-    assertEquals("otherValue2", otherValue2);
 
     assertEquals(
         1.0,
@@ -273,10 +336,6 @@ public class ProducerMetricsTest {
         mBeanServer.getAttribute(
             new ObjectName("kafka.rest:type=produce-api-metrics,otherTag=otherValue2,tag=value2"),
             "request-count-windowed"));
-
-    mBeanServer.unregisterMBean(new ObjectName("kafka.rest:type=produce-api-metrics,tag=value"));
-    mBeanServer.unregisterMBean(
-        new ObjectName("kafka.rest:type=produce-api-metrics," + "otherTag=otherValue2,tag=value2"));
   }
 
   @Test
@@ -325,28 +384,47 @@ public class ProducerMetricsTest {
 
   @Test
   public void test_recordErrorSensor_hasCorrectMetricObjectTypeSetup() {
-    {
-      MetricName name = producerMetrics.getMetricName("record-error-rate", "", tags);
-      KafkaMetric metric = config.getMetrics().metric(name);
-      assertTrue(metric.measurable() instanceof Rate);
-    }
-    {
-      MetricName name = producerMetrics.getMetricName("error-count-windowed", "", tags);
-      KafkaMetric metric = config.getMetrics().metric(name);
-      assertTrue(metric.measurable() instanceof WindowedCount);
+    // Error metrics are registered once per http_status_code bucket (4xx, 5xx, unknown).
+    for (String bucket :
+        new String[] {
+          ProducerMetrics.STATUS_CODE_BUCKET_4XX,
+          ProducerMetrics.STATUS_CODE_BUCKET_5XX,
+          ProducerMetrics.STATUS_CODE_BUCKET_UNKNOWN
+        }) {
+      Map<String, String> tagsWithStatus =
+          ImmutableMap.<String, String>builder()
+              .putAll(tags)
+              .put(ProducerMetrics.HTTP_STATUS_CODE_TAG, bucket)
+              .build();
+      {
+        MetricName name = producerMetrics.getMetricName("record-error-rate", "", tagsWithStatus);
+        KafkaMetric metric = config.getMetrics().metric(name);
+        assertTrue(metric.measurable() instanceof Rate);
+      }
+      {
+        MetricName name = producerMetrics.getMetricName("error-count-windowed", "", tagsWithStatus);
+        KafkaMetric metric = config.getMetrics().metric(name);
+        assertTrue(metric.measurable() instanceof WindowedCount);
+      }
     }
   }
 
   @Test
   public void test_recordRateLimitedSensor_hasCorrectMetricObjectTypeSetup() {
+    Map<String, String> tagsWithStatus =
+        ImmutableMap.<String, String>builder()
+            .putAll(tags)
+            .put(ProducerMetrics.HTTP_STATUS_CODE_TAG, ProducerMetrics.STATUS_CODE_BUCKET_429)
+            .build();
     {
-      MetricName name = producerMetrics.getMetricName("record-rate-limited-rate", "", tags);
+      MetricName name =
+          producerMetrics.getMetricName("record-rate-limited-rate", "", tagsWithStatus);
       KafkaMetric metric = config.getMetrics().metric(name);
       assertTrue(metric.measurable() instanceof Rate);
     }
     {
       MetricName name =
-          producerMetrics.getMetricName("record-rate-limited-count-windowed", "", tags);
+          producerMetrics.getMetricName("record-rate-limited-count-windowed", "", tagsWithStatus);
       KafkaMetric metric = config.getMetrics().metric(name);
       assertTrue(metric.measurable() instanceof WindowedCount);
     }

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/resources/v3/ProducerMetricsTest.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -88,6 +89,23 @@ public class ProducerMetricsTest {
     config.setMetrics(metrics);
 
     producerMetrics = new ProducerMetrics(config, tags);
+  }
+
+  // ProducerMetrics now registers one MBean per http_status_code bucket (and one base bean), so
+  // each test creates multiple beans on the platform MBeanServer. Without explicit cleanup the
+  // beans leak across tests and risk InstanceAlreadyExistsException on re-registration or flaky
+  // queryNames() counts in tests that check bean cardinality.
+  @AfterEach
+  public void tearDown() throws Exception {
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    for (ObjectName beanName :
+        mBeanServer.queryNames(new ObjectName(METRICS_SEARCH_STRING), null)) {
+      try {
+        mBeanServer.unregisterMBean(beanName);
+      } catch (InstanceNotFoundException ignored) {
+        // already gone — fine
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two kafka-rest produce monitors filter on `http_status_code` —
`kafka_rest-produce_request_error_rate_5xx` queries
`{http_status_code=~"5xx|unknown"}` and `kafka_rest-request_error_rate_429`
queries `{http_status_code="429"}` — but the underlying
`kafka_rest_produce_api_error_count_windowed_delta_total` and
`kafka_rest_produce_api_record_rate_limited_count_windowed_delta_total`
metrics never carried that tag. The queries returned no data: the 5xx
monitor was placeholdered to `vector(0)` and **INC-9115** surfaced when
the 429 alert failed to page during a real rate-limit event.

This PR tags both metrics with a bucketed HTTP status code so the existing
monitor queries finally match data.

## What changed

### `ProducerMetrics`
- Adds `http_status_code` to the error and rate-limited sensors.
- Error sensor is registered once per bucket — `4xx`, `5xx`, `unknown` —
  each tagged with the bucket value. Bounded cardinality (3 buckets per
  tenant).
- Rate-limited sensor has `http_status_code="429"` baked into its tag set
  (rate-limit responses are always 429).
- New `recordError(int httpStatusCode)` replaces the no-arg
  `recordError()`. `recordRateLimited()` keeps its existing call shape;
  the 429 tag is internal to the sensor.
- New `httpStatusCodeBucket(int)` helper: `400-499 → "4xx"`,
  `500-599 → "5xx"`, else `"unknown"`. `@VisibleForTesting`.

### `ProduceAction` / `ProduceBatchAction`
- The throwable's HTTP status is resolved via
  `StreamingResponse.toErrorResponse(...).getErrorCode()` — the **same**
  mapper that produces the response sent back to the client — so the
  metric tag is guaranteed to match what the user sees.
- A small `httpStatusCodeFromError(Throwable)` helper unwraps
  `CompletionException` (matching the existing pattern in
  `ProduceBatchAction#toErrorEntryForException`) before mapping.

## Why this works

The kafka metrics library bakes tags into `MetricName` at registration
time, not at record time — so per-tag-value emission requires a sensor
per value. The fix registers one sensor per bucket and routes
`recordError(code)` to the right sensor based on the bucket. The label
set ends up matching the monitor queries exactly:

```
kafka_rest_produce_api_error_count_windowed_delta_total{
  tenant="lkc-xyz",
  http_status_code="5xx"
}
```

vs. the existing monitor:
```
{http_status_code=~"5xx|unknown"}
```

Because the bucket strings are the same ones the monitors already use,
no monitor changes ship with this PR — they're a separate follow-up in
`cc-terraform-monitoring` (re-enable the `vector(0)` placeholder query
in `monitor-kafka_rest-produce_request_error_count_5xx.tf`).

## Why the tag never existed

Git history (`git log -S http_status -- kafka-rest/.../v3/`) shows the
produce_api metrics were never tagged with `http_status_code`. The
monitor queries were speculatively written assuming a tag the metric
didn't carry — most likely a copy-paste from the jersey monitors, where
rest-utils' `MetricsListener` does emit `http_status_code` automatically.
This PR introduces the tag for the first time.

## Backwards compatibility

- Adding a label changes the Prometheus series identity, so the **old**
  series stops emitting and **new** series start. Aggregating queries
  (`sum`, `sum by (tenant)`) are unaffected; queries that match exact
  label sets across metrics could be affected, but I don't see any in
  the kafka-rest dashboards.
- `recordError()`'s signature change is package-private — only callers
  were `ProduceAction` and `ProduceBatchAction`, both updated.
- The legacy 3-arg `ProducerMetrics(KafkaRestConfig, Time, Map)`
  constructor is preserved (it's the one `ce-kafka-rest`'s
  `CloudProducerMetricsFactory` calls), so cloud builds pick up the fix
  via a routine dep bump.

## Verification

- `mvn -pl kafka-rest test-compile`: checkstyle clean, spotless clean,
  compile clean.
- `mvn -pl kafka-rest test
  -Dtest='ProducerMetricsTest,ProduceActionTest,ProduceBatchActionTest'`:
  **39/39 pass** (16 + 8 + 15).

## Test plan

- [x] Unit tests for bucketing logic (`testHttpStatusCodeBucketing`).
- [x] Unit test routes `400/404/429/500/503/0/200` and asserts the right
  bucket bean is incremented (`testRecordErrorBucketing`).
- [x] Updated existing rate / windowed-count tests to target the right
  MBean per tag set.
- [ ] After roll-out: confirm
  `kafka_rest_produce_api_error_count_windowed_delta_total{http_status_code!=""}`
  shows non-zero in stag/prod Grafana.
- [ ] Follow-up `cc-terraform-monitoring` PR re-enables the 5xx query.

Tracking: [KNET-19593](https://confluentinc.atlassian.net/browse/KNET-19593)
Related incident: INC-9115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KNET-19593]: https://confluentinc.atlassian.net/browse/KNET-19593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ