### PR TITLE
INC-10321: Disable javaType resolution in JSONSCHEMA consumer (7.5.x)

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -271,6 +271,7 @@ public class KafkaConsumerManager {
         props.put(
             "value.deserializer",
             "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer");
+        props.put("json.type.allowed.packages", "");
         break;
       case PROTOBUF:
         props.put(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -176,6 +176,46 @@ public class KafkaConsumerManagerTest {
     EasyMock.verify(consumerFactory);
   }
 
+  @Test
+  public void createConsumer_jsonSchemaFormat_disablesJavaTypeResolution() {
+    // INC-10321 / KSECURITY-2716: the JSONSCHEMA consumer must be created with
+    // json.type.allowed.packages="" so KafkaJsonSchemaDeserializer refuses to resolve
+    // arbitrary classes from the schema's javaType property.
+    final Capture<Properties> consumerConfig = Capture.newInstance();
+    EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
+        .andReturn(consumer);
+    EasyMock.replay(consumerFactory);
+
+    consumerManager.createConsumer(
+        groupName, ConsumerInstanceConfig.create(EmbeddedFormat.JSONSCHEMA));
+
+    Properties props = consumerConfig.getValue();
+    assertEquals("", props.get("json.type.allowed.packages"));
+    assertEquals(
+        "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        props.get("key.deserializer"));
+    assertEquals(
+        "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        props.get("value.deserializer"));
+
+    EasyMock.verify(consumerFactory);
+  }
+
+  @Test
+  public void createConsumer_nonJsonSchemaFormat_doesNotSetJavaTypeAllowedPackages() {
+    // The new config is scoped to JSONSCHEMA only; other formats should be unaffected.
+    final Capture<Properties> consumerConfig = Capture.newInstance();
+    EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
+        .andReturn(consumer);
+    EasyMock.replay(consumerFactory);
+
+    consumerManager.createConsumer(groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
+
+    assertNull(consumerConfig.getValue().get("json.type.allowed.packages"));
+
+    EasyMock.verify(consumerFactory);
+  }
+
   /** Response should return no sooner than KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG */
   @Test
   public void testConsumerRequestTimeoutms() throws Exception {


### PR DESCRIPTION
Cherry-pick of #1471 (`0babf58e`) from master onto 7.5.x. This PR is the entry point for backporting the fix across all supported release branches via **pint merge** — after this merges, run pint merge (go/apply-pint-merge with `project=kafka-rest`, `branch=7.5.x`) and the bot will ladder the change up `7.5.x → 7.6.x → 7.7.x → 7.8.x → 7.9.x → 8.0.x → 8.1.x → 8.2.x → 8.3.x → master`.

Sets `json.type.allowed.packages=""` on the V2 consumer when format is `JSONSCHEMA`, so `KafkaJsonSchemaDeserializer` refuses to resolve arbitrary classes from the schema's `javaType` property — the permanent source-side equivalent of the build-time patch on packaging branch 7.5.14 (and on the patch branches 7.6.11, 7.7.9, 7.8.8, 7.9.7, 8.0.5, 8.1.3, 8.2.1, which the pint-merge ladder will cover).

Note: master already has the squashed commit `0babf58e` from #1471, so the final `8.3.x → master` step in the pint-merge chain will produce an empty-diff merge commit. That's expected.

Refs: KSECURITY-2716, INC-10321. Supersedes the manual cherry-picks #1474–#1481 (now closed).

Cherry-pick applied cleanly; spotless passes; unit tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
