### PR TITLE
[8.2.x] Honor instance-level consumer.request.timeout.ms in v2 read scheduler

### DIFF
--- a/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
+++ b/kafka-rest/src/main/java/io/confluent/kafkarest/v2/KafkaConsumerManager.java
@@ -388,12 +388,19 @@ public class KafkaConsumerManager {
 
     public RunnableReadTask(ReadTaskState taskState, KafkaRestConfig config) {
       this.taskState = taskState;
+      // An instance-level consumer.request.timeout.ms set at consumer creation takes
+      // precedence over the proxy-wide setting, mirroring how KafkaConsumerReadTask
+      // resolves its own request timeout.
+      Integer requestWaitMs =
+          taskState.consumerState.getConsumerInstanceConfig().getRequestWaitMs();
       this.requestExpiration =
           clock
               .instant()
               .plus(
                   Duration.ofMillis(
-                      config.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG)));
+                      requestWaitMs != null
+                          ? requestWaitMs
+                          : config.getInt(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG)));
       this.backoff =
           Duration.ofMillis(config.getInt(KafkaRestConfig.CONSUMER_ITERATOR_BACKOFF_MS_CONFIG));
       this.waitExpiration = Instant.EPOCH;

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -256,12 +256,13 @@ public class KafkaConsumerManagerTest {
     consumerManager.subscribe(
         groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
 
-    readFromDefault(cid);
-    Thread.sleep(1000); // twice the proxy-wide timeout
+    CountDownLatch completed = readFromDefaultAndSignal(cid);
     assertFalse(
-        sawCallback, "Read returned at the proxy-wide timeout instead of the consumer's timeout");
-    Thread.sleep(2000); // instance-level timeout (2500ms) plus slack
-    assertTrue(sawCallback, "Callback failed to fire");
+        completed.await(1000, TimeUnit.MILLISECONDS), // twice the proxy-wide timeout
+        "Read returned at the proxy-wide timeout instead of the consumer's timeout");
+    assertTrue(
+        completed.await(2500, TimeUnit.MILLISECONDS), // instance-level timeout plus slack
+        "Callback failed to fire");
     assertNull(actualException, "No exception in callback");
   }
 
@@ -281,11 +282,11 @@ public class KafkaConsumerManagerTest {
     consumerManager.subscribe(
         groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
 
-    readFromDefault(cid);
-    Thread.sleep(500);
-    assertFalse(sawCallback, "Callback failed early");
-    Thread.sleep(1200); // instance-level timeout (1000ms) plus slack
-    assertTrue(sawCallback, "Read did not return at the instance-level timeout");
+    CountDownLatch completed = readFromDefaultAndSignal(cid);
+    assertFalse(completed.await(500, TimeUnit.MILLISECONDS), "Callback failed early");
+    assertTrue(
+        completed.await(1700, TimeUnit.MILLISECONDS), // instance-level timeout plus slack
+        "Read did not return at the instance-level timeout");
     assertNull(actualException, "No exception in callback");
   }
 
@@ -299,6 +300,30 @@ public class KafkaConsumerManagerTest {
         /* autoCommitEnable= */ null,
         /* responseMinBytes= */ null,
         requestWaitMs);
+  }
+
+  /**
+   * Like {@link #readFromDefault(String)}, but returns a latch that is counted down when the read
+   * completes, so tests can await completion without racing on the shared callback fields.
+   */
+  private CountDownLatch readFromDefaultAndSignal(String cid) {
+    CountDownLatch completed = new CountDownLatch(1);
+    consumerManager.readRecords(
+        groupName,
+        cid,
+        BinaryKafkaConsumerState.class,
+        Duration.ofMillis(-1),
+        Long.MAX_VALUE,
+        new ConsumerReadCallback<ByteString, ByteString>() {
+          @Override
+          public void onCompletion(
+              List<ConsumerRecord<ByteString, ByteString>> records, Exception e) {
+            actualException = e;
+            actualRecords = records;
+            completed.countDown();
+          }
+        });
+    return completed;
   }
 
   /** Response should return no sooner than KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG */

--- a/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
+++ b/kafka-rest/src/test/java/io/confluent/kafkarest/v2/KafkaConsumerManagerTest.java
@@ -238,6 +238,69 @@ public class KafkaConsumerManagerTest {
     assertNull(actualException, "No exception in callback");
   }
 
+  /**
+   * A consumer created with an instance-level consumer.request.timeout.ms larger than the
+   * proxy-wide setting should wait the full instance-level timeout instead of being cut off at the
+   * proxy-wide value. Regression test: the KREST-297 refactor made RunnableReadTask expire reads at
+   * the proxy-wide timeout regardless of the instance-level setting.
+   */
+  @Test
+  public void testConsumerRequestTimeoutmsIsRaisablePerConsumer() throws Exception {
+    Properties props = setUpProperties(new Properties());
+    props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "500");
+    setUpConsumer(props);
+
+    expectCreate(consumer);
+    String cid =
+        consumerManager.createConsumer(groupName, consumerInstanceConfigWithRequestWaitMs(2500));
+    consumerManager.subscribe(
+        groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+
+    readFromDefault(cid);
+    Thread.sleep(1000); // twice the proxy-wide timeout
+    assertFalse(
+        sawCallback, "Read returned at the proxy-wide timeout instead of the consumer's timeout");
+    Thread.sleep(2000); // instance-level timeout (2500ms) plus slack
+    assertTrue(sawCallback, "Callback failed to fire");
+    assertNull(actualException, "No exception in callback");
+  }
+
+  /**
+   * A consumer created with an instance-level consumer.request.timeout.ms smaller than the
+   * proxy-wide setting should return at the instance-level timeout.
+   */
+  @Test
+  public void testConsumerRequestTimeoutmsIsLowerablePerConsumer() throws Exception {
+    Properties props = setUpProperties(new Properties());
+    props.setProperty(KafkaRestConfig.CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, "5000");
+    setUpConsumer(props);
+
+    expectCreate(consumer);
+    String cid =
+        consumerManager.createConsumer(groupName, consumerInstanceConfigWithRequestWaitMs(1000));
+    consumerManager.subscribe(
+        groupName, cid, new ConsumerSubscriptionRecord(Collections.singletonList(topicName), null));
+
+    readFromDefault(cid);
+    Thread.sleep(500);
+    assertFalse(sawCallback, "Callback failed early");
+    Thread.sleep(1200); // instance-level timeout (1000ms) plus slack
+    assertTrue(sawCallback, "Read did not return at the instance-level timeout");
+    assertNull(actualException, "No exception in callback");
+  }
+
+  private static ConsumerInstanceConfig consumerInstanceConfigWithRequestWaitMs(
+      Integer requestWaitMs) {
+    return ConsumerInstanceConfig.create(
+        /* id= */ null,
+        /* name= */ null,
+        EmbeddedFormat.BINARY,
+        /* autoOffsetReset= */ null,
+        /* autoCommitEnable= */ null,
+        /* responseMinBytes= */ null,
+        requestWaitMs);
+  }
+
   /** Response should return no sooner than KafkaRestConfig.PROXY_FETCH_MAX_WAIT_MS_CONFIG */
   @Test
   public void testConsumerWaitMs() throws Exception {


### PR DESCRIPTION
Backport of #1489 (+ the CountDownLatch test follow-up) to 8.2.x. Honors an instance-level consumer.request.timeout.ms set at consumer creation in the v2 read scheduler, so a per-consumer value larger than the proxy-wide
  setting is no longer silently capped. Requested for customer ticket 356976 (repro on CP 7.9.6); backported down to 7.9.x to reach the customer and to keep the behavior continuous across the 8.0-8.3 lines. Test-only follow-up uses a
  CountDownLatch instead of Thread.sleep.