### PR TITLE
Honor instance-level consumer.request.timeout.ms in v2 read scheduler

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -388,12 +388,19 @@ public class KafkaConsumerManager {
 
     public RunnableReadTask(ReadTaskState taskState, KafkaRestConfig config) {
       this.taskState = taskState;
+      // An instance-level consumer.request.timeout.ms set at consumer creation takes
+      // precedence over the proxy-wide setting, mirroring how KafkaConsumerReadTask
+      // resolves its own request timeout.
+      Integer requestWaitMs =
+          taskState.consumerState.getConsumerInstanceConfig().getRequestWaitMs();
       this.requestExpiration =
           clock
               .instant()
               .plus(
                   Duration.ofMillis(
-                      config.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG)));
+                      requestWaitMs != null
+                          ? requestWaitMs
+                          : config.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG)));
       this.backoff =
           Duration.ofMillis(config.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG));
       this.waitExpiration = Instant.EPOCH;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -238,6 +238,69 @@ public class KafkaConsumerManagerTest {
     assertNull(actualException, "No exception in callback");
   }
 
+  /**
+   * A consumer created with an instance-level consumer.request.timeout.ms larger than the
+   * proxy-wide setting should wait the full instance-level timeout instead of being cut off at the
+   * proxy-wide value. Regression test: the KREST-297 refactor made RunnableReadTask expire reads at
+   * the proxy-wide timeout regardless of the instance-level setting.
+   */
+  @Test
+  public void testConsumerRequestTimeoutmsIsRaisablePerConsumer() throws Exception {
+    Properties props = setUpProperties(new Properties());
+    props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "500");
+    setUpConsumer(props);
+
+    expectCreate(consumer);
+    String cid =
+        consumerManager.createConsumer(groupName, consumerInstanceConfigWithRequestWaitMs(2500));
+    consumerManager.subscribe(
+        groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+
+    readFromDefault(cid);
+    Thread.sleep(1000); // twice the proxy-wide timeout
+    assertFalse(
+        sawCallback, "Read returned at the proxy-wide timeout instead of the consumer's timeout");
+    Thread.sleep(2000); // instance-level timeout (2500ms) plus slack
+    assertTrue(sawCallback, "Callback failed to fire");
+    assertNull(actualException, "No exception in callback");
+  }
+
+  /**
+   * A consumer created with an instance-level consumer.request.timeout.ms smaller than the
+   * proxy-wide setting should return at the instance-level timeout.
+   */
+  @Test
+  public void testConsumerRequestTimeoutmsIsLowerablePerConsumer() throws Exception {
+    Properties props = setUpProperties(new Properties());
+    props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "5000");
+    setUpConsumer(props);
+
+    expectCreate(consumer);
+    String cid =
+        consumerManager.createConsumer(groupName, consumerInstanceConfigWithRequestWaitMs(1000));
+    consumerManager.subscribe(
+        groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+
+    readFromDefault(cid);
+    Thread.sleep(500);
+    assertFalse(sawCallback, "Callback failed early");
+    Thread.sleep(1200); // instance-level timeout (1000ms) plus slack
+    assertTrue(sawCallback, "Read did not return at the instance-level timeout");
+    assertNull(actualException, "No exception in callback");
+  }
+
+  private static ConsumerInstanceConfig consumerInstanceConfigWithRequestWaitMs(
+      Integer requestWaitMs) {
+    return ConsumerInstanceConfig.create(
+        /* id= */ null,
+        /* name= */ null,
+        EmbeddedFormat.BINARY,
+        /* autoOffsetReset= */ null,
+        /* autoCommitEnable= */ null,
+        /* responseMinBytes= */ null,
+        requestWaitMs);
+  }
+
   /** Response should return no sooner than KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG */
   @Test
   public void testConsumerWaitMs() throws Exception {


### PR DESCRIPTION
The v2 consumer API accepts consumer.request.timeout.ms at consumer instance creation, documented as: 'Sets the consumer.request.timeout.ms setting for this consumer specifically.' Since KREST-297 (#776), the RunnableReadTask hard expiration read only the proxy-wide config, so an instance-level value larger than the proxy-wide one was silently capped at the proxy-wide value; values below it still worked. Before that refactor the scheduler used the merged per-consumer config and honored the instance-level value in both directions.

Derive the read task expiration from the instance-level setting when present, falling back to the proxy-wide config, mirroring how KafkaConsumerReadTask already resolves its per-request timeout. The ?timeout= query param on the records endpoint is unchanged: it still only lowers the effective timeout, per its documented semantics.