### PR TITLE
[Common BOM] Remove redundant jackson.version overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,16 +69,6 @@
                 <version>1.7.2</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-guava</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>


### PR DESCRIPTION
## Summary
- Removes explicit `${jackson.version}` overrides on `jackson-datatype-jdk8` and `jackson-datatype-guava` from `dependencyManagement` — both already managed at the same version (`2.22.1`) by `confluent-common-bom`'s `jackson-bom` import, transitively via the `common` parent POM.
- Scoped to `8.0.x` only for now; should cascade forward via `ci-sem-pint`/pint merge to `8.1.x`–`8.4.x`/`master` normally.

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn validate` passes (full reactor)
- [x] `mvn help:effective-pom` on the `kafka-rest` module confirms both artifacts still resolve to `2.22.1`, unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)