### PR TITLE
Remove redundant snappy.version override in kafka-rest-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,11 +146,6 @@
                 <artifactId>metrics-core</artifactId>
                 <version>4.1.12.1</version>
             </dependency>
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- Cherry-picks the pom.xml change from #1504 onto `8.1.x`.
- #1504 was merged into `8.0.x`, but the subsequent pint-merge cascade from `8.0.x` through `master` ran with the `ours` strategy, which recorded the merge in git history without carrying the content forward. This re-applies the change so it can propagate normally.

## Test plan
- [x] Cherry-pick applied cleanly (`git cherry-pick -x 0dfdf95a`), same diff as #1504.
- [ ] After merge, let `ci-sem-pint` (or `go/run-pint-merge` with default strategy) cascade this forward through `8.2.x`, `8.3.x`, `8.4.x`, `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)