### PR TITLE
INC-10321: Disable javaType resolution in JSONSCHEMA consumer (7.8.x)

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -271,6 +271,7 @@ public class KafkaConsumerManager {
         props.put(
             "value.deserializer",
             "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer");
+        props.put("json.type.allowed.packages", "");
         break;
       case PROTOBUF:
         props.put(

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -176,6 +176,46 @@ public class KafkaConsumerManagerTest {
     EasyMock.verify(consumerFactory);
   }
 
+  @Test
+  public void createConsumer_jsonSchemaFormat_disablesJavaTypeResolution() {
+    // INC-10321 / KSECURITY-2716: the JSONSCHEMA consumer must be created with
+    // json.type.allowed.packages="" so KafkaJsonSchemaDeserializer refuses to resolve
+    // arbitrary classes from the schema's javaType property.
+    final Capture<Properties> consumerConfig = Capture.newInstance();
+    EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
+        .andReturn(consumer);
+    EasyMock.replay(consumerFactory);
+
+    consumerManager.createConsumer(
+        groupName, ConsumerInstanceConfig.create(EmbeddedFormat.JSONSCHEMA));
+
+    Properties props = consumerConfig.getValue();
+    assertEquals("", props.get("json.type.allowed.packages"));
+    assertEquals(
+        "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        props.get("key.deserializer"));
+    assertEquals(
+        "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        props.get("value.deserializer"));
+
+    EasyMock.verify(consumerFactory);
+  }
+
+  @Test
+  public void createConsumer_nonJsonSchemaFormat_doesNotSetJavaTypeAllowedPackages() {
+    // The new config is scoped to JSONSCHEMA only; other formats should be unaffected.
+    final Capture<Properties> consumerConfig = Capture.newInstance();
+    EasyMock.expect(consumerFactory.createConsumer(EasyMock.capture(consumerConfig)))
+        .andReturn(consumer);
+    EasyMock.replay(consumerFactory);
+
+    consumerManager.createConsumer(groupName, ConsumerInstanceConfig.create(EmbeddedFormat.BINARY));
+
+    assertNull(consumerConfig.getValue().get("json.type.allowed.packages"));
+
+    EasyMock.verify(consumerFactory);
+  }
+
   /** Response should return no sooner than KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG */
   @Test
   public void testConsumerRequestTimeoutms() throws Exception {


### PR DESCRIPTION
Cherry-pick of #1471 (`0babf58e`) from master onto 7.8.x.

Sets `json.type.allowed.packages=""` on the V2 consumer when format is `JSONSCHEMA`, so `KafkaJsonSchemaDeserializer` refuses to resolve arbitrary classes from the schema's `javaType` property — the permanent source-side equivalent of the build-time patch on packaging branch 7.8.8.

Refs: KSECURITY-2716, INC-10321.

Cherry-pick applied cleanly; spotless passes; unit tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)