### PR TITLE
Bump log4j2 to 2.25.4 for FedRAMP CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <io.confluent.kafka-rest.version>8.0.2</io.confluent.kafka-rest.version>
         <!-- Allow enough heap space for integration tests with Kraft -->
         <argLine>-Xmx4g -Xms2g</argLine>
+        <log4j2.version>2.25.4</log4j2.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Summary
- Override log4j2.version to 2.25.4 to fix CVE-2026-34477, CVE-2026-34478, CVE-2026-34479, CVE-2026-34480
- Parent rest-utils-parent:8.0.2 is frozen in CodeArtifact with log4j 2.25.3, property override needed

## Test plan
- [ ] Verify log4j-core and log4j-1.2-api resolve to 2.25.4 in dependency tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)