### PR TITLE
Remove redundant snappy.version override in kafka-rest-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,11 +146,6 @@
                 <artifactId>metrics-core</artifactId>
                 <version>4.1.12.1</version>
             </dependency>
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- Removes the explicit `<version>${snappy.version}</version>` override for `org.xerial.snappy:snappy-java` in `pom.xml` (kafka-rest-parent's `dependencyManagement`).
- `snappy-java` is already pinned to `1.1.10.8` via `confluent-common-bom`'s `dependencyManagement`, imported transitively through the `common` parent POM — the same value the removed override was set to.
- Companion cleanup to confluentinc/common-docker#2398, which does the same for `utility-belt`. Removing this makes it possible to eventually retire the now-unused `snappy.version` property from `common`'s pom.xml.
- Supersedes #1503 (same change, retargeted from `master` to `8.0.x`).

## Test plan
- [x] Compared `mvn dependency:tree -Dincludes=org.xerial.snappy -Dverbose` output for the `kafka-rest` module before and after the change on `8.0.x` — resolved version is unchanged (`1.1.10.8` in both cases, now sourced from dependencyManagement instead of the removed explicit `<version>` tag).
- [x] Verified causally by temporarily editing `confluent-common-bom`'s own `snappy-java.version` property and confirming the resolved version in kafka-rest's dependency tree tracked the change.
- [ ] CI build (no build impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)