### PR TITLE
[Common BOM] Remove dead avro-maven-plugin pluginManagement entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,11 +153,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro-maven-plugin</artifactId>
-                    <version>${avro.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>${exec-maven-plugin.version}</version>


### PR DESCRIPTION
## Summary
- Removes a dead `avro-maven-plugin` `pluginManagement` declaration that referenced `${avro.version}` but is never actually invoked anywhere in this reactor — confirmed via grep across every `pom.xml` in the repo and via `mvn help:effective-pom` showing zero remaining references to the plugin after removal.
- `common` doesn't manage this plugin either (only the `avro.version` property and the `org.apache.avro:avro` *dependency* via `confluent-common-bom`), so this declaration wasn't backed by anything upstream — removing it is a pure no-op.
- Verified locally via `mvn -N validate` and `mvn help:effective-pom`.

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` shows zero remaining `avro-maven-plugin` references
- [ ] CI green