### PR TITLE
MINOR: Fix produceWithInvalidData assertion for Jackson 2.21.2

### DIFF
--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionIntegrationTest.java
@@ -410,7 +410,7 @@ public class ProduceActionIntegrationTest {
         "Unrecognized field \"records\" "
             + "(class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), "
             + "not marked as ignorable (6 known properties: \"value\", \"originalSize\", "
-            + "\"partitionId\", \"headers\", \"key\", \"timestamp\"])",
+            + "\"partitionId\", \"headers\", \"key\", \"timestamp\")",
         actual.getMessage());
   }
 

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionNoSchemaIntegrationTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/integration/v3/ProduceActionNoSchemaIntegrationTest.java
@@ -418,7 +418,7 @@ public class ProduceActionNoSchemaIntegrationTest extends ClusterTestHarness {
         "Unrecognized field \"records\" "
             + "(class io.confluent.kafkarest.entities.v3.AutoValue_ProduceRequest$Builder), "
             + "not marked as ignorable (6 known properties: \"value\", \"originalSize\", "
-            + "\"partitionId\", \"headers\", \"key\", \"timestamp\"])",
+            + "\"partitionId\", \"headers\", \"key\", \"timestamp\")",
         actual.getMessage());
   }
 


### PR DESCRIPTION
The 8.x line resolves jackson-databind to 2.21.2 (via io.confluent:common), which changed the UnrecognizedPropertyException message format by dropping a stray unbalanced ']' from the "known properties" suffix:

  old: (6 known properties: ..., "timestamp"])
  new: (6 known properties: ..., "timestamp")

Update the hardcoded expected message in produceWithInvalidData_throwsBadRequest in both ProduceActionIntegrationTest and ProduceActionNoSchemaIntegrationTest to match. This unblocks the release branch build (mvn verify integration tests).

Back-port of the Jackson assertion hunk of #1483 (the createTopicWithAdmin signature change in that commit is Kafka 8.4.0-only and is intentionally omitted).