### PR TITLE
MINOR: Fix test failures from upstream changes and Jackson version bump

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/ClusterTestHarness.java
@@ -798,7 +798,8 @@ public abstract class ClusterTestHarness {
           JavaConverters.mapAsScalaMapConverter(
                   convertReplicasAssignmentToScalaCompatibleType(replicasAssignments))
               .asScala(),
-          topicConfig);
+          topicConfig.stringPropertyNames().stream()
+              .collect(Collectors.toMap(name -> name, topicConfig::getProperty)));
     }
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -410,7 +410,7 @@ public class ProduceActionIntegrationTest {
         "Unrecognized field \"records\" "
             + "(class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), "
             + "not marked as ignorable (6 known properties: \"value\", \"originalSize\", "
-            + "\"partitionId\", \"headers\", \"key\", \"timestamp\"])",
+            + "\"partitionId\", \"headers\", \"key\", \"timestamp\")",
         actual.getMessage());
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionNoSchemaIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionNoSchemaIntegrationTest.java
@@ -418,7 +418,7 @@ public class ProduceActionNoSchemaIntegrationTest extends ClusterTestHarness {
         "Unrecognized field \"records\" "
             + "(class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), "
             + "not marked as ignorable (6 known properties: \"value\", \"originalSize\", "
-            + "\"partitionId\", \"headers\", \"key\", \"timestamp\"])",
+            + "\"partitionId\", \"headers\", \"key\", \"timestamp\")",
         actual.getMessage());
   }
 


### PR DESCRIPTION
This PR fixes two test breakages introduced by the Confluent/Kafka 8.4.0 version bump.

### 1. Compilation error — `createTopicWithAdmin` signature change
The `topicConfig` parameter of `kafka.utils.TestUtils.createTopicWithAdmin` changed from `Properties` to `Map<String, String>`. Convert the `Properties` to a `Map<String, String>` at the call site in `ClusterTestHarness`.

### 2. Test failure — Jackson 2.21.2 message format change
jackson version bump upgraded `jackson-databind` to 2.21.2, which changed the `UnrecognizedPropertyException` message by dropping a stray unbalanced `]` from the "known properties" suffix:

```
old: (6 known properties: ..., "timestamp"])
new: (6 known properties: ..., "timestamp")
```

Update the hardcoded expected message in `produceWithInvalidData_throwsBadRequest` to match the new format, in both `ProduceActionNoSchemaIntegrationTest` and `ProduceActionIntegrationTest` (both assert this identical message).

### Verification
`ProduceActionNoSchemaIntegrationTest` passes (27/27) via failsafe.
