### PR TITLE
[Common BOM] Remove explicit gson.version override, inherit from common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.github.resilience4j</groupId>
                 <artifactId>resilience4j-ratelimiter</artifactId>
                 <version>1.7.1</version>


### PR DESCRIPTION
## Summary
- Removes the whole `com.google.code.gson:gson` `dependencyManagement` entry (versioned via `${gson.version}`), not just its version line — a `dependencyManagement` entry must specify a complete version, it can't inherit a missing one from an ancestor's `dependencyManagement` the way a plain top-level `<dependency>` can.
- Nothing in this repo directly depends on `gson` (confirmed via grep across every `pom.xml`) — this entry exists purely to pin the version of a transitively-included dependency.
- `common`'s own `dependencyManagement` already pins `gson` at `${gson.version}` = `2.11.0`, matching `confluent-common-bom`'s managed value exactly — this is a no-op version change.

## Verification
- `mvn -N validate` passes locally
- `mvn help:effective-pom` confirms `gson` still resolves to `2.11.0`

## Tracking
Part of the `gson.version` cleanup step in the [Common Inheritance Map — Cleanup Plan](https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82) audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)